### PR TITLE
feat: enable issue creation in Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -45,15 +45,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # Additional permissions for Claude to read CI results and manage issues
           additional_permissions: |
             actions: read
+            issues: write
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+          # Allow Claude to manage PRs and issues via the gh CLI
+          allowed_tools: "Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh issue list:*),Bash(gh issue view:*)"
 


### PR DESCRIPTION
Add issues: write to additional_permissions and allow gh issue CLI commands so Claude can create, edit, list, and view GitHub issues when triggered via the workflow.

https://claude.ai/code/session_01RMPuJiWwroazGdyZPB5qeM