### PR TITLE
Set up ESP32 with ESPHome and WireGuard

### DIFF
--- a/packages/esp32-projects/esp32-wireguard-ha-example/.gitignore
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/.gitignore
@@ -1,0 +1,5 @@
+secrets.yaml
+.esphome/
+*.bin
+*.elf
+*.map

--- a/packages/esp32-projects/esp32-wireguard-ha-example/Makefile
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/Makefile
@@ -1,0 +1,150 @@
+# ESP32 WireGuard Home Assistant Example Makefile
+# ESPHome-based ESP32 with WireGuard VPN and Home Assistant integration
+
+.PHONY: help install config compile upload logs clean monitor wireless
+
+# Configuration
+DEVICE_NAME := esp32-wireguard-ha
+CONFIG_FILE := $(DEVICE_NAME).yaml
+SECRETS_FILE := secrets.yaml
+SECRETS_EXAMPLE := secrets.yaml.example
+
+help:
+	@echo "ESP32 WireGuard HA Example - ESPHome Project"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  install      - Install ESPHome and dependencies"
+	@echo "  config       - Copy secrets.yaml.example to secrets.yaml"
+	@echo "  validate     - Validate configuration"
+	@echo "  compile      - Compile firmware"
+	@echo "  upload       - Compile and upload via USB"
+	@echo "  wireless     - Upload via WiFi (OTA)"
+	@echo "  logs         - View device logs"
+	@echo "  monitor      - Monitor logs in real-time"
+	@echo "  clean        - Clean build files"
+	@echo "  dashboard    - Open ESPHome dashboard"
+	@echo "  wg-keys      - Generate WireGuard key pair"
+
+install:
+	@echo "Installing ESPHome..."
+	pip install --upgrade esphome
+
+config:
+	@if [ ! -f $(SECRETS_FILE) ]; then \
+		echo "Creating secrets.yaml from template..."; \
+		cp $(SECRETS_EXAMPLE) $(SECRETS_FILE); \
+		echo ""; \
+		echo "⚠️  IMPORTANT: Edit $(SECRETS_FILE) with your configuration:"; \
+		echo "   1. WiFi credentials"; \
+		echo "   2. WireGuard keys and server details"; \
+		echo "   3. API encryption key (will be generated on first run)"; \
+	else \
+		echo "$(SECRETS_FILE) already exists"; \
+	fi
+
+validate:
+	@echo "Validating configuration..."
+	esphome config $(CONFIG_FILE)
+
+compile:
+	@echo "Compiling firmware..."
+	esphome compile $(CONFIG_FILE)
+
+upload:
+	@if [ ! -f $(SECRETS_FILE) ]; then \
+		echo "Error: $(SECRETS_FILE) not found. Run 'make config' first."; \
+		exit 1; \
+	fi
+	@echo "Compiling and uploading via USB..."
+	esphome run $(CONFIG_FILE)
+
+wireless:
+	@echo "Uploading via WiFi (OTA)..."
+	esphome run $(CONFIG_FILE) --device $(DEVICE_NAME).local
+
+logs:
+	@echo "Viewing logs..."
+	esphome logs $(CONFIG_FILE)
+
+monitor: logs
+
+clean:
+	@echo "Cleaning build files..."
+	rm -rf .esphome/
+	rm -f *.bin *.elf *.map
+
+dashboard:
+	@echo "Starting ESPHome dashboard..."
+	@echo "Access at http://localhost:6052"
+	esphome dashboard .
+
+# WireGuard key generation
+wg-keys:
+	@echo "Generating WireGuard key pair..."
+	@if command -v wg >/dev/null 2>&1; then \
+		echo ""; \
+		echo "Private key:"; \
+		wg genkey | tee /tmp/wg_private.key | wg pubkey > /tmp/wg_public.key; \
+		cat /tmp/wg_private.key; \
+		echo ""; \
+		echo "Public key (share with server):"; \
+		cat /tmp/wg_public.key; \
+		echo ""; \
+		echo "⚠️  Save the private key in secrets.yaml"; \
+		echo "⚠️  Share the public key with your WireGuard server admin"; \
+		rm -f /tmp/wg_private.key /tmp/wg_public.key; \
+	else \
+		echo "Error: wireguard-tools not installed"; \
+		echo "Install with: sudo apt-get install wireguard-tools"; \
+		echo "Or manually generate keys at https://www.wireguardconfig.com/"; \
+	fi
+
+# Development workflow shortcuts
+.PHONY: init first-flash dev
+
+init: install config
+	@echo ""
+	@echo "Initialization complete!"
+	@echo "Next steps:"
+	@echo "  1. Run 'make wg-keys' to generate WireGuard keys"
+	@echo "  2. Edit $(SECRETS_FILE) with all required values"
+	@echo "  3. Configure your WireGuard server with this device's public key"
+	@echo "  4. Run 'make upload' to flash the device via USB"
+	@echo "  5. Run 'make logs' to monitor WireGuard connection status"
+
+first-flash: config upload
+	@echo ""
+	@echo "First flash complete!"
+	@echo "Future updates can be done wirelessly with 'make wireless'"
+
+dev: upload logs
+
+# Quick reference
+.PHONY: status info
+
+status:
+	@echo "Device: $(DEVICE_NAME)"
+	@echo "Config: $(CONFIG_FILE)"
+	@echo "Secrets: $(SECRETS_FILE)"
+	@if [ -f $(SECRETS_FILE) ]; then \
+		echo "Status: Configured ✓"; \
+	else \
+		echo "Status: Not configured - run 'make config'"; \
+	fi
+
+info:
+	@echo "ESP32 WireGuard HA Example"
+	@echo ""
+	@echo "This project demonstrates:"
+	@echo "  • WireGuard VPN connection from ESP32"
+	@echo "  • Home Assistant integration via native API"
+	@echo "  • Remote device access over VPN"
+	@echo "  • Secure encrypted communication"
+	@echo ""
+	@echo "Requirements:"
+	@echo "  • ESP32 development board"
+	@echo "  • WireGuard VPN server"
+	@echo "  • Home Assistant instance"
+	@echo "  • WiFi network"
+	@echo ""
+	@echo "For detailed setup instructions, see README.md"

