### PR TITLE
fix: remove invalid 'workflows' permission from claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,7 +16,6 @@ permissions:
   issues: write
   id-token: write
   actions: read
-  workflows: write
 
 # Prevent concurrent Claude runs on the same issue/PR
 concurrency:


### PR DESCRIPTION
The 'workflows' permission is not a valid top-level workflow permission
in GitHub Actions, causing the workflow file validation to fail at line 19.

https://claude.ai/code/session_015EFfMYwk2rd9K4diLf5KdT