### PR TITLE
docs(it-troubleshooter): add project documentation, ADRs, and Claude Code rules

### DIFF
--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/code-style.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/code-style.md
@@ -1,0 +1,46 @@
+# Code Style
+
+**Confidence**: Very High — enforced by pre-commit hooks and clang-format config
+**Source**: `.clang-format`, `.pre-commit-config.yaml`, multiple `fix(auto)` commits
+
+## C/C++ Formatting
+
+- **Style base**: Google with 4-space indent (overrides Google's 2-space default)
+- **Line limit**: 100 characters (strict — critical for readability on OLED boards)
+- **Brace style**: Linux (break before braces for control flow)
+- **Pointer alignment**: Right (`int *ptr`, not `int* ptr`)
+- **Enforced by**: `clang-format` v17+ via pre-commit; CI fails on violations
+
+Do not manually format C/C++ — run `clang-format` or let pre-commit handle it.
+
+## Python Formatting
+
+- **Formatter**: `ruff-format` (not Black)
+- **Linter**: `ruff` with auto-fix enabled
+- **Type checker**: `mypy` (excludes test files)
+- **Python version**: 3.11 (pinned in pre-commit)
+
+## Function and Component Design
+
+- Keep functions small and single-responsibility
+- Prefer explicit initialization over constructor side effects:
+  ```c
+  // Good — explicit opt-in initialization
+  wifi_manager_init();
+  wifi_manager_connect();
+
+  // Avoid — side effects in init() that always run
+  ```
+- This pattern prevents unwanted behavior in tests and alternative configurations
+
+## Naming
+
+- Public component functions: `{component_name}_{verb}_{noun}()` (e.g., `status_led_set_mode()`)
+- Static (private) functions: no prefix required
+- Log tags: `static const char *TAG = "component_name"` (matches component directory name)
+- `#define` constants: `SCREAMING_SNAKE_CASE`
+
+## Paths to Format Config
+
+- `.clang-format` — C/C++ rules (repo root)
+- `.pre-commit-config.yaml` — enforcement hooks (repo root)

--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/dependencies.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/dependencies.md
@@ -1,0 +1,64 @@
+# Dependencies
+
+**Confidence**: High — derived from build system and CI patterns
+**Source**: docker-compose.yml, idf_component.yml files, CI workflow analysis
+
+## ESP-IDF Version
+
+Pin to a specific ESP-IDF version in `sdkconfig.defaults` and `docker-compose.yml`. The current project uses ESP-IDF v5.4.
+
+```
+docker image: espressif/idf:v5.4
+CONFIG_IDF_TARGET=esp32s3
+```
+
+Do not use `latest` — ESP-IDF has breaking API changes between minor versions.
+
+## IDF Component Manager
+
+Declare dependencies in `idf_component.yml` using exact or semver-compatible ranges:
+
+```yaml
+# Good — semver constraint
+dependencies:
+  espressif/esp_tinyusb: "^1.0.0"
+  espressif/led_strip: ">=2.0.0"
+```
+
+- `managed_components/` is gitignored — downloaded by IDF at build time
+- Do not vendor managed components into the repository
+- `EXTRA_COMPONENT_DIRS "components"` in root `CMakeLists.txt` for local components
+
+## REQUIRES vs PRIV_REQUIRES
+
+In component `CMakeLists.txt`:
+- `REQUIRES` — only for dependencies used in public headers (`include/`)
+- `PRIV_REQUIRES` — for dependencies used only in `.c` implementation files
+
+```cmake
+idf_component_register(
+    SRCS "status_led.c"
+    INCLUDE_DIRS "include"
+    REQUIRES led_strip       # used in public header? No → should be PRIV_REQUIRES
+    PRIV_REQUIRES esp_timer  # only used in .c file
+)
+```
+
+Missing `esp_timer` in `PRIV_REQUIRES` is a recurring issue — always declare it explicitly (see commit 861a908).
+
+## Python Dependencies
+
+- **Package manager**: `uv` for Python projects (not pip directly)
+- **Lock file**: Committed; use `uv sync` to install
+- **Tool management**: `uv run` for one-off tools, `uv tool install` for persistent tools
+
+## GitHub Actions Dependencies
+
+Updated via Dependabot automatically. Current pinned versions:
+- `actions/checkout@v6`
+- `actions/cache@v5`
+- `actions/setup-python@v6`
+- `actions/upload-artifact@v7`
+- `codecov/codecov-action@v5`
+
+Use SHA pinning for external actions in security-sensitive workflows.

--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/development.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/development.md
@@ -1,0 +1,26 @@
+# Development Workflow
+
+## Build System
+
+- All firmware compilation runs in Docker (`espressif/idf:v5.4`) via `just build`
+- Flash and monitor run natively on the host (macOS USB passthrough is unreliable in containers)
+- Use `just` recipes as the primary interface; run `just --list` to see all available recipes
+
+## Commit Conventions
+
+Use conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `ci:`, `build:`
+
+Scope examples: `(usb_composite)`, `(status_led)`, `(main)`, `(build)`
+
+## ESP-IDF Component Conventions
+
+- Each component lives in `components/<name>/` with its own `CMakeLists.txt` and `idf_component.yml`
+- Public headers go in `components/<name>/include/`
+- Use `PRIV_REQUIRES` for internal dependencies, `REQUIRES` only for public API dependencies
+- Prefix all public functions with the component name (e.g., `usb_composite_*`, `status_led_*`)
+- Static functions for all internal helpers
+
+## Credentials
+
+- Copy `main/credentials.h.example` → `main/credentials.h` (gitignored)
+- Never commit `credentials.h` or any file containing WiFi/API credentials

--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/document-management.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/document-management.md
@@ -1,0 +1,71 @@
+# Document Management
+
+Rules for organizing and managing project documentation.
+
+## Document Types and Locations
+
+| Document Type | Directory | Naming Convention | Purpose |
+|--------------|-----------|-------------------|---------|
+| PRD | `docs/prds/` | `{feature-name}.md` | Product Requirements Documents |
+| ADR | `docs/adrs/` | `{number}-{title}.md` | Architecture Decision Records |
+| PRP | `docs/prps/` | `{feature-name}.md` | Product Requirement Prompts |
+
+### Examples
+
+```
+docs/
+├── prds/
+│   ├── usb-composite.md
+│   ├── wifi-connectivity.md
+│   └── claude-api-integration.md
+├── adrs/
+│   ├── 0001-usb-composite-architecture.md
+│   └── 0002-phased-development-approach.md
+└── prps/
+    ├── cdc-ncm-usb-ethernet.md
+    └── wifi-hotspot-connection.md
+```
+
+## Root Directory Policy
+
+The repository root should contain only standard files (README, CLAUDE.md, CMakeLists.txt, justfile, sdkconfig.defaults, etc.). Move documentation into `docs/`.
+
+## Document Lifecycle
+
+### 1. Detection
+Claude identifies documentation opportunities during conversation:
+- Feature discussions trigger PRD detection
+- Architecture debates trigger ADR detection
+- Implementation planning triggers PRP detection
+
+### 2. Confirmation
+User approves document creation via AskUserQuestion prompt:
+- "Yes, create [document type]" - Proceed with creation
+- "Not now, remind me later" - Defer, re-prompt if topic expands
+- "No, just continue" - Skip documentation
+
+### 3. Generation
+Document created in appropriate location.
+
+### 4. Tracking
+Manifest updated with document metadata; feature-tracker.json updated if FR codes are referenced.
+
+## Automatic Detection
+
+When `has_document_detection` is enabled, Claude will proactively prompt to create:
+
+| Conversation Type | Document Suggested |
+|-------------------|-------------------|
+| Feature requirements discussed | PRD |
+| Architecture decisions debated | ADR |
+| Implementation approach planned | PRP |
+
+## ADR Numbering
+
+ADRs use sequential 4-digit zero-padded prefixes: `0001-title.md`, `0002-title.md`, etc.
+
+## Cross-Referencing
+
+Link related documents using relative paths:
+- PRD → ADR: `See [ADR-0001](../adrs/0001-title.md) for rationale`
+- PRP → PRD: `Implements requirements from [PRD](../prds/feature.md)`

--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/error-handling.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/error-handling.md
@@ -1,0 +1,94 @@
+# Error Handling
+
+**Confidence**: High — derived from recurring fix patterns in git history
+**Source**: commits c871c18, 392897c, fix(auto) series, it-troubleshooter main.c patterns
+
+## Graceful Degradation Over Crash
+
+Optional features (USB enumeration, WiFi connection) should fail gracefully — log a warning, set an error LED state, and continue or return. Do not `ESP_ERROR_CHECK` on optional init paths.
+
+```c
+// Good — graceful degradation
+esp_err_t ret = usb_composite_init();
+if (ret != ESP_OK) {
+    ESP_LOGW(TAG, "USB init failed (%s)", esp_err_to_name(ret));
+    status_led_set_mode(STATUS_LED_ERROR);
+    return;   // return from app_main, not reboot
+}
+
+// Avoid — fatal crash on optional feature
+ESP_ERROR_CHECK(usb_composite_init());
+```
+
+## Timeout-Based Polling (Not Infinite Blocking)
+
+Use bounded polling loops for all wait conditions. Always yield inside the loop.
+
+```c
+// Good — timeout + LED feedback
+int wait_ms = 0;
+while (!usb_composite_is_mounted() && wait_ms < USB_MOUNT_TIMEOUT_MS) {
+    status_led_update();
+    vTaskDelay(pdMS_TO_TICKS(10));
+    wait_ms += 10;
+}
+if (!usb_composite_is_mounted()) {
+    ESP_LOGW(TAG, "USB mount timeout after %d ms", USB_MOUNT_TIMEOUT_MS);
+    status_led_set_mode(STATUS_LED_ERROR);
+    return;
+}
+```
+
+## Mutex + Bounded Timeout
+
+Use short timeouts on mutex takes (never `portMAX_DELAY` for shared state). Log if the mutex cannot be taken.
+
+```c
+// Good — bounded timeout
+if (s_mutex && xSemaphoreTake(s_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    s_shared_state = new_value;
+    xSemaphoreGive(s_mutex);
+} else {
+    ESP_LOGW(TAG, "Failed to take mutex — skipping update");
+}
+```
+
+## Always Log Error Return Values
+
+Every `esp_err_t`-returning function call should have its result logged if it may fail, even if recovery is not possible.
+
+```c
+esp_err_t ret = some_operation();
+if (ret != ESP_OK) {
+    ESP_LOGE(TAG, "Operation failed: %s", esp_err_to_name(ret));
+}
+```
+
+## HID/CDC Per-Operation Readiness Check
+
+Check peripheral readiness before each send; return `ESP_ERR_TIMEOUT` if not ready — let the caller decide recovery.
+
+```c
+int retries = HID_READY_TIMEOUT_MS / HID_READY_POLL_MS;
+while (!tud_hid_ready() && retries-- > 0) {
+    vTaskDelay(pdMS_TO_TICKS(HID_READY_POLL_MS));
+}
+if (!tud_hid_ready()) {
+    ESP_LOGW(TAG, "HID not ready after timeout");
+    return ESP_ERR_TIMEOUT;
+}
+```
+
+## FreeRTOS Timer Handles
+
+Always store timer handles in static variables. Clean up on re-initialization to prevent orphaned timers.
+
+```c
+static TimerHandle_t s_stability_timer = NULL;
+
+if (s_stability_timer != NULL) {
+    xTimerDelete(s_stability_timer, pdMS_TO_TICKS(100));
+    s_stability_timer = NULL;
+}
+s_stability_timer = xTimerCreate(...);
+```

--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/security-practices.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/security-practices.md
@@ -1,0 +1,51 @@
+# Security Practices
+
+**Confidence**: Very High — enforced by pre-commit hooks and gitleaks config
+**Source**: security commit (2025-06-27), .gitleaks.toml, .pre-commit-config.yaml, CI permission hardening commits
+
+## Credential Files
+
+Never commit files containing credentials. Use `.example` templates instead:
+
+```
+credentials.h         ← gitignored (never commit)
+credentials.h.example ← committed (template with placeholder values)
+```
+
+Pre-commit hooks automatically block: `credentials.h`, files ending in `.key`, `.secret`, `.token`.
+
+All credential values go in `credentials.h` (gitignored). Non-sensitive defaults go in `sdkconfig.defaults`.
+
+## Secret Scanning
+
+`gitleaks` runs on every commit via pre-commit. The `.gitleaks.toml` allowlist is deliberately narrow — only two entries:
+1. ESPHome `secrets.yaml` example (dummy values only)
+2. Build artifact sodium source (test vectors)
+
+Do not expand the allowlist without strong justification.
+
+## GitHub Actions Permissions
+
+Apply least privilege: set `permissions: {}` at the top-level workflow (deny all), then grant only what each job needs at the job level.
+
+```yaml
+# Top-level — deny by default
+permissions: {}
+
+jobs:
+  build:
+    permissions:
+      contents: read        # only what this job needs
+      pull-requests: write  # only if creating PR comments
+```
+
+Do not use top-level `permissions: write-all` or `permissions: contents: write` for workflow-level grants.
+
+## API Token Storage
+
+Store API tokens in `~/.api_tokens` (sourced by mise), never in the repository. Reference via environment variables in code and configuration.
+
+```c
+// In credentials.h (gitignored)
+#define CLAUDE_API_KEY "sk-ant-..."
+```

--- a/packages/esp32-projects/it-troubleshooter/.claude/rules/testing.md
+++ b/packages/esp32-projects/it-troubleshooter/.claude/rules/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+## Firmware Testing Approach
+
+This is embedded firmware — standard unit testing is limited. Verification is primarily done via:
+
+1. **Build verification** — `just build` must succeed with zero warnings
+2. **Hardware testing** — Flash to Waveshare ESP32-S3-Zero, observe LED states and USB enumeration
+3. **CDC loopback** — Connect to CDC serial port and verify echo behavior
+4. **HID injection** — Open a text editor on the host, verify typed characters match expected output
+
+## Static Analysis
+
+- `cppcheck` for C code analysis (run via `make lint` at repo root)
+- `clang-format` for formatting (Google style, 4-space indent, 100-char limit)
+
+## Integration Checklist (before PR)
+
+- [ ] `just build` succeeds cleanly
+- [ ] Device enumerates as composite USB (HID + CDC visible in system USB info)
+- [ ] Status LED cycles through BOOT → USB_READY correctly
+- [ ] HID keyboard types demo string correctly
+- [ ] CDC echo works bidirectionally
+- [ ] Monitor output (GPIO43/44 UART) shows no errors or assertion failures

--- a/packages/esp32-projects/it-troubleshooter/.gitignore
+++ b/packages/esp32-projects/it-troubleshooter/.gitignore
@@ -1,0 +1,13 @@
+# ESP-IDF build artifacts
+build/
+sdkconfig
+managed_components/
+
+# Credentials (never commit)
+main/credentials.h
+
+# Blueprint work orders (task-specific, may contain sensitive details)
+docs/blueprint/work-orders/
+
+# macOS
+.DS_Store

--- a/packages/esp32-projects/it-troubleshooter/CLAUDE.md
+++ b/packages/esp32-projects/it-troubleshooter/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**IT Troubleshooter** is a phased ESP32-S3 firmware project that emulates a USB composite device (HID keyboard + CDC serial). The goal is network troubleshooting automation via USB command injection and bidirectional communication.
+
+**Current phase:** Phase 1 PoC — HID keyboard + CDC-ACM serial.
+**Planned:** WiFi connectivity, Claude API integration, CDC-NCM (USB Ethernet).
+
+**Target hardware:** Waveshare ESP32-S3-Zero (ESP32-S3, 4MB flash, 2MB PSRAM, WS2812 RGB on GPIO21).
+
+## Build Commands
+
+Builds run in Docker (`espressif/idf:v5.4`); flash/monitor run natively (USB passthrough on macOS is unreliable).
+
+```bash
+just build        # Compile in Docker
+just flash        # Flash to /dev/cu.usbmodem101 (USB-Serial-JTAG)
+just monitor      # Serial via minicom on GPIO43/44 USB-UART adapter @ 115200
+just deploy       # build + flash
+just menuconfig   # Interactive sdkconfig in Docker
+just clean        # Remove build/, sdkconfig, managed_components (prompts confirm)
+```
+
+Override USB port: `just flash PORT=/dev/ttyUSB0`
+
+**Credentials setup:**
+```bash
+cp main/credentials.h.example main/credentials.h
+# Edit with WiFi SSID, password, Claude API key (gitignored)
+```
+
+## Architecture
+
+### Initialization sequence (`main/main.c`)
+
+1. NVS flash init
+2. `status_led_init()` → set BOOT mode
+3. `usb_composite_init()` → TinyUSB HID keyboard + CDC
+4. Poll `usb_composite_is_mounted()` (30s timeout)
+5. Type demo string via HID keyboard
+6. Spawn CDC echo task on core 1
+
+**Core assignment:** Core 0 — USB stack (TinyUSB interrupts). Core 1 — application tasks (CDC echo, future work).
+
+### Component: `usb_composite`
+
+TinyUSB composite device with two functional interfaces:
+
+- **HID Boot Keyboard** (interface 0, endpoint 0x81): 8-byte boot protocol report, BIOS-compatible
+- **CDC-ACM** (interfaces 1–2, endpoints 0x82/0x03/0x83): standard serial over USB
+
+Key API: `usb_keyboard_type_string()`, `usb_keyboard_press_with_modifier()`, `usb_cdc_write()`, `usb_cdc_read()`.
+
+ASCII → HID keycode mapping covers full US QWERTY including shifted characters. Timing: 20ms key hold, 10ms between chars.
+
+### Component: `status_led`
+
+WS2812 RMT driver (no background task — caller must invoke `status_led_update()` periodically at ≥50Hz).
+
+| Mode | Color/Pattern | Meaning |
+|------|--------------|---------|
+| `BOOT` | Blue blink 250ms | Initializing |
+| `USB_READY` | Cyan solid | USB mounted |
+| `BIOS_MODE` | Yellow blink 250ms | Injecting keystrokes |
+| `WIFI_CONNECTING` | Blue pulse 1000ms | WiFi connecting |
+| `DIAGNOSTIC` | Green pulse 1000ms | Running diagnostics |
+| `ERROR` | Red solid | Failure |
+| `COMPLETE` | Green solid | Success |
+
+## Hardware Constraints
+
+**USB PHY sharing (critical):** USB-Serial-JTAG and USB-OTG share a single internal PHY on ESP32-S3. Once `tinyusb_driver_install()` is called, JTAG disconnects entirely — `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG` does **not** redirect ESP_LOG.
+
+**Only reliable monitoring:** USB-UART adapter on GPIO43 (TX) / GPIO44 (RX) at 115200 baud.
+
+**RMT + TinyUSB DMA conflict:** `with_dma = true` on the RMT channel breaks after TinyUSB init. Status LED uses `with_dma = false` + `mem_block_symbols = 48`.
+
+**TinyUSB `tinyusb_config_t` (esp_tinyusb v2.x):** The `.task` field (`size`, `priority`, `xCoreID`) must be non-zero or `tinyusb_driver_install()` returns `ESP_ERR_INVALID_ARG`.
+
+## Dependencies
+
+- `espressif/esp_tinyusb` ^1.0.0 — USB device stack
+- `espressif/led_strip` ≥2.0.0 — WS2812 RMT driver
+- ESP-IDF core: `nvs_flash`, `driver`, `esp_timer`, `freertos`

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0001-esp32s3-mcu-selection.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0001-esp32s3-mcu-selection.md
@@ -1,0 +1,36 @@
+# ADR-0001: ESP32-S3 MCU Selection
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 9/10
+
+## Context
+
+The IT Troubleshooter requires a microcontroller capable of emulating a USB HID keyboard and, in later phases, a USB CDC-NCM Ethernet adapter. Initial considerations included the ESP32-C6 (lower cost, newer) and the ESP32-S3.
+
+## Decision
+
+Use the **Waveshare ESP32-S3-Zero** (ESP32-S3, 4MB flash, 2MB PSRAM).
+
+## Rationale
+
+| Feature | ESP32-C6 | ESP32-S3 |
+|---------|----------|----------|
+| USB OTG (device mode) | No — USB-Serial-JTAG only | Yes — full USB 2.0 OTG |
+| HID keyboard emulation | Not possible | Supported via TinyUSB |
+| CDC-NCM (Phase 4) | Not possible | Supported via TinyUSB |
+| Dual core | No | Yes (240 MHz ×2) |
+| PSRAM | No | 2 MB (SPI) |
+
+The ESP32-C6 was rejected because it only has USB-Serial-JTAG (JTAG-over-USB), which cannot act as a USB device class (HID, CDC, etc.) visible to the host OS as a keyboard or network adapter.
+
+## Evidence
+
+- Commit `e1c2a7f`: feat(it-troubleshooter): add Phase 1 USB composite PoC — uses `CONFIG_IDF_TARGET=esp32s3`
+- `sdkconfig.defaults`: `CONFIG_TINYUSB_ENABLED=y`, `CONFIG_SPIRAM=y`
+
+## Consequences
+
+- Debugging requires a separate USB-UART adapter (GPIO43/44) because USB-Serial-JTAG shares the PHY with USB-OTG (see ADR-0006)
+- PSRAM available for future buffering of SSH session output or Claude API payloads
+- Dual core enables USB stack isolation on core 0 (see ADR-0007)

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0002-hid-boot-protocol-keyboard.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0002-hid-boot-protocol-keyboard.md
@@ -1,0 +1,38 @@
+# ADR-0002: HID Boot Protocol Keyboard
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 9/10
+
+## Context
+
+USB HID keyboards can use either a full HID report descriptor (flexible, arbitrary key mappings) or the simpler HID boot protocol (fixed 8-byte report, subclass=1, protocol=1). The IT Troubleshooter must work in BIOS/UEFI environments where no HID drivers are loaded.
+
+## Decision
+
+Implement the keyboard as **HID boot protocol** (bInterfaceSubClass=0x01, bInterfaceProtocol=0x01).
+
+## Rationale
+
+BIOS and UEFI firmware implements a simplified USB keyboard driver that only understands boot protocol. A standard HID keyboard with a complex report descriptor may not be recognized at the BIOS level, which would defeat the primary use case of BIOS access and pre-OS interaction.
+
+Boot protocol uses a fixed 8-byte report:
+```
+Byte 0: Modifier keys (Ctrl, Shift, Alt, GUI)
+Byte 1: Reserved (0x00)
+Bytes 2–7: Up to 6 simultaneous keycodes
+```
+
+This is sufficient for all keyboard input needed (full ASCII + modifier combos).
+
+## Evidence
+
+- `components/usb_composite/usb_composite.c`: `bInterfaceSubClass = 0x01` (Boot Interface), `bInterfaceProtocol = 0x01` (Keyboard)
+- HID report descriptor uses standard boot keyboard format (modifiers + 6 keycodes + 5 LED bits output)
+
+## Consequences
+
+- Works in BIOS/UEFI without drivers
+- Compatible with all modern OS keyboard drivers (they accept boot protocol keyboards)
+- Limited to 6 simultaneous keys — sufficient for normal typing
+- LED output report (Num Lock, Caps Lock, Scroll Lock) is received and acknowledged but not acted upon

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0003-cdc-acm-to-ncm-phased.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0003-cdc-acm-to-ncm-phased.md
@@ -1,0 +1,40 @@
+# ADR-0003: CDC-ACM in Phase 1, CDC-NCM in Phase 4
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 8/10
+
+## Context
+
+For operator communication with the device, two USB serial class options exist:
+- **CDC-ACM** (Abstract Control Model): Virtual serial port, widely supported, simple
+- **CDC-NCM** (Network Control Model): USB Ethernet adapter, full TCP/IP stack, enables HTTP/SSH without HID injection
+
+The device will eventually need full networking (Phase 4), but starting with networking adds significant complexity.
+
+## Decision
+
+Use **CDC-ACM** in Phase 1 (simple serial PoC), migrate to **CDC-NCM** in Phase 4 (USB Ethernet + WiFi bridge).
+
+## Rationale
+
+CDC-ACM is trivial to implement with TinyUSB's built-in CDC class support. CDC-NCM requires:
+- Custom composite USB descriptor (no official ESP-IDF HID+NCM example exists)
+- lwIP TCP/IP integration
+- DHCP server for host IP assignment
+- WiFi-to-USB NAT/bridge routing
+
+Deferring NCM to Phase 4 allows Phase 1 to validate USB enumeration, HID injection, and the composite descriptor structure without network complexity.
+
+## Evidence
+
+- `credentials.h.example`: Comment explicitly documents Phase 1 (CDC-ACM) → Phase 4 (CDC-NCM) transition
+- `components/usb_composite/usb_composite.c`: CDC-ACM implementation with single CDC instance
+- `sdkconfig.defaults`: `CONFIG_TINYUSB_CDC_ENABLED=y`, `CONFIG_TINYUSB_CDC_COUNT=1`
+
+## Consequences
+
+- Phase 1–3: Operator communicates via CDC serial terminal (minicom, screen, etc.)
+- Phase 4: Requires significant refactor of composite descriptor and addition of TCP/IP stack
+- HID keyboard interface must be retained alongside NCM in Phase 4 (for BIOS access)
+- Phase 4 NCM enables: SSH to managed hosts, HTTP self-bootstrap server, standard tools without HID injection

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0004-caller-driven-status-led.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0004-caller-driven-status-led.md
@@ -1,0 +1,39 @@
+# ADR-0004: Caller-Driven Status LED (No Background Task)
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 8/10
+
+## Context
+
+The WS2812 RGB LED (GPIO21) needs periodic refresh for blink/pulse animations. This can be implemented as:
+1. A dedicated FreeRTOS task polling a shared state variable
+2. A caller-driven update function invoked from existing application loops
+
+## Decision
+
+Implement the LED as **caller-driven**: `status_led_update()` must be called periodically (≥50 Hz) from the application's existing loop. No background task is created.
+
+## Rationale
+
+This pattern was refined from the xbox-switch-bridge project, which initially had a dedicated LED task but dropped it after discovering that `bp32_host_start()` (BTstack) starved other core 0 tasks.
+
+For the IT Troubleshooter, the USB stack runs on core 0 via TinyUSB's internal task. Adding a separate LED task on core 0 risks scheduling contention. The application loop on core 1 is a natural call site.
+
+Benefits:
+- Zero additional task overhead
+- No inter-task synchronization for LED state (volatile atomic store + single writer)
+- Application controls LED update rate implicitly through its own loop frequency
+- Easier to integrate into future WiFi/Claude API loops (just add `status_led_update()` call)
+
+## Evidence
+
+- `components/status_led/status_led.c`: No task creation; `status_led_update()` reads volatile mode and calls `esp_timer_get_time()` for blink timing
+- `main/main.c`: CDC echo task on core 1 calls `status_led_update()` in its loop
+- `sdkconfig.defaults`: `CONFIG_FREERTOS_HZ=1000` (1ms tick resolution supports accurate blink timing)
+
+## Consequences
+
+- Callers must invoke `status_led_update()` frequently enough (≥50 Hz) for smooth blink rendering
+- If the application task blocks (e.g., waiting for WiFi), LED may appear frozen — caller responsible for non-blocking design
+- LED state changes (`status_led_set_mode()`) are non-blocking volatile stores; safe to call from any context

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0005-rmt-dma-disabled.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0005-rmt-dma-disabled.md
@@ -1,0 +1,34 @@
+# ADR-0005: RMT DMA Disabled for WS2812 Driver
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 9/10
+
+## Context
+
+The ESP-IDF `led_strip` component drives WS2812 LEDs via RMT (Remote Control peripheral). On ESP32-S3, RMT can optionally use DMA for zero-copy transfers. TinyUSB also uses DMA for USB endpoint transfers. Both sharing DMA resources causes a conflict.
+
+## Decision
+
+Configure the LED strip driver with **DMA disabled**: `with_dma = false`, `mem_block_symbols = 48`.
+
+## Rationale
+
+Symptom observed in the xbox-switch-bridge project (same hardware): with `with_dma = true`, the RMT channel malfunctions after `tinyusb_driver_install()` is called — the LED output becomes corrupted or stops entirely. Root cause is DMA resource contention between TinyUSB's USB endpoint DMA and RMT DMA on ESP32-S3.
+
+With `with_dma = false`, RMT uses its internal memory buffer instead of DMA. For a single WS2812 LED (24 bits = 48 RMT symbols), this is fully within the ESP32-S3's RMT memory capacity.
+
+`mem_block_symbols = 48` is ESP32-S3 specific — generic ESP32-S3 boards use 64, but the Waveshare ESP32-S3-Zero requires 48 due to its memory block configuration.
+
+## Evidence
+
+- `components/status_led/status_led.c`: `strip_config.with_dma = false` and `rmt_config.mem_block_symbols = 48`
+- Pattern confirmed by xbox-switch-bridge project (`../xbox-switch-bridge/components/status_led/`)
+- Same hardware (Waveshare ESP32-S3-Zero), same constraint
+
+## Consequences
+
+- No DMA overhead for RMT — CPU handles RMT transfers (negligible for 1 LED)
+- RMT and TinyUSB coexist without conflict
+- `mem_block_symbols = 48` must be preserved if LED count is increased (verify capacity)
+- If adding more WS2812 LEDs (e.g., a strip), revisit DMA isolation strategy

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0006-external-uart-debug.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0006-external-uart-debug.md
@@ -1,0 +1,37 @@
+# ADR-0006: External USB-UART Adapter for Debug Monitoring
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 10/10
+
+## Context
+
+ESP32-S3 has a built-in USB-Serial-JTAG peripheral that normally provides log output and a JTAG interface via the on-chip USB-C connector. However, the ESP32-S3 has a single internal USB PHY shared between USB-Serial-JTAG and USB-OTG.
+
+## Decision
+
+Use an **external USB-UART adapter** connected to GPIO43 (TX) / GPIO44 (RX) at 115200 baud for all debug monitoring.
+
+## Rationale
+
+Once `tinyusb_driver_install()` is called, the USB-OTG peripheral claims the shared PHY. USB-Serial-JTAG disconnects from the USB bus entirely — it is no longer visible as a USB device on the host.
+
+Mitigations that do NOT work:
+- `CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y` — does not redirect ESP_LOG output after TinyUSB takes the PHY
+- `usb_serial_jtag_driver_install()` + `esp_log_set_vprintf()` — fails after TinyUSB init
+- Redirecting console to USB-Serial-JTAG before TinyUSB — logs stop when TinyUSB initializes
+
+The only reliable solution is a hardware UART on separate pins, connected to an external USB-UART adapter.
+
+## Evidence
+
+- `justfile`: `monitor` recipe uses `minicom -b 115200 -D /dev/cu.usbserial-*` (external UART adapter)
+- `sdkconfig.defaults`: UART0 console remains enabled (default GPIO43/44 on ESP32-S3)
+- Pattern confirmed identically in xbox-switch-bridge project
+
+## Consequences
+
+- Monitoring requires a USB-UART adapter (CH340, CP2102, FT232, etc.) connected to GPIO43/44
+- USB-C connector on the device is exclusively for the composite USB device (keyboard + CDC)
+- Development workflow: two USB connections — one for the device function, one for debug monitoring
+- JTAG debugging is unavailable while TinyUSB is running (same PHY constraint)

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0007-core-assignment-strategy.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0007-core-assignment-strategy.md
@@ -1,0 +1,35 @@
+# ADR-0007: Core Assignment Strategy
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 8/10
+
+## Context
+
+ESP32-S3 has two cores (core 0 = PRO_CPU, core 1 = APP_CPU). TinyUSB creates an internal task. Application tasks can run on either core. The choice affects USB timing reliability and application responsiveness.
+
+## Decision
+
+- **Core 0**: TinyUSB internal task (USB stack, interrupt handling)
+- **Core 1**: Application tasks (CDC echo, future WiFi, Claude API, command execution)
+
+TinyUSB task config: `{ .size = 4096, .priority = 5, .xCoreID = 0 }`
+
+## Rationale
+
+USB interrupt handling is time-sensitive — jitter can cause enumeration failures or missed HID reports. Pinning TinyUSB to core 0 gives it a dedicated core with predictable scheduling.
+
+Application work (WiFi, API calls, HID injection, CDC processing) runs on core 1 without competing with the USB stack. This mirrors the proven pattern from xbox-switch-bridge where BTstack was pinned to core 0 and the bridge task ran on core 1.
+
+## Evidence
+
+- `components/usb_composite/usb_composite.c`: `tinyusb_config_t.task = { .xCoreID = 0 }`
+- `main/main.c`: `xTaskCreatePinnedToCore(..., 1)` for CDC echo task (core 1)
+- TinyUSB requires non-zero `.task.size` and `.task.priority` — zero values return `ESP_ERR_INVALID_ARG`
+
+## Consequences
+
+- USB timing is isolated from application blocking operations (WiFi, HTTP, UART)
+- Future tasks should default to core 1 unless they have USB-level timing requirements
+- If WiFi is added, `esp_wifi_set_ps(WIFI_PS_NONE)` should be set for minimum latency
+- Core 0 must not be overloaded with high-frequency application tasks

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/0008-phased-delivery.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/0008-phased-delivery.md
@@ -1,0 +1,42 @@
+# ADR-0008: Phased Delivery Approach
+
+**Status**: Accepted
+**Date**: 2026-03-09
+**Confidence**: 9/10
+
+## Context
+
+The full IT Troubleshooter vision (USB keyboard + Ethernet + WiFi + AI) is complex to develop and validate in one shot. Intermediate validation reduces risk.
+
+## Decision
+
+Deliver the project in four distinct phases, each providing a standalone working device:
+
+| Phase | Deliverable | USB Interface |
+|-------|-------------|---------------|
+| 1 | HID keyboard + CDC-ACM PoC | HID + CDC-ACM |
+| 2 | WiFi + command execution via HID injection | HID + CDC-ACM |
+| 3 | Claude API AI-driven troubleshooting | HID + CDC-ACM |
+| 4 | CDC-NCM USB Ethernet + WiFi bridge | HID + CDC-NCM |
+
+## Rationale
+
+Each phase validates a critical subsystem before adding the next:
+
+1. **Phase 1** validates: USB composite enumeration, HID boot keyboard compatibility, CDC-ACM bidirectional communication
+2. **Phase 2** validates: WiFi stack coexistence with USB, NVS state persistence, HID injection for real workflows
+3. **Phase 3** validates: Claude API integration, AI decision loop, output capture via CDC or HID
+4. **Phase 4** validates: CDC-NCM Ethernet, DHCP server, WiFi bridge — highest complexity, builds on proven USB foundation
+
+## Evidence
+
+- Commit `e1c2a7f`: "feat(it-troubleshooter): add Phase 1 USB composite PoC" — explicitly Phase 1
+- `credentials.h.example`: Contains `WIFI_SSID`, `WIFI_PASS`, `CLAUDE_API_KEY` fields with comments noting Phase 1→4 progression
+- `main/main.c`: NVS flash initialized in Phase 1 even though not yet used — preparing for Phase 2 state machine
+
+## Consequences
+
+- Phase 1 code is intentionally minimal — avoid over-engineering for future phases
+- Each phase merges as a standalone PR with working firmware
+- Phase 4 requires the largest refactor (composite descriptor, lwIP, DHCP server) — timeline uncertain
+- NVS is initialized from Phase 1 to avoid structural changes later

--- a/packages/esp32-projects/it-troubleshooter/docs/adrs/README.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/adrs/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the IT Troubleshooter project.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [0001](0001-esp32s3-mcu-selection.md) | ESP32-S3 MCU Selection | Accepted | 2026-03-09 |
+| [0002](0002-hid-boot-protocol-keyboard.md) | HID Boot Protocol Keyboard | Accepted | 2026-03-09 |
+| [0003](0003-cdc-acm-to-ncm-phased.md) | CDC-ACM in Phase 1, CDC-NCM in Phase 4 | Accepted | 2026-03-09 |
+| [0004](0004-caller-driven-status-led.md) | Caller-Driven Status LED (No Background Task) | Accepted | 2026-03-09 |
+| [0005](0005-rmt-dma-disabled.md) | RMT DMA Disabled for WS2812 Driver | Accepted | 2026-03-09 |
+| [0006](0006-external-uart-debug.md) | External USB-UART Adapter for Debug Monitoring | Accepted | 2026-03-09 |
+| [0007](0007-core-assignment-strategy.md) | Core Assignment Strategy | Accepted | 2026-03-09 |
+| [0008](0008-phased-delivery.md) | Phased Delivery Approach | Accepted | 2026-03-09 |
+
+## Creating New ADRs
+
+Name new ADRs: `{NNNN}-{kebab-case-title}.md`
+
+Find next number:
+```bash
+ls docs/adrs/ | grep -E '^[0-9]{4}-' | sort -r | head -1 | cut -d'-' -f1
+```
+
+## ADR Status Values
+
+- **Proposed** — Under discussion
+- **Accepted** — Decision made and implemented
+- **Deprecated** — No longer applies
+- **Superseded** — Replaced by a later ADR (link to successor)

--- a/packages/esp32-projects/it-troubleshooter/docs/blueprint/README.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/blueprint/README.md
@@ -1,0 +1,57 @@
+# Blueprint
+
+This directory contains [Blueprint Development](https://github.com/laurigates/claude-plugins/tree/main/blueprint-plugin) system state for this project.
+
+## What is Blueprint?
+
+Blueprint Development is a structured, documentation-first methodology for AI-assisted development. It provides:
+
+- **PRDs** (`docs/prds/`) - Product Requirements Documents
+- **ADRs** (`docs/adrs/`) - Architecture Decision Records
+- **PRPs** (`docs/prps/`) - Product Requirement Prompts (implementation-ready task definitions)
+
+## Directory Structure
+
+```
+docs/blueprint/
+├── README.md            # This file
+├── manifest.json        # Version tracking, project configuration
+├── feature-tracker.json # FR code tracking and progress
+├── work-orders/         # Task packages for subagent execution
+│   ├── completed/
+│   └── archived/
+└── ai_docs/             # Curated documentation for AI context
+    ├── libraries/       # External library docs
+    └── project/         # Project-specific patterns
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `manifest.json` | Tracks blueprint version, enabled features, and generated content metadata |
+| `feature-tracker.json` | Maps requirement codes (FR1, FR1.1) to implementation status, tracks current phase and tasks |
+
+## Related Locations
+
+| Location | Content |
+|----------|---------|
+| `docs/prds/` | Product Requirements Documents |
+| `docs/adrs/` | Architecture Decision Records |
+| `docs/prps/` | Product Requirement Prompts |
+| `.claude/rules/` | Behavior rules (manual and generated from PRDs) |
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/blueprint:status` | Show version and configuration |
+| `/blueprint:derive-prd` | Derive PRD from existing documentation |
+| `/blueprint:derive-adr` | Derive ADRs from codebase analysis |
+| `/blueprint:derive-plans` | Derive docs from git history |
+| `/blueprint:derive-rules` | Derive rules from git commit decisions |
+| `/blueprint:prp-create` | Create a Product Requirement Prompt |
+| `/blueprint:generate-rules` | Generate rules from PRDs |
+| `/blueprint:sync` | Check for stale generated content |
+| `/blueprint:feature-tracker-status` | View feature completion stats |
+| `/blueprint:feature-tracker-sync` | Sync tracker with project files |

--- a/packages/esp32-projects/it-troubleshooter/docs/blueprint/feature-tracker.json
+++ b/packages/esp32-projects/it-troubleshooter/docs/blueprint/feature-tracker.json
@@ -1,0 +1,74 @@
+{
+  "version": "1.0.0",
+  "updated_at": "2026-03-10T00:00:00.000Z",
+  "source_document": null,
+  "phases": {
+    "phase-1": {
+      "name": "USB Composite PoC",
+      "description": "HID keyboard + CDC-ACM serial proof of concept",
+      "status": "in_progress",
+      "requirements": {
+        "FR1": {
+          "id": "FR1",
+          "title": "USB HID Boot Keyboard",
+          "description": "Emulate a USB HID boot protocol keyboard recognized by BIOS and OS",
+          "status": "completed",
+          "implemented_in": ["components/usb_composite/usb_composite.c"]
+        },
+        "FR2": {
+          "id": "FR2",
+          "title": "USB CDC-ACM Serial",
+          "description": "Expose a CDC-ACM serial port for bidirectional communication with host",
+          "status": "completed",
+          "implemented_in": ["components/usb_composite/usb_composite.c"]
+        },
+        "FR3": {
+          "id": "FR3",
+          "title": "ASCII String Injection",
+          "description": "Type arbitrary ASCII strings via HID keyboard with correct US QWERTY keycodes",
+          "status": "completed",
+          "implemented_in": ["components/usb_composite/usb_composite.c"]
+        },
+        "FR4": {
+          "id": "FR4",
+          "title": "CDC Echo Demo",
+          "description": "Echo received CDC data back to host as basic bidirectional verification",
+          "status": "completed",
+          "implemented_in": ["main/main.c"]
+        },
+        "FR5": {
+          "id": "FR5",
+          "title": "Visual Status LED",
+          "description": "WS2812 RGB LED indicating device state (boot, USB ready, BIOS mode, error, etc.)",
+          "status": "completed",
+          "implemented_in": ["components/status_led/status_led.c"]
+        }
+      }
+    },
+    "phase-2": {
+      "name": "WiFi + Command Execution",
+      "description": "Connect to hotspot and execute diagnostic commands",
+      "status": "planned",
+      "requirements": {}
+    },
+    "phase-3": {
+      "name": "Claude API Integration",
+      "description": "AI-driven troubleshooting via Claude API",
+      "status": "planned",
+      "requirements": {}
+    },
+    "phase-4": {
+      "name": "CDC-NCM USB Ethernet",
+      "description": "Replace CDC-ACM with CDC-NCM for USB Ethernet networking",
+      "status": "planned",
+      "requirements": {}
+    }
+  },
+  "summary": {
+    "total": 5,
+    "completed": 5,
+    "in_progress": 0,
+    "planned": 0,
+    "blocked": 0
+  }
+}

--- a/packages/esp32-projects/it-troubleshooter/docs/blueprint/manifest.json
+++ b/packages/esp32-projects/it-troubleshooter/docs/blueprint/manifest.json
@@ -1,0 +1,154 @@
+{
+  "format_version": "3.2.0",
+  "created_at": "2026-03-10T00:00:00.000Z",
+  "updated_at": "2026-03-10T12:00:00.000Z",
+  "created_by": {
+    "blueprint_plugin": "3.24.0"
+  },
+  "project": {
+    "name": "it-troubleshooter",
+    "detected_stack": ["c", "esp-idf", "esp32s3", "tinyusb", "freertos"]
+  },
+  "structure": {
+    "has_prds": true,
+    "has_adrs": true,
+    "has_prps": true,
+    "has_work_orders": true,
+    "has_ai_docs": false,
+    "has_modular_rules": true,
+    "has_feature_tracker": true,
+    "has_document_detection": true,
+    "claude_md_mode": "both"
+  },
+  "feature_tracker": {
+    "file": "feature-tracker.json",
+    "source_document": null,
+    "sync_targets": []
+  },
+  "generated": {
+    "rules": {
+      "code-style.md": {
+        "generated_at": "2026-03-10T12:00:00.000Z",
+        "source": "git-derive-rules",
+        "confidence": "very-high"
+      },
+      "error-handling.md": {
+        "generated_at": "2026-03-10T12:00:00.000Z",
+        "source": "git-derive-rules",
+        "confidence": "high"
+      },
+      "security-practices.md": {
+        "generated_at": "2026-03-10T12:00:00.000Z",
+        "source": "git-derive-rules",
+        "confidence": "very-high"
+      },
+      "dependencies.md": {
+        "generated_at": "2026-03-10T12:00:00.000Z",
+        "source": "git-derive-rules",
+        "confidence": "high"
+      }
+    },
+    "commands": {}
+  },
+  "custom_overrides": {
+    "skills": [],
+    "commands": []
+  },
+  "task_registry": {
+    "derive-prd": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {},
+      "context": {}
+    },
+    "derive-plans": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": "2026-03-10T12:00:00.000Z",
+      "last_result": "success",
+      "schedule": "weekly",
+      "stats": {
+        "runs_total": 1,
+        "items_processed": 89,
+        "items_created": 12
+      },
+      "context": {
+        "commits_analyzed_up_to": "e1c2a7f",
+        "commits_analyzed_count": 89
+      }
+    },
+    "derive-rules": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": "2026-03-10T12:00:00.000Z",
+      "last_result": "success",
+      "schedule": "weekly",
+      "stats": {
+        "runs_total": 1,
+        "items_processed": 89,
+        "items_created": 4
+      },
+      "context": {
+        "commits_analyzed_up_to": "e1c2a7f",
+        "commits_analyzed_count": 89
+      }
+    },
+    "generate-rules": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {},
+      "context": {}
+    },
+    "adr-validate": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "weekly",
+      "stats": {},
+      "context": {}
+    },
+    "feature-tracker-sync": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "daily",
+      "stats": {},
+      "context": {}
+    },
+    "sync-ids": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {},
+      "context": {}
+    },
+    "claude-md": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {},
+      "context": {}
+    },
+    "curate-docs": {
+      "enabled": false,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {},
+      "context": {}
+    }
+  }
+}

