### PR TITLE
docs(audiobook-player): Rename board to ESP32 WiFi & Bluetooth Battery Board

### DIFF
--- a/packages/esp32-projects/audiobook-player/CLAUDE.md
+++ b/packages/esp32-projects/audiobook-player/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ESPHome-based RFID audiobook player for kids. Scan picture cards with RFID tags to trigger Home Assistant automations that play audiobooks. Physical play/pause buttons provide tactile control.
 
-**Hardware:** WEMOS Battery ESP32, RC522 RFID reader (SPI), two buttons (GPIO32/GPIO33), tilt switch (GPIO27) for deep sleep wake
+**Hardware:** ESP32 WiFi & Bluetooth Battery Board (18650), RC522 RFID reader (SPI), two buttons (GPIO32/GPIO33), tilt switch (GPIO27) for deep sleep wake
 
 **Integration:** Device sends events to Home Assistant via ESPHome API. Home Assistant automations map RFID tag UIDs to media playback actions.
 
@@ -67,7 +67,7 @@ esphome logs audiobook-player.yaml
 
 ### Power Considerations
 
-- WEMOS Battery ESP32 has integrated 18650 battery holder
+- ESP32 WiFi & Bluetooth Battery Board has integrated 18650 battery holder
 - Built-in charging circuit when powered via USB
 - Status LED on GPIO16 (inverted logic)
 

--- a/packages/esp32-projects/audiobook-player/README.md
+++ b/packages/esp32-projects/audiobook-player/README.md
@@ -4,7 +4,7 @@ An RFID-based audiobook player that integrates with Home Assistant. Scan picture
 
 ## Hardware
 
-- **WEMOS WiFi & Bluetooth Battery ESP32** (with 18650 battery holder)
+- **ESP32 WiFi & Bluetooth Battery Board** (with 18650 battery holder, ESPHome board: `wemosbat`)
 - **RC522 RFID Reader Module**
 - **Green button** (Play)
 - **Red button** (Pause)

--- a/packages/esp32-projects/audiobook-player/WIRING.md
+++ b/packages/esp32-projects/audiobook-player/WIRING.md
@@ -4,8 +4,8 @@
 
 ```
                     ┌─────────────────────────────┐
-                    │  WEMOS Battery ESP32        │
-                    │  (WiFi & Bluetooth)         │
+                    │  ESP32 WiFi & Bluetooth     │
+                    │  Battery Board (18650)      │
                     └─────────────────────────────┘
                            │
         ┌──────────────────┼──────────────────┬──────────────┐
@@ -22,7 +22,7 @@
 The RC522 uses SPI communication protocol:
 
 ```
-RC522               WEMOS ESP32
+RC522               ESP32 Battery Board
 ┌─────────┐        ┌─────────┐
 │ SDA(CS) ├────────┤ GPIO17  │ SPI CS
 │ SCK     ├────────┤ GPIO18  │ SPI Clock
@@ -44,7 +44,7 @@ Both buttons use the same wiring pattern with internal pull-up resistors:
 ### Green Button (Play)
 
 ```
-     WEMOS ESP32
+     ESP32 Battery Board
     ┌────────────┐
     │  GPIO32    ├──────┬─── One side of button
     │            │      │
@@ -58,7 +58,7 @@ Both buttons use the same wiring pattern with internal pull-up resistors:
 ### Red Button (Pause)
 
 ```
-     WEMOS ESP32
+     ESP32 Battery Board
     ┌────────────┐
     │  GPIO33    ├──────┬─── One side of button
     │            │      │
@@ -76,7 +76,7 @@ Both buttons use the same wiring pattern with internal pull-up resistors:
 The tilt switch (SW-200D or similar ball tilt switch) wakes the device from deep sleep:
 
 ```
-     WEMOS ESP32
+     ESP32 Battery Board
     ┌────────────┐
     │  GPIO27    ├──────┬─── One side of tilt switch
     │            │      │
@@ -103,7 +103,7 @@ The tilt switch (SW-200D or similar ball tilt switch) wakes the device from deep
 The piezo buzzer provides pleasant musical tones for state indication:
 
 ```
-     WEMOS ESP32
+     ESP32 Battery Board
     ┌────────────┐
     │  GPIO25    ├──────────── + Buzzer
     │            │
@@ -127,7 +127,7 @@ The piezo buzzer provides pleasant musical tones for state indication:
 The vibration motor provides tactile feedback when a tag is scanned:
 
 ```
-     WEMOS ESP32                    Motor Circuit
+     ESP32 Battery Board            Motor Circuit
     ┌────────────┐                 ┌─────────────┐
     │  GPIO26    ├──── 1kΩ ────────┤ Base        │
     │            │                 │   NPN       │
@@ -174,7 +174,7 @@ The vibration motor provides tactile feedback when a tag is scanned:
 
 ## Power Considerations
 
-- The WEMOS Battery ESP32 can be powered via:
+- The ESP32 WiFi & Bluetooth Battery Board can be powered via:
   - **USB** (5V) - Easiest for development
   - **18650 Battery** - Built-in battery holder on back
     - Always-on runtime: ~17 hours (80mA average)
@@ -211,7 +211,7 @@ A standard USB power supply (500mA+) is sufficient for development. For portable
 If you want an external status LED instead of the built-in one:
 
 ```
-     WEMOS ESP32
+     ESP32 Battery Board
     ┌────────────┐
     │  GPIO16    ├────┬── Anode (+) of LED
     │            │    │
@@ -234,7 +234,7 @@ Resistor: 220Ω - 330Ω (for standard 3.3V LED)
 │  └──────────┘      └──────────────┘   │
 │                                        │
 │          ┌────────────────────┐        │
-│          │   WEMOS ESP32      │        │
+│          │  ESP32 Battery     │        │
 │          │   (Battery)        │        │
 │          └────────────────────┘        │
 │                                        │
@@ -257,7 +257,7 @@ Power via USB cable or 18650 battery in rear holder
 4. ✓ Tilt switch wired to GPIO27 and GND
 5. ✓ Buzzer wired to GPIO25 and GND
 6. ✓ Vibration motor wired via transistor to GPIO26
-7. ✓ WEMOS ESP32 powered via USB or 18650 battery
+7. ✓ ESP32 Battery Board powered via USB or 18650 battery
 8. ✓ Upload firmware and check logs
 9. ✓ Test boot sequence (LED blinks fast, hears ascending tones)
 10. ✓ Test ready state (LED pulses slowly, hears ready chime)


### PR DESCRIPTION
## Summary

- Update documentation to use the more accurate board name instead of "WEMOS Battery ESP32"
- The board is actually a generic ESP32 WiFi & Bluetooth Battery Board with 18650 holder
- Added ESPHome board type `wemosbat` to README for clarity

## Files Changed

- `CLAUDE.md` - Updated hardware description
- `README.md` - Updated hardware section with board type
- `WIRING.md` - Updated all wiring diagrams and references

🤖 Generated with [Claude Code](https://claude.com/claude-code)