### PR TITLE
fix(ci): use correct working directory for ESP-IDF build action

### DIFF
--- a/.github/workflows/esp32-build.yml
+++ b/.github/workflows/esp32-build.yml
@@ -48,28 +48,20 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup ESP-IDF
+      - name: Build ${{ matrix.project }}
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: ${{ env.IDF_VERSION }}
           target: ${{ matrix.target }}
-
-      - name: Build ${{ matrix.project }}
-        working-directory: packages/esp32-projects/${{ matrix.project }}
-        run: |
-          echo "Building ${{ matrix.description }}"
-          idf.py build
-
-      - name: Generate size analysis
-        working-directory: packages/esp32-projects/${{ matrix.project }}
-        run: |
-          echo "# Build Size Analysis for ${{ matrix.project }}" > size-report.txt
-          echo "" >> size-report.txt
-          echo "## Component Size Summary" >> size-report.txt
-          idf.py size >> size-report.txt 2>&1 || true
-          echo "" >> size-report.txt
-          echo "## Detailed Component Sizes" >> size-report.txt
-          idf.py size-components >> size-report.txt 2>&1 || true
+          command: >-
+            cd packages/esp32-projects/${{ matrix.project }} &&
+            echo "Building ${{ matrix.description }}" &&
+            idf.py build &&
+            echo "# Build Size Analysis for ${{ matrix.project }}" > size-report.txt &&
+            echo "## Component Size Summary" >> size-report.txt &&
+            (idf.py size >> size-report.txt 2>&1 || true) &&
+            echo "## Detailed Component Sizes" >> size-report.txt &&
+            (idf.py size-components >> size-report.txt 2>&1 || true)
 
       - name: Archive firmware binaries
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
The esp-idf-ci-action runs inside a Docker container and was looking for CMakeLists.txt at the repository root. Pass the project subdirectory via the command parameter and consolidate the build + size analysis steps into a single action invocation.

Fixes #76

https://claude.ai/code/session_01Xgojj9Hx5rNbdjwPzUExQx