--- a/packages/esp32-projects/it-troubleshooter/docs/prds/it-troubleshooter.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/prds/it-troubleshooter.md
@@ -1,0 +1,108 @@
+# IT Troubleshooter — Product Requirements Document
+
+**Status**: Phase 1 Complete / Phase 2 Planned
+**Last Updated**: 2026-03-10
+**Confidence**: 8/10 (derived from git history and source code analysis)
+
+## Overview
+
+IT Troubleshooter is a portable USB device built on the Waveshare ESP32-S3-Zero that plugs into any computer and emulates keyboard and network hardware. The primary use case is remote IT support and network troubleshooting — the device can type commands into BIOS or OS terminals, access systems over SSH, and run diagnostics without requiring pre-installed software on the target machine.
+
+## Target Users
+
+- IT administrators performing remote/physical troubleshooting
+- Network engineers needing out-of-band device access
+- Developers wanting a self-contained USB automation tool
+
+## Architecture
+
+The device uses a phased delivery approach, starting with a simple USB composite PoC and graduating toward a full AI-driven troubleshooting agent.
+
+```
+[Target Computer] ←── USB-C ───→ [ESP32-S3-Zero]
+                                        │
+                              ┌─────────┴──────────┐
+                              │   HID Keyboard      │  (Phase 1+)
+                              │   CDC-ACM Serial    │  (Phase 1)
+                              │   CDC-NCM Ethernet  │  (Phase 4)
+                              └─────────┬──────────┘
+                                        │
+                              ┌─────────┴──────────┐
+                              │   WiFi Hotspot      │  (Phase 2+)
+                              │   Claude API        │  (Phase 3+)
+                              └────────────────────┘
+```
+
+## Phases
+
+### Phase 1 — USB Composite PoC (Complete)
+
+**Goal**: Prove ESP32-S3 can enumerate as a simultaneous HID keyboard and CDC-ACM serial device.
+
+| FR Code | Requirement | Status |
+|---------|-------------|--------|
+| FR1 | USB HID boot-protocol keyboard recognized by BIOS and OS without drivers | Completed |
+| FR2 | USB CDC-ACM serial port for bidirectional communication with host | Completed |
+| FR3 | Type arbitrary ASCII strings via HID with correct US QWERTY keycodes | Completed |
+| FR4 | CDC echo demo to verify bidirectional serial communication | Completed |
+| FR5 | WS2812 RGB status LED indicating device state | Completed |
+
+**Hardware**: Waveshare ESP32-S3-Zero (4MB flash, 2MB PSRAM, GPIO21 WS2812)
+
+### Phase 2 — WiFi + Command Execution (Planned)
+
+**Goal**: Connect to a mobile hotspot and execute diagnostic commands on target hosts via SSH.
+
+| FR Code | Requirement | Status |
+|---------|-------------|--------|
+| FR2.1 | Connect to pre-configured WiFi hotspot on device boot | Planned |
+| FR2.2 | Accept SSH or command input via CDC serial from operator | Planned |
+| FR2.3 | Inject commands into target via HID keyboard | Planned |
+| FR2.4 | NVS-persisted state machine for multi-step workflows across power cycles | Planned |
+| FR2.5 | Visual LED feedback during WiFi connection and command execution phases | Planned |
+
+### Phase 3 — Claude API Integration (Planned)
+
+**Goal**: AI-driven troubleshooting; Claude analyzes output and decides next actions.
+
+| FR Code | Requirement | Status |
+|---------|-------------|--------|
+| FR3.1 | Capture command output via CDC serial or USB HID | Planned |
+| FR3.2 | Forward output to Claude API for analysis | Planned |
+| FR3.3 | Execute Claude-suggested commands via HID injection | Planned |
+| FR3.4 | Configurable API key and model via `credentials.h` | Planned |
+
+### Phase 4 — CDC-NCM USB Ethernet (Planned)
+
+**Goal**: Replace CDC-ACM with CDC-NCM for full TCP/IP over USB — enabling HTTP, SSH, and DHCP without HID injection.
+
+| FR Code | Requirement | Status |
+|---------|-------------|--------|
+| FR4.1 | CDC-NCM USB Ethernet interface visible to host OS as network adapter | Planned |
+| FR4.2 | DHCP server assigning IP to host | Planned |
+| FR4.3 | WiFi-to-USB bridge routing host traffic through device's WiFi connection | Planned |
+| FR4.4 | HTTP server hosting self-bootstrapping agent script | Planned |
+| FR4.5 | Retain HID keyboard interface for BIOS-level access | Planned |
+
+## Non-Functional Requirements
+
+| Requirement | Target |
+|-------------|--------|
+| USB enumeration time | < 5 seconds |
+| Time to first keystroke after mount | < 200 ms (Phase 2+) |
+| HID inter-character delay | 10 ms (reliable for most OS keyboard handlers) |
+| Boot-to-WiFi ready | < 15 seconds |
+| Flash footprint | < 3.5 MB (within 4 MB flash with OTA headroom) |
+
+## Technical Decisions
+
+See ADRs for rationale behind key decisions:
+
+- [ADR-0001: ESP32-S3 MCU Selection](../adrs/0001-esp32s3-mcu-selection.md)
+- [ADR-0002: HID Boot Protocol Keyboard](../adrs/0002-hid-boot-protocol-keyboard.md)
+- [ADR-0003: CDC-ACM to CDC-NCM Phased Approach](../adrs/0003-cdc-acm-to-ncm-phased.md)
+- [ADR-0004: Caller-Driven Status LED](../adrs/0004-caller-driven-status-led.md)
+- [ADR-0005: RMT DMA Disabled](../adrs/0005-rmt-dma-disabled.md)
+- [ADR-0006: External UART for Debug Monitoring](../adrs/0006-external-uart-debug.md)
+- [ADR-0007: Core Assignment Strategy](../adrs/0007-core-assignment-strategy.md)
+- [ADR-0008: Phased Delivery Approach](../adrs/0008-phased-delivery.md)

