### PR TITLE
ci: add Claude auto-fix workflow for CI failures

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,240 @@
+name: Claude Auto-fix CI Failures
+
+on:
+  workflow_run:
+    workflows: ["Test Suite", "ESP32 Build Pipeline"]
+    types: [completed]
+
+  # Manual trigger for testing — provide the failed run ID
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Failed workflow run ID to analyze"
+        required: true
+        type: string
+
+concurrency:
+  group: auto-fix-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  auto-fix:
+    name: Analyze and fix CI failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    # Only run on failures, skip if triggered by auto-fix commits (loop prevention)
+    if: >
+      (github.event_name == 'workflow_dispatch') ||
+      (
+        github.event.workflow_run.conclusion == 'failure' &&
+        !startsWith(github.event.workflow_run.head_commit.message, 'fix(auto):')
+      )
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read
+      checks: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Gather failure context
+        id: context
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI_CONTEXT_DIR: ${{ runner.temp }}/ci-failure-context
+        run: |
+          # Determine which run to analyze
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RUN_ID="${{ inputs.run_id }}"
+          else
+            RUN_ID="${{ github.event.workflow_run.id }}"
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+          # Get run metadata
+          WORKFLOW_NAME=$(gh run view "${RUN_ID}" --json workflowName -q '.workflowName')
+          HEAD_BRANCH=$(gh run view "${RUN_ID}" --json headBranch -q '.headBranch')
+          HEAD_SHA=$(gh run view "${RUN_ID}" --json headSha -q '.headSha')
+          RUN_URL=$(gh run view "${RUN_ID}" --json url -q '.url')
+          echo "workflow_name=${WORKFLOW_NAME}" >> "$GITHUB_OUTPUT"
+          echo "head_branch=${HEAD_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "run_url=${RUN_URL}" >> "$GITHUB_OUTPUT"
+
+          # Check for associated PR
+          PR_NUMBER=$(gh pr list --head "${HEAD_BRANCH}" --json number -q '.[0].number // empty' 2>/dev/null || echo "")
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          if [ -n "${PR_NUMBER}" ]; then
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          # Save failure logs to runner temp directory
+          mkdir -p "${CI_CONTEXT_DIR}"
+          echo "context_dir=${CI_CONTEXT_DIR}" >> "$GITHUB_OUTPUT"
+
+          gh run view "${RUN_ID}" --log-failed 2>/dev/null \
+            | tail -c 65536 > "${CI_CONTEXT_DIR}/failure-logs.txt"
+
+          gh run view "${RUN_ID}" --json jobs \
+            -q '.jobs[] | select(.conclusion == "failure") | "Job: \(.name)\nStatus: \(.conclusion)\nSteps:\n" + ([.steps[] | select(.conclusion == "failure") | "  - \(.name): \(.conclusion)"] | join("\n"))' \
+            > "${CI_CONTEXT_DIR}/failed-jobs.txt"
+
+          # Save metadata summary
+          cat > "${CI_CONTEXT_DIR}/metadata.txt" <<EOF
+          Workflow: ${WORKFLOW_NAME}
+          Branch: ${HEAD_BRANCH}
+          Commit: ${HEAD_SHA}
+          Run URL: ${RUN_URL}
+          Run ID: ${RUN_ID}
+          PR Number: ${PR_NUMBER:-none}
+          EOF
+
+          echo "Failure context saved to ${CI_CONTEXT_DIR}/"
+          echo "Workflow: ${WORKFLOW_NAME}"
+          echo "Branch: ${HEAD_BRANCH}"
+          echo "PR: ${PR_NUMBER:-none}"
+
+      - name: Check for existing auto-fix attempts
+        id: dedup
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check for open auto-fix PRs (cap at 3 to avoid flooding)
+          EXISTING_PRS=$(gh pr list \
+            --search "auto-fix in:title head:auto-fix/" \
+            --state open \
+            --json number \
+            -q 'length')
+
+          if [ "${EXISTING_PRS}" -gt "2" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping auto-fix: ${EXISTING_PRS} auto-fix PRs already open"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude auto-fix analysis
+        if: steps.dedup.outputs.skip != 'true'
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          additional_permissions: |
+            actions: read
+            checks: read
+
+          prompt: |
+            ## CI Failure Auto-Fix Task
+
+            A CI workflow has failed and you need to analyze and potentially fix the issue.
+
+            ### Failure Context
+
+            - **Workflow**: ${{ steps.context.outputs.workflow_name }}
+            - **Branch**: ${{ steps.context.outputs.head_branch }}
+            - **Commit**: ${{ steps.context.outputs.head_sha }}
+            - **Run URL**: ${{ steps.context.outputs.run_url }}
+            - **Run ID**: ${{ steps.context.outputs.run_id }}
+            - **Is PR**: ${{ steps.context.outputs.is_pr }}
+            - **PR Number**: ${{ steps.context.outputs.pr_number }}
+
+            ### Step 0: Read the failure logs
+
+            IMPORTANT: Start by reading these files to understand what failed:
+            1. Read `${{ steps.context.outputs.context_dir }}/failed-jobs.txt` for a summary of which jobs and steps failed
+            2. Read `${{ steps.context.outputs.context_dir }}/failure-logs.txt` for the detailed failure output
+
+            ### Step 1: Analyze the failure
+
+            After reading the logs:
+            - Identify the root cause of the failure
+            - Categorize the failure type (formatting, linting, build error, test failure, pre-commit hook, dependency issue)
+            - Determine if this is auto-fixable or requires human intervention
+
+            ### Step 2: Decide on action
+
+            A failure IS auto-fixable if it's:
+            - C/C++ formatting errors (run `clang-format` with `--style=file` on affected files)
+            - Python formatting errors (run `ruff format` on affected files)
+            - Python linting issues with auto-fixable rules (run `ruff check --fix`)
+            - Pre-commit hook failures caused by formatting or trailing whitespace
+            - Simple typos or syntax errors in C/C++/Python code that are obvious from the error message
+            - Missing trailing newlines or whitespace issues
+            - Simple cppcheck warnings with clear fixes (unused variables, missing initializers)
+
+            A failure is NOT auto-fixable (open issue instead) if it's:
+            - ESP-IDF build errors requiring architectural changes or missing components
+            - Complex C/C++ compilation errors (missing headers from ESP-IDF, linker errors)
+            - Test failures in the Python simulation that require logic changes
+            - Binary size threshold exceeded (requires optimization decisions)
+            - ESP-IDF version incompatibilities or SDK configuration issues
+            - Missing secrets or environment variable configuration
+            - Failures in the CI workflow configuration itself (YAML syntax, action versions)
+            - External service/infrastructure failures (network, CI runner issues, Codecov)
+            - The failure cause is ambiguous or unclear from the logs
+            - Security vulnerabilities requiring significant refactoring
+            - sdkconfig or partition table changes that could affect device behavior
+
+            ### Step 3A: If auto-fixable — Fix and create PR
+
+            1. Create a new branch: `auto-fix/${{ steps.context.outputs.head_branch }}-${{ steps.context.outputs.run_id }}`
+            2. Make the necessary code changes
+            3. Run verification commands to confirm the fix works:
+               - For C/C++ format errors: `find packages/esp32-projects -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) ! -path "*/managed_components/*" ! -path "*/components/esp-idf-lib/*" ! -path "*/build/*" -print0 | xargs -0 clang-format --dry-run --Werror --style=file`
+               - For Python format errors: `ruff format --check packages/esp32-projects/robocar-simulation/`
+               - For Python lint errors: `ruff check packages/esp32-projects/robocar-simulation/`
+               - For pre-commit issues: `pre-commit run --all-files`
+            4. Commit with message format: `fix(auto): {concise description}`
+            5. Push the branch
+            6. Create a PR using `gh pr create`:
+               - Title: `fix(auto): {description}` (under 70 chars)
+               - Base: `${{ steps.context.outputs.head_branch }}`
+               - Body must include:
+                 - Summary of what failed and why
+                 - What was changed to fix it
+                 - Link to the failed run: ${{ steps.context.outputs.run_url }}
+                 - Verification steps taken
+                 - Note: "This is an automated fix — please review before merging."
+            7. If this was a PR failure (is_pr == true), also comment on PR #${{ steps.context.outputs.pr_number }} linking to the fix PR
+
+            ### Step 3B: If NOT auto-fixable — Open an issue
+
+            Create a GitHub issue using `gh issue create`:
+            - Title: `CI failure: {workflow name} on {branch}` (under 70 chars)
+            - Labels: `bug,ci-failure`
+            - Body must include:
+              - **Failure summary**: What failed and root cause analysis
+              - **Workflow**: Name and link to the failed run
+              - **Branch**: The affected branch
+              - **Error details**: Key error messages from the logs
+              - **Suggested approach**: How a developer might fix this
+              - **Why not auto-fixed**: Why this requires human intervention
+
+            If this was a PR failure (is_pr == true), also comment on PR #${{ steps.context.outputs.pr_number }} with a link to the issue.
+
+            ### Important Rules
+
+            - Do NOT force push or rewrite history
+            - Do NOT modify workflow files (.github/workflows/) — those need manual fixes
+            - Do NOT add new dependencies without strong justification
+            - Do NOT make unrelated changes beyond what's needed to fix the failure
+            - Do NOT modify sdkconfig.defaults or partition tables — those affect device behavior
+            - If in doubt about whether a fix is correct, prefer opening an issue
+            - Follow project conventions from CLAUDE.md (Google style C/C++, 4-space indent, conventional commits)
+
+          claude_args: |
+            --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,Bash(clang-format:*),Bash(ruff:*),Bash(cppcheck:*),Bash(pre-commit:*),Bash(pip install:*),Bash(uv:*),Bash(python:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git switch:*),Bash(git checkout -b:*),Bash(gh issue create:*),Bash(gh issue list:*),Bash(gh issue comment:*),Bash(gh pr create:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh api:*),Bash(ls:*),Bash(find:*),Bash(grep:*),Bash(cat:*)"
+            --max-turns 50


### PR DESCRIPTION
Adds a workflow that triggers when "Test Suite" or "ESP32 Build Pipeline"
workflows fail. Claude analyzes the failure logs and either auto-fixes
simple issues (formatting, linting, whitespace) via a PR, or opens a
GitHub issue for failures that require human intervention.

Adapted for this repo's embedded/ESP32 tech stack with appropriate
auto-fixable categories (clang-format, ruff, pre-commit, cppcheck).

https://claude.ai/code/session_01KkdC7d1UoqvucbdyEqRkxz