--- a/packages/esp32-projects/esp32-wireguard-ha-example/README.md
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/README.md
@@ -1,0 +1,342 @@
+# ESP32 WireGuard Home Assistant Example
+
+A complete example project demonstrating how to connect an ESP32 to Home Assistant via a WireGuard VPN tunnel using ESPHome. This enables secure remote access to IoT devices without exposing them directly to the internet.
+
+## Features
+
+- **WireGuard VPN Integration**: Secure VPN tunnel for remote device access
+- **Home Assistant Native API**: Direct, low-latency communication with Home Assistant
+- **Connection Monitoring**: Real-time status of both WiFi and WireGuard connections
+- **Encrypted Communication**: API encryption for secure data transmission
+- **OTA Updates**: Wireless firmware updates over WiFi or VPN
+- **Example Sensors**: WiFi signal, uptime, and VPN handshake monitoring
+
+## Use Cases
+
+This example is useful when:
+- Home Assistant is on a different network (e.g., cloud server, different location)
+- You want secure remote access without port forwarding
+- Running IoT devices across multiple locations connected via VPN
+- Testing ESPHome over WireGuard before deploying to production
+
+## Hardware Requirements
+
+- **ESP32 Development Board** (ESP32-DevKitC, NodeMCU-32S, or similar)
+  - Note: WireGuard is only supported on ESP32, ESP8266, and BK72xx platforms
+- **USB cable** for initial programming
+- **WiFi network** with internet access
+
+## Prerequisites
+
+### 1. WireGuard VPN Server
+
+You need a WireGuard server that both the ESP32 and Home Assistant can connect to. Options include:
+
+- **Self-hosted**: Install on Linux server, Raspberry Pi, or router
+- **Cloud VPS**: DigitalOcean, Linode, AWS Lightsail
+- **Pre-configured**: PiVPN, Tailscale, or similar solutions
+
+**Important**: Ensure your WireGuard server allows peer-to-peer communication.
+
+### 2. Home Assistant
+
+- Home Assistant instance accessible via the VPN network
+- ESPHome integration enabled (usually auto-discovered)
+
+### 3. Development Tools
+
+- Python 3.9 or newer
+- ESPHome CLI (`pip install esphome`)
+- WireGuard tools (optional, for key generation): `apt-get install wireguard-tools`
+
+## Quick Start
+
+### 1. Initialize Project
+
+```bash
+make init
+```
+
+This will:
+- Install ESPHome
+- Create `secrets.yaml` from the template
+
+### 2. Generate WireGuard Keys
+
+```bash
+make wg-keys
+```
+
+Or manually:
+```bash
+wg genkey | tee private.key | wg pubkey > public.key
+```
+
+Save the **private key** for your ESP32's `secrets.yaml`.
+Share the **public key** with your WireGuard server administrator.
+
+### 3. Configure WireGuard Server
+
+Add the ESP32 as a peer on your WireGuard server. Example server configuration:
+
+```ini
+# /etc/wireguard/wg0.conf
+
+[Interface]
+Address = 10.0.0.1/24
+ListenPort = 51820
+PrivateKey = <server-private-key>
+
+# ESP32 peer
+[Peer]
+PublicKey = <esp32-public-key>
+AllowedIPs = 10.0.0.100/32
+```
+
+Restart WireGuard server: `sudo wg-quick down wg0 && sudo wg-quick up wg0`
+
+### 4. Configure Secrets
+
+Edit `secrets.yaml` with your configuration:
+
+```yaml
+# WiFi
+wifi_ssid: "MyWiFi"
+wifi_password: "MyPassword"
+
+# WireGuard
+wg_address: "10.0.0.100"
+wg_private_key: "<esp32-private-key>"
+wg_peer_endpoint: "vpn.example.com"
+wg_peer_public_key: "<server-public-key>"
+wg_peer_port: "51820"
+wg_allowed_ips: "10.0.0.0/24"  # Or "0.0.0.0/0" for all traffic
+
+# Network (optional - can use DHCP)
+device_ip: "192.168.1.100"
+gateway_ip: "192.168.1.1"
+# ... etc
+```
+
+### 5. Upload Firmware
+
+First upload via USB:
+
+```bash
+make upload
+```
+
+### 6. Monitor Logs
+
+Watch the connection process:
+
+```bash
+make logs
+```
+
+You should see:
+1. WiFi connection established
+2. Time synchronized via NTP
+3. WireGuard handshake completed
+4. Home Assistant API connected
+
+### 7. Add to Home Assistant
+
+The device should appear automatically in Home Assistant:
+
+1. Navigate to **Settings** → **Devices & Services**
+2. Look for "ESP32 WireGuard HA Example" under ESPHome
+3. Click **Configure** and enter the API encryption key from `secrets.yaml`
+
+## Configuration Explained
+
+### Time Synchronization
+
+WireGuard requires accurate time for cryptographic operations:
+
+```yaml
+time:
+  - platform: sntp
+    timezone: "UTC"
+```
+
+**Important**: Do NOT use the `homeassistant` time platform if Home Assistant is accessed via WireGuard, as this creates a circular dependency.
+
+### WireGuard Settings
+
+```yaml
+wireguard:
+  address: "10.0.0.100"          # Device's VPN IP
+  private_key: !secret wg_private_key
+  peer_endpoint: !secret wg_peer_endpoint
+  peer_public_key: !secret wg_peer_public_key
+  peer_port: 51820
+  peer_allowed_ips:              # Networks routed through VPN
+    - "10.0.0.0/24"              # Just VPN network
+    # - "0.0.0.0/0"              # ALL traffic (use carefully)
+  peer_persistent_keepalive: 25s # NAT traversal
+  netmask: 255.255.255.0
+```
+
+### Allowed IPs
+
+The `peer_allowed_ips` setting determines what traffic goes through the VPN:
+
+- `10.0.0.0/24` - Only VPN traffic (recommended)
+- `192.168.50.0/24` - Specific network (e.g., Home Assistant's network)
+- `0.0.0.0/0` - All traffic (makes ESP32 fully remote)
+
+## Monitoring
+
+The configuration includes several sensors for monitoring:
+
+### Binary Sensors
+- **WireGuard Status**: Shows if VPN peer is online
+- **Device Status**: Overall device health
+
+### Sensors
+- **WiFi Signal**: Signal strength in dB
+- **Uptime**: Device uptime in seconds
+- **WG Latest Handshake**: Timestamp of last successful handshake
+
+### Text Sensors
+- **WG Address**: Current VPN address
+- **Device IP**: Local WiFi IP
+- **ESPHome Version**: Installed firmware version
+
+## Troubleshooting
+
+### WireGuard Not Connecting
+
+**Check time synchronization:**
+```bash
+make logs | grep -i "time"
+```
+
+Time must be synchronized before WireGuard can connect.
+
+**Verify server connectivity:**
+- Ensure the WireGuard server is reachable from your WiFi network
+- Check firewall rules allow UDP port 51820
+- Verify DNS resolution of `wg_peer_endpoint`
+
+**Check server configuration:**
+```bash
+# On WireGuard server
+sudo wg show
+```
+
+Look for the ESP32 peer and verify its public key matches.
+
+### Home Assistant Not Discovering Device
+
+**If using WireGuard for HA connection:**
+- Ensure `wg_allowed_ips` includes Home Assistant's network
+- Verify WireGuard peer is online (check HA binary sensor)
+- Check Home Assistant can ping the ESP32's VPN IP
+
+**API encryption key mismatch:**
+- Re-generate key: `openssl rand -base64 32`
+- Update in both `secrets.yaml` and Home Assistant
+
+### Common Issues
+
+**"Time is not synchronized"**
+- Check NTP server accessibility
+- Verify internet connection from WiFi network
+- Consider using local NTP server
+
+**"Handshake did not complete"**
+- Verify all WireGuard keys are correct
+- Check server allows the ESP32's VPN IP in AllowedIPs
+- Ensure keepalive is set (important for NAT)
+
+**"API connection failed"**
+- Verify encryption key matches in Home Assistant
+- Check WireGuard connection is established first
+- Ensure Home Assistant is accessible via VPN
+
+## Advanced Configuration
+
+### Adding Sensors
+
+Uncomment the I2C sensor example in the YAML file:
+
+```yaml
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+
+sensor:
+  - platform: bme280
+    temperature:
+      name: "Temperature"
+    # ...
+```
+
+### Adding Controls
+
+Enable the relay/LED example:
+
+```yaml
+switch:
+  - platform: gpio
+    pin: GPIO2
+    name: "Relay 1"
+```
+
+### Full VPN Routing
+
+To route ALL ESP32 traffic through VPN:
+
+```yaml
+wireguard:
+  # ...
+  peer_allowed_ips:
+    - "0.0.0.0/0"
+```
+
+**Warning**: This may impact OTA updates if the VPN server has limited bandwidth.
+
+## Security Considerations
+
+1. **Never commit `secrets.yaml`** - It's in `.gitignore` by default
+2. **Use API encryption** - Always set an encryption key
+3. **Strong OTA password** - Prevent unauthorized firmware updates
+4. **Firewall rules** - Only allow necessary traffic on WireGuard server
+5. **Regular updates** - Keep ESPHome and WireGuard server updated
+
+## Network Topology
+
+```
+┌─────────────┐         ┌──────────────┐         ┌─────────────┐
+│   ESP32     │ WiFi    │  WireGuard   │ Internet│    Home     │
+│  (10.0.0.100)◄────────►    Server    ◄─────────►  Assistant  │
+│             │         │  (10.0.0.1)  │         │ (10.0.0.5)  │
+└─────────────┘         └──────────────┘         └─────────────┘
+      │                                                  │
+      └──────────────── VPN Tunnel ────────────────────┘
+```
+
+## References
+
+- [ESPHome WireGuard Component](https://esphome.io/components/wireguard/)
+- [ESPHome Native API](https://esphome.io/components/api/)
+- [WireGuard Official Documentation](https://www.wireguard.com/)
+- [Home Assistant ESPHome Integration](https://www.home-assistant.io/integrations/esphome/)
+
+## License
+
+This example is provided as-is for educational and development purposes.
+
+## Contributing
+
+This is part of the MCU Tinkering Lab repository. Feel free to submit improvements or report issues.
+
+## Next Steps
+
+1. **Add real sensors** - Temperature, humidity, motion, etc.
+2. **Create automations** - Use Home Assistant to automate based on sensor data
+3. **Multi-location deployment** - Connect devices from different physical locations
+4. **Mesh network** - Connect multiple ESP32 devices via WireGuard
+5. **Monitoring dashboard** - Create a Home Assistant dashboard for all VPN-connected devices

--- a/packages/esp32-projects/esp32-wireguard-ha-example/WIRING.md
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/WIRING.md
@@ -1,0 +1,292 @@
+# Wiring Guide
+
+This example project primarily focuses on network connectivity (WiFi and WireGuard VPN), so minimal hardware wiring is required. However, this guide provides information for adding optional sensors and controls.
+
+## Basic Setup
+
+### ESP32 Development Board
+
+The basic setup requires only:
+- ESP32 development board (ESP32-DevKitC, NodeMCU-32S, or similar)
+- USB cable for programming
+- Power supply (USB or external 5V)
+
+**No additional wiring is required** for the basic WireGuard and Home Assistant integration!
+
+## Power Considerations
+
+- **USB Power**: 5V via USB port (easiest for development)
+- **External Power**: 5V to VIN pin or 3.3V to 3V3 pin
+- **Battery Power**: Use 3.7V LiPo with voltage regulator
+
+**Warning**: Never apply more than 3.6V directly to 3V3 pin or more than 6V to VIN pin.
+
+## Optional: I2C Sensors (BME280 Example)
+
+To add environmental sensors like the BME280 (temperature, humidity, pressure):
+
+### BME280 Wiring
+
+| BME280 Pin | ESP32 Pin | Notes |
+|------------|-----------|-------|
+| VCC        | 3.3V      | Do not use 5V! |
+| GND        | GND       | Common ground |
+| SDA        | GPIO21    | I2C data (default) |
+| SCL        | GPIO22    | I2C clock (default) |
+
+### Configuration
+
+Uncomment these sections in `esp32-wireguard-ha.yaml`:
+
+```yaml
+i2c:
+  sda: GPIO21
+  scl: GPIO22
+  scan: true
+
+sensor:
+  - platform: bme280
+    temperature:
+      name: "Temperature"
+    pressure:
+      name: "Pressure"
+    humidity:
+      name: "Humidity"
+    address: 0x76  # or 0x77 depending on module
+    update_interval: 60s
+```
+
+## Optional: GPIO Control (Relay/LED)
+
+To control external devices:
+
+### Relay Module Wiring
+
+| Relay Module | ESP32 Pin | Notes |
+|--------------|-----------|-------|
+| VCC          | 5V (VIN)  | Most relay modules need 5V |
+| GND          | GND       | Common ground |
+| IN           | GPIO2     | Control signal |
+
+**Note**: If using a 3.3V relay, connect VCC to 3.3V instead.
+
+### Configuration
+
+Uncomment in `esp32-wireguard-ha.yaml`:
+
+```yaml
+switch:
+  - platform: gpio
+    pin: GPIO2
+    name: "Relay 1"
+    id: relay1
+    restore_mode: RESTORE_DEFAULT_OFF
+```
+
+## Optional: Physical Button
+
+To add a physical button for triggering actions:
+
+### Button Wiring
+
+| Component | ESP32 Pin | Notes |
+|-----------|-----------|-------|
+| Button (one side) | GPIO0 | Boot button (built-in on most boards) |
+| Button (other side) | GND | Connects to ground when pressed |
+
+**Note**: GPIO0 is the built-in BOOT button on most ESP32 dev boards.
+
+For external button:
+
+| Component | ESP32 Pin | Notes |
+|-----------|-----------|-------|
+| Button (one side) | GPIO4 | Any available GPIO |
+| Button (other side) | GND | Connects to ground when pressed |
+
+### Configuration
+
+Uncomment in `esp32-wireguard-ha.yaml`:
+
+```yaml
+binary_sensor:
+  - platform: gpio
+    pin:
+      number: GPIO0
+      mode:
+        input: true
+        pullup: true
+      inverted: true
+    name: "Button"
+    on_press:
+      then:
+        - switch.toggle: relay1  # If you have a relay
+        # Or trigger other actions
+```
+
+## GPIO Pin Reference
+
+### Safe to Use (ESP32-DevKitC)
+
+These GPIOs are generally safe for general use:
+
+- GPIO4, GPIO5
+- GPIO12, GPIO13, GPIO14, GPIO15
+- GPIO16, GPIO17, GPIO18, GPIO19
+- GPIO21, GPIO22, GPIO23
+- GPIO25, GPIO26, GPIO27
+- GPIO32, GPIO33
+
+### Avoid or Use with Caution
+
+- **GPIO0**: Boot mode selection (also BOOT button)
+- **GPIO1, GPIO3**: UART TX/RX (used for serial debugging)
+- **GPIO6-11**: Connected to flash chip (do not use!)
+- **GPIO34-39**: Input only, no pullup/pulldown resistors
+
+### Special Function Pins
+
+- **GPIO21, GPIO22**: Default I2C (SDA, SCL)
+- **GPIO18, GPIO19, GPIO23, GPIO5**: Default SPI (SCK, MISO, MOSI, CS)
+- **GPIO2**: Often has built-in LED
+
+## Peripheral Examples
+
+### 1. Temperature & Humidity (DHT22)
+
+```
+DHT22 Pin 1 (VCC) ──── 3.3V
+DHT22 Pin 2 (DATA) ─── GPIO4 (with 4.7kΩ pull-up to 3.3V)
+DHT22 Pin 3 (NC) ────── (not connected)
+DHT22 Pin 4 (GND) ──── GND
+```
+
+### 2. Motion Sensor (PIR)
+
+```
+PIR VCC ──── 5V (VIN)
+PIR OUT ──── GPIO5
+PIR GND ──── GND
+```
+
+### 3. LED Indicator
+
+```
+LED Anode (+) ──── GPIO2
+LED Cathode (-) ─── 220Ω resistor ──── GND
+```
+
+### 4. OLED Display (I2C)
+
+```
+OLED VCC ──── 3.3V
+OLED GND ──── GND
+OLED SDA ──── GPIO21
+OLED SCL ──── GPIO22
+```
+
+## Power Consumption
+
+Typical ESP32 power consumption:
+
+- **Active WiFi**: 160-260mA
+- **Active WiFi + WireGuard**: 180-280mA
+- **Light sleep**: 0.8mA
+- **Deep sleep**: 10-150µA
+
+For battery-powered applications, consider implementing deep sleep modes when not actively communicating.
+
+## Safety Notes
+
+1. **Voltage Levels**: ESP32 GPIOs are 3.3V - do not connect 5V signals directly
+2. **Current Limits**: Each GPIO can source/sink ~40mA maximum
+3. **Total Current**: Keep total GPIO current under 200mA
+4. **Relay Isolation**: Use optocoupler relays for AC loads
+5. **ESD Protection**: Handle the ESP32 with care to avoid static damage
+
+## Recommended Development Setup
+
+```
+Computer USB Port
+      │
+      │ USB Cable
+      │
+      ▼
+┌─────────────┐
+│   ESP32     │
+│  Dev Board  │
+└─────────────┘
+      │
+      │ (Optional) Sensors/Peripherals
+      │
+      ▼
+┌─────────────┐
+│ BME280 or   │
+│ Other I2C   │
+│ Sensor      │
+└─────────────┘
+```
+
+## Enclosure Considerations
+
+When deploying in an enclosure:
+
+1. **Ventilation**: Ensure airflow for temperature sensors
+2. **Antenna placement**: Keep WiFi antenna away from metal
+3. **Access**: Leave USB port accessible for debugging
+4. **LED visibility**: Position status LEDs where visible
+5. **Button access**: Make physical buttons easily reachable
+
+## Breadboard Layout Example
+
+For prototyping with BME280 and relay:
+
+```
+     ESP32           BME280         Relay
+      │                │              │
+  ┌───┴───┐        ┌──┴──┐       ┌───┴────┐
+  │ 3.3V  ├────────┤ VCC │       │        │
+  │ GND   ├────┬───┤ GND │───────┤ GND    │
+  │ GPIO21├────┼───┤ SDA │       │        │
+  │ GPIO22├────┼───┤ SCL │       │        │
+  │ GPIO2 ├────┼───┼─────┼───────┤ IN     │
+  │ 5V    ├────┼───┼─────┼───────┤ VCC    │
+  └───────┘    │   └─────┘       └────────┘
+               │
+            Common
+            Ground Bus
+```
+
+## Testing
+
+After wiring:
+
+1. **Visual inspection**: Check all connections
+2. **Continuity test**: Verify ground connections
+3. **Power test**: Measure voltage at VCC pins (should be 3.3V)
+4. **Upload firmware**: Flash the basic configuration
+5. **Check logs**: Monitor for any I2C or GPIO errors
+
+## Troubleshooting
+
+**Sensor not detected:**
+- Check I2C address (use `scan: true` in i2c config)
+- Verify wiring (SDA/SCL not swapped)
+- Check pull-up resistors (usually built-in to modules)
+
+**Relay not switching:**
+- Verify control voltage (should be 3.3V when on)
+- Check relay module voltage requirements
+- Test GPIO output with LED first
+
+**ESP32 not booting:**
+- Check GPIO0 is not grounded at boot (except for flashing)
+- Verify power supply can provide sufficient current
+- Disconnect peripherals and test with bare ESP32
+
+## Next Steps
+
+1. Start with the basic configuration (no extra hardware)
+2. Verify WireGuard and Home Assistant connectivity
+3. Add one sensor/peripheral at a time
+4. Test each addition before proceeding
+5. Document your final wiring for future reference

--- a/packages/esp32-projects/esp32-wireguard-ha-example/esp32-wireguard-ha.yaml
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/esp32-wireguard-ha.yaml
@@ -1,0 +1,165 @@
+esphome:
+  name: esp32-wireguard-ha
+  friendly_name: "ESP32 WireGuard HA Example"
+  platform: ESP32
+  board: esp32dev
+
+# Enable logging
+logger:
+  level: DEBUG
+
+# Enable Home Assistant API with encryption
+api:
+  encryption:
+    key: !secret api_encryption_key
+  # Reboot if API connection is lost for too long
+  reboot_timeout: 15min
+
+# Enable OTA updates
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+# WiFi configuration
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "ESP32-WireGuard-HA"
+    password: !secret fallback_password
+
+  # Use manual IP (optional but recommended for WireGuard)
+  manual_ip:
+    static_ip: !secret device_ip
+    gateway: !secret gateway_ip
+    subnet: !secret subnet_mask
+    dns1: !secret dns1
+    dns2: !secret dns2
+
+captive_portal:
+
+# Time synchronization using SNTP (required for WireGuard)
+# IMPORTANT: Do not use 'homeassistant' time platform if HA is accessed via WireGuard
+time:
+  - platform: sntp
+    id: sntp_time
+    timezone: "UTC"
+    servers:
+      - 0.pool.ntp.org
+      - 1.pool.ntp.org
+      - 2.pool.ntp.org
+
+# WireGuard VPN Configuration
+wireguard:
+  # Local IP address for this device on the VPN
+  address: !secret wg_address
+
+  # This device's private key (generate with: wg genkey)
+  private_key: !secret wg_private_key
+
+  # WireGuard server configuration
+  peer_endpoint: !secret wg_peer_endpoint
+  peer_public_key: !secret wg_peer_public_key
+  peer_port: !secret wg_peer_port
+
+  # Optional: Pre-shared key for additional security
+  # peer_preshared_key: !secret wg_peer_preshared_key
+
+  # Networks allowed through the VPN tunnel (CIDR notation)
+  # This example routes Home Assistant traffic through VPN
+  peer_allowed_ips:
+    - !secret wg_allowed_ips
+
+  # Keepalive for NAT traversal (25 seconds recommended)
+  peer_persistent_keepalive: 25s
+
+  # Netmask for the VPN network
+  netmask: 255.255.255.0
+
+# Binary sensors to monitor WireGuard status
+binary_sensor:
+  # Status of WireGuard connection
+  - platform: wireguard
+    name: "WireGuard Status"
+    id: wg_status
+
+  # Built-in status LED indicator
+  - platform: status
+    name: "Device Status"
+    id: device_status
+
+# Sensors for monitoring
+sensor:
+  # WiFi signal strength
+  - platform: wifi_signal
+    name: "WiFi Signal"
+    update_interval: 60s
+
+  # Device uptime
+  - platform: uptime
+    name: "Uptime"
+    update_interval: 60s
+
+  # WireGuard latest handshake timestamp
+  - platform: wireguard
+    name: "WG Latest Handshake"
+    id: wg_handshake
+
+# Text sensors
+text_sensor:
+  # WireGuard VPN address
+  - platform: wireguard
+    name: "WG Address"
+    id: wg_address_sensor
+
+  # Device IP address
+  - platform: wifi_info
+    ip_address:
+      name: "Device IP"
+
+  # ESPHome version
+  - platform: version
+    name: "ESPHome Version"
+
+# Example: Temperature sensor (BME280 via I2C)
+# Uncomment and configure if you have sensors connected
+# i2c:
+#   sda: GPIO21
+#   scl: GPIO22
+#   scan: true
+
+# sensor:
+#   - platform: bme280
+#     temperature:
+#       name: "Temperature"
+#       oversampling: 16x
+#     pressure:
+#       name: "Pressure"
+#     humidity:
+#       name: "Humidity"
+#     address: 0x76
+#     update_interval: 60s
+
+# Example: Control a relay or LED
+# switch:
+#   - platform: gpio
+#     pin: GPIO2
+#     name: "Relay 1"
+#     id: relay1
+#     restore_mode: RESTORE_DEFAULT_OFF
+
+# Example: Physical button input
+# binary_sensor:
+#   - platform: gpio
+#     pin:
+#       number: GPIO0
+#       mode:
+#         input: true
+#         pullup: true
+#       inverted: true
+#     name: "Button"
+#     on_press:
+#       then:
+#         - switch.toggle: relay1

--- a/packages/esp32-projects/esp32-wireguard-ha-example/home-assistant-example.yaml
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/home-assistant-example.yaml
@@ -1,0 +1,327 @@
+# Home Assistant Configuration Examples
+# These examples show how to use the ESP32 WireGuard device in Home Assistant
+
+# ============================================================================
+# Automations
+# ============================================================================
+
+automation:
+  # Monitor WireGuard connection status
+  - id: esp32_wireguard_connected
+    alias: "ESP32 WireGuard - Connection Established"
+    description: "Notify when ESP32 successfully connects via WireGuard"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.esp32_wireguard_ha_wireguard_status
+        to: 'on'
+    action:
+      - service: notify.notify
+        data:
+          title: "ESP32 Connected"
+          message: "ESP32 WireGuard HA device is now online via VPN"
+
+  # Alert on WireGuard disconnection
+  - id: esp32_wireguard_disconnected
+    alias: "ESP32 WireGuard - Connection Lost"
+    description: "Alert when ESP32 loses WireGuard connection"
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.esp32_wireguard_ha_wireguard_status
+        to: 'off'
+        for:
+          minutes: 5
+    action:
+      - service: notify.notify
+        data:
+          title: "ESP32 Disconnected"
+          message: "ESP32 WireGuard HA device lost VPN connection for 5 minutes"
+          data:
+            priority: high
+
+  # Monitor WiFi signal strength
+  - id: esp32_weak_wifi_signal
+    alias: "ESP32 WireGuard - Weak WiFi Signal"
+    description: "Alert when WiFi signal becomes weak"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.esp32_wireguard_ha_wifi_signal
+        below: -80
+        for:
+          minutes: 10
+    action:
+      - service: notify.notify
+        data:
+          title: "Weak WiFi Signal"
+          message: >
+            ESP32 WiFi signal is weak: {{ states('sensor.esp32_wireguard_ha_wifi_signal') }} dBm.
+            Consider improving WiFi coverage.
+
+  # Daily uptime report
+  - id: esp32_daily_status
+    alias: "ESP32 WireGuard - Daily Status Report"
+    description: "Send daily status report"
+    trigger:
+      - platform: time
+        at: "08:00:00"
+    condition:
+      - condition: state
+        entity_id: binary_sensor.esp32_wireguard_ha_device_status
+        state: 'on'
+    action:
+      - service: notify.notify
+        data:
+          title: "ESP32 Daily Status"
+          message: >
+            ESP32 Status Report:
+            Uptime: {{ states('sensor.esp32_wireguard_ha_uptime') | int // 3600 }} hours
+            WiFi Signal: {{ states('sensor.esp32_wireguard_ha_wifi_signal') }} dBm
+            WireGuard: {{ states('binary_sensor.esp32_wireguard_ha_wireguard_status') }}
+            IP Address: {{ states('sensor.esp32_wireguard_ha_device_ip') }}
+            VPN Address: {{ states('sensor.esp32_wireguard_ha_wg_address') }}
+
+  # Example: Use sensor data for automation (if you add a temperature sensor)
+  - id: esp32_temperature_alert
+    alias: "ESP32 - High Temperature Alert"
+    description: "Alert when temperature exceeds threshold"
+    trigger:
+      - platform: numeric_state
+        entity_id: sensor.esp32_wireguard_ha_temperature
+        above: 30
+    action:
+      - service: notify.notify
+        data:
+          title: "High Temperature"
+          message: "Temperature is {{ states('sensor.esp32_wireguard_ha_temperature') }}°C"
+
+  # Example: Toggle relay based on time
+  - id: esp32_relay_schedule
+    alias: "ESP32 - Scheduled Relay Control"
+    description: "Turn relay on/off based on schedule"
+    trigger:
+      - platform: time
+        at: "07:00:00"
+        id: morning
+      - platform: time
+        at: "22:00:00"
+        id: evening
+    action:
+      - choose:
+          - conditions:
+              - condition: trigger
+                id: morning
+            sequence:
+              - service: switch.turn_on
+                target:
+                  entity_id: switch.esp32_wireguard_ha_relay_1
+          - conditions:
+              - condition: trigger
+                id: evening
+            sequence:
+              - service: switch.turn_off
+                target:
+                  entity_id: switch.esp32_wireguard_ha_relay_1
+
+# ============================================================================
+# Scripts
+# ============================================================================
+
+script:
+  # Restart ESP32 remotely
+  esp32_wireguard_restart:
+    alias: "ESP32 - Restart Device"
+    sequence:
+      - service: button.press
+        target:
+          entity_id: button.esp32_wireguard_ha_restart
+
+  # Check ESP32 connection health
+  esp32_wireguard_health_check:
+    alias: "ESP32 - Health Check"
+    sequence:
+      - service: notify.notify
+        data:
+          title: "ESP32 Health Check"
+          message: >
+            Device Status: {{ states('binary_sensor.esp32_wireguard_ha_device_status') }}
+            WireGuard: {{ states('binary_sensor.esp32_wireguard_ha_wireguard_status') }}
+            WiFi Signal: {{ states('sensor.esp32_wireguard_ha_wifi_signal') }} dBm
+            Uptime: {{ (states('sensor.esp32_wireguard_ha_uptime') | int / 86400) | round(1) }} days
+            Last Handshake: {{ states('sensor.esp32_wireguard_ha_wg_latest_handshake') }}
+
+# ============================================================================
+# Template Sensors
+# ============================================================================
+
+sensor:
+  # Convert uptime to human-readable format
+  - platform: template
+    sensors:
+      esp32_wireguard_uptime_formatted:
+        friendly_name: "ESP32 Uptime (Formatted)"
+        value_template: >
+          {% set uptime = states('sensor.esp32_wireguard_ha_uptime') | int %}
+          {% set days = (uptime / 86400) | int %}
+          {% set hours = ((uptime % 86400) / 3600) | int %}
+          {% set minutes = ((uptime % 3600) / 60) | int %}
+          {{ days }}d {{ hours }}h {{ minutes }}m
+
+  # WiFi signal quality percentage
+  - platform: template
+    sensors:
+      esp32_wifi_quality:
+        friendly_name: "ESP32 WiFi Quality"
+        unit_of_measurement: "%"
+        value_template: >
+          {% set rssi = states('sensor.esp32_wireguard_ha_wifi_signal') | int %}
+          {% if rssi >= -50 %}
+            100
+          {% elif rssi <= -100 %}
+            0
+          {% else %}
+            {{ ((rssi + 100) * 2) | int }}
+          {% endif %}
+        icon_template: >
+          {% set rssi = states('sensor.esp32_wireguard_ha_wifi_signal') | int %}
+          {% if rssi >= -50 %}
+            mdi:wifi-strength-4
+          {% elif rssi >= -60 %}
+            mdi:wifi-strength-3
+          {% elif rssi >= -70 %}
+            mdi:wifi-strength-2
+          {% else %}
+            mdi:wifi-strength-1
+          {% endif %}
+
+  # Time since last WireGuard handshake
+  - platform: template
+    sensors:
+      esp32_handshake_age:
+        friendly_name: "ESP32 WireGuard Handshake Age"
+        value_template: >
+          {% set handshake = states('sensor.esp32_wireguard_ha_wg_latest_handshake') %}
+          {% if handshake not in ['unknown', 'unavailable', ''] %}
+            {{ relative_time(strptime(handshake, '%Y-%m-%d %H:%M:%S')) }}
+          {% else %}
+            Unknown
+          {% endif %}
+
+# ============================================================================
+# Binary Sensors
+# ============================================================================
+
+binary_sensor:
+  # Connection health indicator
+  - platform: template
+    sensors:
+      esp32_wireguard_healthy:
+        friendly_name: "ESP32 Connection Healthy"
+        device_class: connectivity
+        value_template: >
+          {{ is_state('binary_sensor.esp32_wireguard_ha_wireguard_status', 'on') and
+             is_state('binary_sensor.esp32_wireguard_ha_device_status', 'on') and
+             states('sensor.esp32_wireguard_ha_wifi_signal') | int > -80 }}
+
+# ============================================================================
+# Lovelace Dashboard Card Examples
+# ============================================================================
+
+# Add this to your Lovelace dashboard configuration:
+
+# - type: entities
+#   title: ESP32 WireGuard Status
+#   entities:
+#     - entity: binary_sensor.esp32_wireguard_ha_device_status
+#       name: Device Online
+#     - entity: binary_sensor.esp32_wireguard_ha_wireguard_status
+#       name: VPN Connected
+#     - entity: sensor.esp32_wireguard_ha_wifi_signal
+#       name: WiFi Signal
+#     - entity: sensor.esp32_wifi_quality
+#       name: WiFi Quality
+#     - entity: sensor.esp32_wireguard_uptime_formatted
+#       name: Uptime
+#     - entity: sensor.esp32_wireguard_ha_device_ip
+#       name: Local IP
+#     - entity: sensor.esp32_wireguard_ha_wg_address
+#       name: VPN IP
+#     - entity: sensor.esp32_handshake_age
+#       name: Last Handshake
+#     - entity: button.esp32_wireguard_ha_restart
+#       name: Restart
+
+# Gauge card for WiFi signal
+# - type: gauge
+#   entity: sensor.esp32_wifi_quality
+#   name: WiFi Quality
+#   min: 0
+#   max: 100
+#   severity:
+#     green: 70
+#     yellow: 40
+#     red: 0
+
+# Status indicator card
+# - type: glance
+#   title: ESP32 Quick Status
+#   entities:
+#     - entity: binary_sensor.esp32_wireguard_healthy
+#       name: Healthy
+#     - entity: binary_sensor.esp32_wireguard_ha_wireguard_status
+#       name: VPN
+#     - entity: binary_sensor.esp32_wireguard_ha_device_status
+#       name: Online
+
+# ============================================================================
+# Advanced: Node-RED Flow Example
+# ============================================================================
+
+# If using Node-RED, here's a flow to monitor the ESP32:
+#
+# [State Change Node] -> [Switch Node] -> [Notification Node]
+#    (WireGuard Status)    (on/off)         (Alert)
+#
+# 1. Add "events: state" node for binary_sensor.esp32_wireguard_ha_wireguard_status
+# 2. Add "switch" node to check if state is 'off'
+# 3. Add "call service" node to send notification
+# 4. Add delay node to prevent spam
+
+# ============================================================================
+# Integration with Other Systems
+# ============================================================================
+
+# Example: Trigger webhook on status change
+# automation:
+#   - id: esp32_webhook_trigger
+#     alias: "ESP32 - Webhook Notification"
+#     trigger:
+#       - platform: state
+#         entity_id: binary_sensor.esp32_wireguard_ha_wireguard_status
+#     action:
+#       - service: rest_command.esp32_webhook
+#         data:
+#           status: "{{ states('binary_sensor.esp32_wireguard_ha_wireguard_status') }}"
+
+# rest_command:
+#   esp32_webhook:
+#     url: "https://example.com/webhook"
+#     method: POST
+#     payload: '{"device": "esp32-wireguard", "status": "{{ status }}"}'
+#     content_type: 'application/json'
+
+# ============================================================================
+# Alerting via Multiple Channels
+# ============================================================================
+
+# Group notification services
+# notify:
+#   - name: all_devices
+#     platform: group
+#     services:
+#       - service: mobile_app
+#       - service: telegram
+#       - service: email
+
+# Then use in automations:
+# - service: notify.all_devices
+#   data:
+#     message: "ESP32 status changed"

--- a/packages/esp32-projects/esp32-wireguard-ha-example/secrets.yaml.example
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/secrets.yaml.example
@@ -1,0 +1,49 @@
+# ESPHome Secrets Template
+# Copy this file to secrets.yaml and fill in your actual values
+# IMPORTANT: Never commit secrets.yaml to version control!
+
+# WiFi Configuration
+wifi_ssid: "YourWiFiSSID"
+wifi_password: "YourWiFiPassword"
+
+# Device Network Configuration (optional - remove manual_ip section in main yaml if using DHCP)
+device_ip: "192.168.1.100"
+gateway_ip: "192.168.1.1"
+subnet_mask: "255.255.255.0"
+dns1: "8.8.8.8"
+dns2: "8.8.4.4"
+
+# ESPHome API Encryption Key
+# Generate with: esphome run esp32-wireguard-ha.yaml
+# Or manually: openssl rand -base64 32
+api_encryption_key: "your-32-byte-base64-encoded-api-key-here"
+
+# OTA Update Password
+ota_password: "your-ota-password-here"
+
+# Fallback Access Point Password
+fallback_password: "wireguard123"
+
+# WireGuard Configuration
+# Local VPN IP address for this ESP32 device
+wg_address: "10.0.0.100"
+
+# This device's WireGuard private key
+# Generate key pair with:
+#   wg genkey | tee private.key | wg pubkey > public.key
+# Then copy the content of private.key here
+wg_private_key: "your-device-private-key-here"
+
+# WireGuard server/peer configuration
+wg_peer_endpoint: "your-wireguard-server.com"
+wg_peer_public_key: "your-server-public-key-here"
+wg_peer_port: "51820"
+
+# Optional: Pre-shared key for additional security
+# Generate with: wg genpsk
+# wg_peer_preshared_key: "your-preshared-key-here"
+
+# Networks allowed through the VPN tunnel (CIDR notation)
+# Example: Allow traffic to Home Assistant network
+# Use "0.0.0.0/0" to route ALL traffic through VPN
+wg_allowed_ips: "192.168.50.0/24"


### PR DESCRIPTION
Add a comprehensive example project demonstrating how to connect an ESP32 to Home Assistant via WireGuard VPN using ESPHome.

Features:
- WireGuard VPN integration with connection monitoring
- Home Assistant native API with encryption
- Example sensors (WiFi signal, uptime, VPN handshake)
- Comprehensive documentation and setup guides
- Makefile for easy development workflow
- Home Assistant automation examples

Project includes:
- ESPHome configuration with WireGuard and HA API
- Detailed README with setup instructions
- Wiring guide for optional sensors/peripherals
- Secrets template for easy configuration
- Example Home Assistant automations and dashboards

This enables secure remote IoT device access without exposing devices directly to the internet.