### PR TITLE
feat: Add RFID tag visibility and LED feedback to audiobook player

### DIFF
--- a/packages/esp32-projects/audiobook-player/audiobook-player.yaml
+++ b/packages/esp32-projects/audiobook-player/audiobook-player.yaml
@@ -1,7 +1,8 @@
 esphome:
   name: audiobook-player
   friendly_name: "Audiobook Player"
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 # Enable logging
@@ -41,17 +42,38 @@ rc522_spi:
   # When a tag is detected, send it to Home Assistant
   on_tag:
     then:
+      - text_sensor.template.publish:
+          id: last_rfid_tag
+          state: !lambda 'return x;'
       - homeassistant.tag_scanned: !lambda 'return x;'
+      - homeassistant.event:
+          event: esphome.audiobook_triggered
+          data:
+            device_id: audiobook-player
+            tag_id: !lambda 'return x;'
       - logger.log:
           format: "Tag scanned: %s"
           args: ['x.c_str()']
+      - output.turn_on: status_led_output
+      - delay: 300ms
+      - output.turn_off: status_led_output
 
   # When tag is removed
   on_tag_removed:
     then:
+      - text_sensor.template.publish:
+          id: last_rfid_tag
+          state: ""
       - logger.log:
           format: "Tag removed: %s"
           args: ['x.c_str()']
+
+# Text sensor to store the last scanned RFID tag
+text_sensor:
+  - platform: template
+    name: "Last RFID Tag"
+    id: last_rfid_tag
+    icon: "mdi:card-account-details"
 
 # Binary sensors for buttons
 binary_sensor:
@@ -95,8 +117,10 @@ binary_sensor:
             data:
               action: pause
 
-# Status LED (optional - uses built-in LED)
-status_led:
-  pin:
-    number: D4  # GPIO2 - Built-in LED
-    inverted: true
+# Output for built-in LED to indicate RFID tag reads
+output:
+  - platform: gpio
+    pin:
+      number: D4  # GPIO2 - Built-in LED
+      inverted: true
+    id: status_led_output


### PR DESCRIPTION
## Summary

Enhances the audiobook player with improved RFID tag tracking and visual feedback capabilities.

## Key Changes

- **Text Sensor**: Added `text_sensor.audiobook_player_last_rfid_tag` entity to expose the last scanned RFID tag ID in Home Assistant UI
- **Custom Event**: Added `esphome.audiobook_triggered` event with `tag_id` payload for easier automation creation
- **LED Feedback**: Implemented 300ms LED blink on the built-in LED when an RFID tag is scanned for immediate visual confirmation
- **Configuration Fix**: Updated ESPHome platform configuration to use separate `esp8266` block (proper format)
- **State Management**: Text sensor clears to empty string when tag is removed

## Benefits

- **Improved Visibility**: Tag IDs now visible as entities in Home Assistant
- **Easier Automations**: Custom events make it simpler to create tag-specific automations
- **User Feedback**: LED blink provides immediate confirmation that a tag was read
- **Better Debugging**: Can view tag IDs in Developer Tools → Events

## Testing

After flashing this configuration:
1. Scan an RFID tag and verify LED blinks
2. Check `text_sensor.audiobook_player_last_rfid_tag` entity shows tag ID
3. Listen to `esphome.audiobook_triggered` events in Developer Tools → Events
4. Verify tag_id appears in event data

🤖 Generated with [Claude Code](https://claude.com/claude-code)