### PR TITLE
feat: Update partition tables for 4MB flash OTA support (#22)

### DIFF
--- a/packages/esp32-projects/robocar-camera/partitions.csv
+++ b/packages/esp32-projects/robocar-camera/partitions.csv
@@ -1,9 +1,16 @@
-# ESP32-CAM Partition Table for OTA
+# ESP32-CAM Partition Table for OTA (4MB Flash)
 # Name,   Type, SubType, Offset,  Size,     Flags
+# Flash Layout:
+#   nvs:      24KB  (Non-Volatile Storage)
+#   otadata:  8KB   (OTA selection data)
+#   phy_init: 4KB   (PHY init data)
+#   ota_0:    1.8MB (OTA app partition 0)
+#   ota_1:    1.8MB (OTA app partition 1)
+#   spiffs:   336KB (File storage for AI models)
+# Total: 4MB (0x400000 bytes)
 nvs,      data, nvs,     0x9000,  0x6000,
-phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 0x180000,
-ota_0,    app,  ota_0,   0x190000,0x180000,
-ota_1,    app,  ota_1,   0x310000,0x180000,
-ota_data, data, ota,     0x490000,0x2000,
-storage,  data, spiffs,  0x492000,0x16E000,
+otadata,  data, ota,     0xF000,  0x2000,
+phy_init, data, phy,     0x11000, 0x1000,
+ota_0,    app,  ota_0,   0x12000, 0x1CD000,
+ota_1,    app,  ota_1,   0x1DF000,0x1CD000,
+spiffs,   data, spiffs,  0x3AC000,0x54000,

--- a/packages/esp32-projects/robocar-docs/PARTITION_UPDATE_NOTES.md
+++ b/packages/esp32-projects/robocar-docs/PARTITION_UPDATE_NOTES.md
@@ -1,0 +1,134 @@
+# OTA Partition Table Update - Phase 1.2
+
+## Overview
+Updated partition tables for both robocar-main (Heltec WiFi LoRa 32) and robocar-camera (ESP32-CAM) to properly support OTA updates within 4MB flash constraints.
+
+## Changes Made
+
+### Previous Partition Layout (6MB - INCORRECT)
+The previous partition tables were designed for 6MB flash, which exceeded the actual 4MB flash size on both boards:
+- nvs: 24KB
+- phy_init: 4KB
+- factory: 1.5MB
+- ota_0: 1.5MB
+- ota_1: 1.5MB
+- ota_data: 8KB
+- storage: 1.4MB
+- **Total: ~6MB** ❌
+
+### New Partition Layout (4MB - CORRECT)
+```
+Partition   | Offset    | Size      | Description
+----------- | --------- | --------- | -----------
+nvs         | 0x009000  | 24KB      | Non-Volatile Storage
+otadata     | 0x00F000  | 8KB       | OTA selection data
+phy_init    | 0x011000  | 4KB       | PHY init data
+ota_0       | 0x012000  | 1.8MB     | OTA app partition 0
+ota_1       | 0x1DF000  | 1.8MB     | OTA app partition 1
+spiffs      | 0x3AC000  | 336KB     | File storage for AI models
+----------- | --------- | --------- | -----------
+TOTAL       |           | 3.96MB    | Fits in 4MB flash ✓
+```
+
+### Key Changes
+1. **Removed factory partition**: Not needed with dual OTA partitions
+2. **Increased OTA partition sizes**: From 1.5MB to 1.8MB each
+3. **Reduced SPIFFS size**: From 1.4MB to 336KB (sufficient for AI models)
+4. **Reorganized layout**: Moved otadata earlier for better reliability
+5. **Total size**: Fits exactly within 4MB flash
+
+## Board Specifications
+
+### Heltec WiFi LoRa 32 (robocar-main)
+- **MCU**: ESP32
+- **Flash**: 4MB
+- **Features**: WiFi, LoRa, OLED display
+
+### ESP32-CAM (robocar-camera)
+- **MCU**: ESP32
+- **Flash**: 4MB
+- **Features**: WiFi, Camera (OV2640)
+
+## Verification
+
+Run the verification script to validate the partition table:
+```bash
+python3 verify_partitions.py
+```
+
+This confirms:
+- ✓ All partitions fit in 4MB flash
+- ✓ No gaps or overlaps
+- ✓ Proper 4KB alignment
+- ✓ Continuous memory layout
+
+## Build Instructions
+
+### Clean Build (Recommended)
+When changing partition tables, it's recommended to perform a clean build and erase flash:
+
+```bash
+# For robocar-main
+cd packages/esp32-projects/robocar-main
+idf.py fullclean
+idf.py erase-flash
+idf.py build flash monitor
+
+# For robocar-camera
+cd packages/esp32-projects/robocar-camera
+idf.py fullclean
+idf.py erase-flash
+idf.py build flash monitor
+```
+
+### Verify Partition Table
+After flashing, verify the partition table was applied correctly:
+```bash
+idf.py partition-table
+```
+
+## OTA Update Workflow
+
+With the new partition table, OTA updates will work as follows:
+
+1. **Initial Flash**: App is written to `ota_0` partition
+2. **First OTA Update**: New firmware downloads to `ota_1` partition
+3. **Boot**: Device boots from `ota_1` (new firmware)
+4. **Second OTA Update**: New firmware downloads to `ota_0` partition
+5. **Rollback**: If boot fails, device automatically reverts to previous partition
+
+## Testing Checklist
+
+- [ ] Build robocar-main with new partition table
+- [ ] Flash and verify robocar-main boots successfully
+- [ ] Verify WiFi and LoRa functionality on robocar-main
+- [ ] Build robocar-camera with new partition table
+- [ ] Flash and verify robocar-camera boots successfully
+- [ ] Verify WiFi and camera functionality on robocar-camera
+- [ ] Test OTA update on both boards
+- [ ] Verify SPIFFS functionality (AI model storage)
+- [ ] Test OTA rollback functionality
+
+## Troubleshooting
+
+### Error: "Partition table does not fit in configured flash size"
+- Verify flash size is set to 4MB in `idf.py menuconfig`
+- Navigate to: `Serial flasher config` → `Flash size` → Select `4 MB`
+
+### Error: "ota_begin error err=0x104"
+- This indicates insufficient space for OTA
+- Verify partition table is correctly flashed
+- Run `idf.py erase-flash` and reflash
+
+### Error: "Partition table MD5 checksum failed"
+- The partition table has been modified
+- Run `idf.py erase-flash` to clear old partition table
+- Reflash with new partition table
+
+## Related Issues
+- Issue #22: OTA Phase 1.2 - Modify Partition Tables for OTA
+- Issue #14: Parent OTA implementation issue
+
+## References
+- [ESP-IDF Partition Tables Documentation](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html)
+- [ESP-IDF OTA Updates](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/ota.html)

--- a/packages/esp32-projects/robocar-docs/verify_partitions.py
+++ b/packages/esp32-projects/robocar-docs/verify_partitions.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Verify ESP32 partition table fits within flash size constraints.
+"""
+
+# Partition definitions (offset, size in bytes)
+partitions = {
+    'nvs':      (0x9000,   0x6000),    # 24KB
+    'otadata':  (0xF000,   0x2000),    # 8KB
+    'phy_init': (0x11000,  0x1000),    # 4KB
+    'ota_0':    (0x12000,  0x1CD000),  # 1.8MB
+    'ota_1':    (0x1DF000, 0x1CD000),  # 1.8MB
+    'spiffs':   (0x3AC000, 0x54000),   # 336KB
+}
+
+FLASH_SIZE_4MB = 0x400000  # 4MB = 4,194,304 bytes
+
+def bytes_to_mb(bytes_val):
+    """Convert bytes to MB."""
+    return bytes_val / (1024 * 1024)
+
+def bytes_to_kb(bytes_val):
+    """Convert bytes to KB."""
+    return bytes_val / 1024
+
+print("=" * 60)
+print("ESP32 Partition Table Verification (4MB Flash)")
+print("=" * 60)
+
+# Verify each partition
+print("\nPartition Details:")
+print("-" * 60)
+total_size = 0
+for name, (offset, size) in partitions.items():
+    end = offset + size
+    print(f"{name:10s} | Offset: 0x{offset:06X} | Size: 0x{size:06X} ({bytes_to_kb(size):7.1f} KB) | End: 0x{end:06X}")
+    total_size += size
+
+print("-" * 60)
+print(f"{'TOTAL':10s} |                    | Size: 0x{total_size:06X} ({bytes_to_mb(total_size):7.2f} MB)")
+print(f"{'FLASH':10s} |                    | Size: 0x{FLASH_SIZE_4MB:06X} ({bytes_to_mb(FLASH_SIZE_4MB):7.2f} MB)")
+print("-" * 60)
+
+# Verify gaps between partitions
+print("\nPartition Continuity Check:")
+print("-" * 60)
+prev_name = None
+prev_end = 0x9000  # Start of first partition
+is_continuous = True
+
+for name, (offset, size) in partitions.items():
+    if prev_name:
+        gap = offset - prev_end
+        if gap > 0:
+            print(f"WARNING: Gap of 0x{gap:X} bytes ({gap} bytes) between {prev_name} and {name}")
+            is_continuous = False
+        elif gap < 0:
+            print(f"ERROR: Overlap of 0x{-gap:X} bytes ({-gap} bytes) between {prev_name} and {name}")
+            is_continuous = False
+        else:
+            print(f"✓ {prev_name} → {name}: Continuous")
+
+    prev_name = name
+    prev_end = offset + size
+
+if is_continuous:
+    print("\n✓ All partitions are continuous (no gaps or overlaps)")
+
+# Verify total size fits in flash
+print("\nFlash Size Verification:")
+print("-" * 60)
+last_partition = list(partitions.items())[-1]
+last_name, (last_offset, last_size) = last_partition
+last_end = last_offset + last_size
+
+if last_end <= FLASH_SIZE_4MB:
+    remaining = FLASH_SIZE_4MB - last_end
+    print(f"✓ Partition table fits in 4MB flash")
+    print(f"  Last partition ends at: 0x{last_end:06X}")
+    print(f"  Flash size:             0x{FLASH_SIZE_4MB:06X}")
+    print(f"  Remaining space:        0x{remaining:06X} ({bytes_to_kb(remaining):.1f} KB)")
+else:
+    overflow = last_end - FLASH_SIZE_4MB
+    print(f"✗ ERROR: Partition table exceeds 4MB flash by 0x{overflow:06X} ({bytes_to_kb(overflow):.1f} KB)")
+
+# Verify 4KB alignment (ESP32 flash sector size)
+print("\nAlignment Verification (4KB sectors):")
+print("-" * 60)
+alignment_ok = True
+for name, (offset, size) in partitions.items():
+    if offset % 0x1000 != 0:
+        print(f"✗ {name}: Offset 0x{offset:06X} is NOT 4KB-aligned")
+        alignment_ok = False
+    if size % 0x1000 != 0:
+        print(f"✗ {name}: Size 0x{size:06X} is NOT 4KB-aligned")
+        alignment_ok = False
+
+if alignment_ok:
+    print("✓ All partitions are properly 4KB-aligned")
+
+print("\n" + "=" * 60)
+print("Verification Complete")
+print("=" * 60)

--- a/packages/esp32-projects/robocar-main/partitions.csv
+++ b/packages/esp32-projects/robocar-main/partitions.csv
@@ -1,9 +1,16 @@
-# ESP32 Partition Table for OTA
+# ESP32 Partition Table for OTA (4MB Flash)
 # Name,   Type, SubType, Offset,  Size,     Flags
+# Flash Layout:
+#   nvs:      24KB  (Non-Volatile Storage)
+#   otadata:  8KB   (OTA selection data)
+#   phy_init: 4KB   (PHY init data)
+#   ota_0:    1.8MB (OTA app partition 0)
+#   ota_1:    1.8MB (OTA app partition 1)
+#   spiffs:   336KB (File storage for AI models)
+# Total: 4MB (0x400000 bytes)
 nvs,      data, nvs,     0x9000,  0x6000,
-phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 0x180000,
-ota_0,    app,  ota_0,   0x190000,0x180000,
-ota_1,    app,  ota_1,   0x310000,0x180000,
-ota_data, data, ota,     0x490000,0x2000,
-storage,  data, spiffs,  0x492000,0x16E000,
+otadata,  data, ota,     0xF000,  0x2000,
+phy_init, data, phy,     0x11000, 0x1000,
+ota_0,    app,  ota_0,   0x12000, 0x1CD000,
+ota_1,    app,  ota_1,   0x1DF000,0x1CD000,
+spiffs,   data, spiffs,  0x3AC000,0x54000,


### PR DESCRIPTION
Modified partition tables for both robocar-main and robocar-camera to properly
support OTA updates within 4MB flash constraints.

## Changes
- Updated robocar-main partition table for 4MB flash (was 6MB)
- Updated robocar-camera partition table for 4MB flash (was 6MB)
- Removed factory partition (not needed with dual OTA)
- Increased OTA partitions from 1.5MB to 1.8MB each
- Adjusted SPIFFS from 1.4MB to 336KB (sufficient for AI models)
- Added comprehensive documentation and verification script

## New Partition Layout (4MB)
- nvs: 24KB (Non-Volatile Storage)
- otadata: 8KB (OTA selection data)
- phy_init: 4KB (PHY init data)
- ota_0: 1.8MB (OTA app partition 0)
- ota_1: 1.8MB (OTA app partition 1)
- spiffs: 336KB (File storage for AI models)

## Verification
- All partitions properly 4KB-aligned
- No gaps or overlaps in memory layout
- Total size: 3.96MB (fits in 4MB flash)
- Includes Python verification script

Resolves #22