--- a/packages/esp32-projects/it-troubleshooter/docs/prps/cdc-ncm-usb-ethernet.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/prps/cdc-ncm-usb-ethernet.md
@@ -1,0 +1,90 @@
+# PRP: CDC-NCM USB Ethernet (Phase 4)
+
+**Source**: [IT Troubleshooter PRD — Phase 4](../prds/it-troubleshooter.md#phase-4--cdc-ncm-usb-ethernet-planned)
+**Confidence**: 6/10
+**Status**: Planned
+
+## Goal
+
+Replace the CDC-ACM serial interface with CDC-NCM (USB Ethernet), enabling the device to bridge WiFi to USB and present itself as a network adapter to the host. This eliminates the need for HID keyboard injection for most workflows, while retaining HID for BIOS-level access.
+
+## Requirements
+
+From PRD Phase 4:
+- FR4.1: CDC-NCM USB Ethernet interface visible to host OS as network adapter
+- FR4.2: DHCP server assigning IP to host
+- FR4.3: WiFi-to-USB bridge routing host traffic through device's WiFi
+- FR4.4: HTTP server hosting self-bootstrapping agent script
+- FR4.5: Retain HID keyboard interface alongside NCM
+
+## Design Notes
+
+### Composite Descriptor Refactor
+
+Phase 1–3 use: `HID (if=0) + CDC-ACM (if=1,2)` — 3 interfaces total.
+
+Phase 4 replaces with: `HID (if=0) + CDC-NCM (if=1,2)` — CDC-NCM also uses 2 interfaces (Control + Data).
+
+No official ESP-IDF example exists for HID + CDC-NCM composite. The `usb_composite` component descriptor must be fully rewritten. Key references:
+- TinyUSB `examples/device/cdc_msc_hid` for composite patterns
+- USB CDC-NCM spec (USB IF)
+- lwIP netif integration via `esp_netif`
+
+### Network Stack
+
+```
+[Host OS] ←── USB NCM ───→ [ESP32 NCM netif] ←──→ [esp_netif WiFi STA]
+                                   │
+                            NAT/bridge routing
+                            DHCP server (192.168.7.1/24)
+                            HTTP server (:80)
+```
+
+- `esp_netif` for both STA (WiFi) and USB NCM interfaces
+- lwIP for IP stack, DHCP server, NAT
+- `esp_http_server` for bootstrap HTTP server
+
+### Bootstrap HTTP Server
+
+Serve a script at `http://192.168.7.1/bootstrap` that:
+1. Installs an SSH key for passwordless access
+2. Configures SSH reverse tunnel back to operator's machine
+3. Runs initial diagnostic commands
+
+### HID Retention
+
+HID keyboard interface must remain functional in Phase 4 for:
+- BIOS/UEFI access (before OS loads, NCM not available)
+- Typing credentials on login screens
+- Emergency recovery when network path fails
+
+## Implementation Steps
+
+1. Research TinyUSB CDC-NCM descriptor requirements
+2. Rewrite `usb_composite` component descriptor for HID + NCM
+3. Implement lwIP NAT between NCM netif and WiFi STA netif
+4. Add DHCP server on NCM interface (192.168.7.1/24, assign 192.168.7.2 to host)
+5. Add `esp_http_server` with bootstrap endpoint
+6. Test enumeration on Linux, macOS, Windows
+
+## Key Risks
+
+- No official HID+NCM composite example — descriptor construction is complex
+- NAT/routing between two `esp_netif` interfaces may require custom lwIP hooks
+- Windows NCM driver may require RNDIS instead (test on target platforms)
+- Flash budget: lwIP + HTTP server + WiFi + TinyUSB may approach 3.5 MB limit
+
+## Test Plan
+
+1. Verify NCM enumeration: host shows new network adapter after plug-in
+2. Ping 192.168.7.1 from host; verify DHCP lease
+3. Access `http://192.168.7.1/bootstrap`; verify script served
+4. Browse internet from host via USB NCM → WiFi bridge
+5. Verify HID keyboard still works (open text editor, type test string)
+6. Test on Linux, macOS, Windows
+
+## Related
+
+- [ADR-0003: CDC-ACM to CDC-NCM Phased](../adrs/0003-cdc-acm-to-ncm-phased.md)
+- [ADR-0007: Core Assignment Strategy](../adrs/0007-core-assignment-strategy.md)
+- [PRP: WiFi Connectivity](wifi-connectivity.md) — prerequisite

--- a/packages/esp32-projects/it-troubleshooter/docs/prps/claude-api-integration.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/prps/claude-api-integration.md
@@ -1,0 +1,90 @@
+# PRP: Claude API Integration (Phase 3)
+
+**Source**: [IT Troubleshooter PRD — Phase 3](../prds/it-troubleshooter.md#phase-3--claude-api-integration-planned)
+**Confidence**: 6/10
+**Status**: Planned
+
+## Goal
+
+Integrate the Claude API so the device can analyze command output captured from the target and autonomously decide what commands to run next — closing the human-in-the-loop and enabling AI-driven troubleshooting.
+
+## Requirements
+
+From PRD Phase 3:
+- FR3.1: Capture command output from target (via CDC or screen-scraping simulation)
+- FR3.2: Forward output to Claude API for analysis
+- FR3.3: Execute Claude-suggested next commands via HID injection
+- FR3.4: Configurable API key and model via `credentials.h`
+
+## Design Notes
+
+### Output Capture Challenge
+
+The target machine's command output is not automatically sent to the ESP32 — the device emulates a keyboard, not a terminal. Options:
+
+1. **CDC serial relay**: Operator copies output to CDC serial manually (simplest, Phase 3a)
+2. **Screen reader**: Not feasible with HID keyboard only (would need USB HID mouse + display capture)
+3. **SSH output capture**: With Phase 2 WiFi, SSH to target and capture output natively (preferred, Phase 3b)
+
+Phase 3a (CDC relay) should be implemented first; Phase 3b upgrades the capture mechanism.
+
+### New Component: `claude_client`
+
+```
+components/claude_client/
+├── CMakeLists.txt
+├── idf_component.yml
+├── include/claude_client.h
+└── claude_client.c
+```
+
+Uses `esp_http_client` to POST to `api.anthropic.com/v1/messages`.
+
+Key considerations:
+- TLS: Use `esp_tls` with bundled certificates (`CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y`)
+- Payload size: Command output may be large — consider chunking or truncation
+- Response parsing: Parse JSON response to extract `content[0].text`
+- Model: Default to `claude-haiku-4-5-20251001` for low latency/cost; configurable via `credentials.h`
+
+### Main Flow Update (Phase 3)
+
+```
+diagnostic_loop():
+  output = read_from_cdc_or_ssh()
+  analysis = claude_client_analyze(output, context)
+  if analysis.has_command:
+    usb_keyboard_type_string(analysis.next_command)
+    status_led_set_mode(BIOS_MODE)
+  else if analysis.complete:
+    status_led_set_mode(COMPLETE)
+  else:
+    status_led_set_mode(ERROR)
+```
+
+## Configuration
+
+Add to `credentials.h`:
+```c
+#define CLAUDE_API_KEY "sk-ant-..."
+#define CLAUDE_MODEL   "claude-haiku-4-5-20251001"
+```
+
+## sdkconfig.defaults additions
+
+```
+CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=y
+CONFIG_ESP_TLS_INSECURE=n
+CONFIG_HEAP_TRACING=n
+```
+
+## Test Plan
+
+1. Paste sample command output to CDC serial; verify Claude API call is made
+2. Verify suggested command is typed via HID on target
+3. Test with invalid API key; verify error LED and graceful fallback
+4. Test with truncated/oversized output; verify no heap exhaustion
+
+## Related
+
+- [ADR-0008: Phased Delivery](../adrs/0008-phased-delivery.md) — Phase 3 scope
+- [PRP: WiFi Connectivity](wifi-connectivity.md) — prerequisite

--- a/packages/esp32-projects/it-troubleshooter/docs/prps/wifi-connectivity.md
+++ b/packages/esp32-projects/it-troubleshooter/docs/prps/wifi-connectivity.md
@@ -1,0 +1,89 @@
+# PRP: WiFi Connectivity (Phase 2)
+
+**Source**: [IT Troubleshooter PRD — Phase 2](../prds/it-troubleshooter.md#phase-2--wifi--command-execution-planned)
+**Confidence**: 7/10
+**Status**: Planned
+
+## Goal
+
+Add WiFi connectivity to the IT Troubleshooter so it can connect to a mobile hotspot on boot, enabling operator-driven command execution on remote hosts.
+
+## Requirements
+
+From PRD Phase 2:
+- FR2.1: Connect to pre-configured WiFi hotspot on boot
+- FR2.2: Accept operator input via CDC serial
+- FR2.3: Inject commands to target via HID keyboard
+- FR2.4: NVS-persisted state machine for multi-step workflows
+- FR2.5: LED feedback during WiFi and execution phases
+
+## Implementation Approach
+
+### New Component: `wifi_manager`
+
+```
+components/wifi_manager/
+├── CMakeLists.txt
+├── idf_component.yml
+├── include/wifi_manager.h
+└── wifi_manager.c
+```
+
+Responsibilities:
+- Connect to SSID/password from `credentials.h`
+- Retry with exponential backoff
+- Expose `wifi_manager_is_connected()` for polling
+- Call `status_led_set_mode(STATUS_LED_WIFI_CONNECTING)` during connection
+
+### NVS State Machine
+
+Store device state in NVS namespace `"it-ts"`:
+- `"phase"` (uint8): current phase (1=USB only, 2=WiFi connected, 3=command running)
+- `"step"` (uint8): current step within phase
+- Persist across power cycles for multi-step workflows
+
+### Main Flow Update
+
+```
+app_main():
+  nvs_flash_init()
+  status_led_init()
+  usb_composite_init()
+  wait_for_usb_mount()
+  wifi_manager_init()
+  wait_for_wifi_connected()   ← NEW
+  start_command_loop_task()   ← NEW (core 1, replaces CDC echo)
+```
+
+### Command Loop Task (core 1)
+
+```
+command_loop_task():
+  while(true):
+    status_led_update()
+    if cdc_data_available():
+      cmd = usb_cdc_read()
+      usb_keyboard_type_string(cmd)   ← inject to target
+    vTaskDelay(10ms)
+```
+
+## Hardware/Config
+
+- WiFi credentials in `credentials.h`: `WIFI_SSID`, `WIFI_PASS`
+- `sdkconfig.defaults` additions needed:
+  - `CONFIG_ESP_WIFI_ENABLED=y`
+  - `CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=10`
+  - `CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=32`
+- Power management must stay disabled (`CONFIG_PM_ENABLE=n`) for USB + WiFi low latency
+
+## Test Plan
+
+1. Build and flash; observe LED transitions: BOOT → USB_READY → WIFI_CONNECTING → DIAGNOSTIC
+2. Connect terminal to CDC serial; type a command; verify it appears on target screen via HID
+3. Power cycle; verify NVS state restores correctly
+4. Disconnect WiFi hotspot; verify reconnection retry and LED feedback
+
+## Related
+
+- [ADR-0007: Core Assignment Strategy](../adrs/0007-core-assignment-strategy.md) — WiFi tasks on core 1
+- [ADR-0008: Phased Delivery](../adrs/0008-phased-delivery.md) — Phase 2 scope


### PR DESCRIPTION
## Summary

- Add CLAUDE.md with build commands, architecture overview, and hardware constraints for the IT Troubleshooter project
- Add 8 Architecture Decision Records (ADRs) covering MCU selection, USB protocols, LED strategy, debug UART, core assignment, and phased delivery
- Add PRD, PRPs for planned features (CDC-NCM USB Ethernet, WiFi connectivity, Claude API integration)
- Add Claude Code rules for code style, error handling, dependencies, testing, security, and document management
- Add project .gitignore and blueprint tracking files

## Test plan

- [x] All files are documentation/configuration only — no code changes
- [ ] Verify ADR numbering is sequential and consistent
- [ ] Verify CLAUDE.md build commands match existing justfile recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)