### PR TITLE
chore: improve justfile port detection and device recipes

### DIFF
--- a/packages/esp32-projects/it-troubleshooter/dependencies.lock
+++ b/packages/esp32-projects/it-troubleshooter/dependencies.lock
@@ -1,0 +1,51 @@
+dependencies:
+  espressif/esp_tinyusb:
+    component_hash: 6a50305bc61c7a361da8c0833642be824e92dacb0a6001719a832a4e96e471bf
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    - name: espressif/tinyusb
+      registry_url: https://components.espressif.com
+      require: public
+      version: '>=0.14.2'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.7.6~2
+  espressif/led_strip:
+    component_hash: 28621486f77229aaf81c71f5e15d6fbf36c2949cf11094e07090593e659e7639
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 3.0.3
+  espressif/tinyusb:
+    component_hash: 5ea9d3b6d6b0734a0a0b3491967aa0e1bece2974132294dbda5dd2839b247bfa
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    targets:
+    - esp32s2
+    - esp32s3
+    - esp32p4
+    - esp32h4
+    version: 0.19.0~2
+  idf:
+    source:
+      type: idf
+    version: 5.4.0
+direct_dependencies:
+- espressif/esp_tinyusb
+- espressif/led_strip
+- idf
+manifest_hash: 27c4fe9b5a94de28b5d69adc5b8dadd70b9a38f4426542bf9228afab089768fc
+target: esp32s3
+version: 2.0.0

--- a/packages/esp32-projects/it-troubleshooter/justfile
+++ b/packages/esp32-projects/it-troubleshooter/justfile
@@ -1,11 +1,13 @@
-# IT Troubleshooter — ESP32-S3-Zero
+# IT Troubleshooter — ESP32-S3-Zero USB composite device
 # Run `just --list` for available recipes
 
 set positional-arguments
 
 project_dir := justfile_directory()
 compose_file := project_dir / "../../../docker-compose.yml"
-port := env("PORT", "/dev/cu.usbmodem101")
+# Auto-detect ESP32-S3 USB-Serial-JTAG by Espressif VID (0x303a=12346); override with PORT env var
+port := env("PORT", `ioreg -r -c IOUSBHostDevice -l 2>/dev/null | grep -A 30 '"idVendor" = 12346' | grep IODialinDevice | head -1 | sed 's/.*"\(\/dev\/[^"]*\)".*/\1/' | sed 's/tty\./cu./' || true`)
+baud := env("BAUD", "460800")
 
 ##########
 # Default
@@ -33,18 +35,43 @@ clean:
     rm -rf build sdkconfig sdkconfig.old managed_components
 
 ##########
-# Flash
+# Device (flash & monitor — native, USB passthrough on macOS is unreliable)
 ##########
 
+# Auto-detect ESP32-S3 port or show error
+[group: "device"]
+detect-port:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "{{port}}" ]; then
+        echo "ERROR: No ESP32-S3 USB-Serial-JTAG device found"
+        echo "  - Is the board plugged in?"
+        echo "  - Try: ioreg -p IOUSB -l | grep -B 5 -A 10 'USB JTAG'"
+        echo "  - Or set PORT manually: PORT=/dev/cu.usbmodem101 just flash"
+        exit 1
+    fi
+    echo "Detected port: {{port}}"
+
+# Require a valid port for device recipes
+[private]
+require-port:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -z "{{port}}" ]; then
+        echo "ERROR: No ESP32-S3 USB-Serial-JTAG device found" >&2
+        echo "  Is the board plugged in? Override with: PORT=/dev/cu.usbmodem101 just flash" >&2
+        exit 1
+    fi
+
 # Flash firmware to device
-[group: "flash"]
-flash:
-    esptool.py -p {{port}} -b 460800 \
-        --before default_reset --after hard_reset \
-        write_flash @build/flash_args
+[group: "device"]
+flash: require-port
+    cd {{project_dir}}/build && esptool --chip esp32s3 -p {{port}} -b {{baud}} \
+        --before default-reset --after hard-reset \
+        write-flash @flash_args
 
 # Build and flash
-[group: "flash"]
+[group: "device"]
 deploy: build flash
 
 ##########
@@ -67,3 +94,15 @@ menuconfig:
         -w /workspace/packages/esp32-projects/it-troubleshooter \
         esp-idf \
         idf.py menuconfig
+
+##########
+# Info
+##########
+
+# Show project information
+[group: "info"]
+info:
+    @echo "Project: it-troubleshooter"
+    @echo "  Target: ESP32-S3"
+    @echo "  Port:   {{if port == "" { "(not detected — board not connected?)" } else { port } }}"
+    @echo "  Baud:   {{baud}}"

--- a/packages/esp32-projects/xbox-switch-bridge/justfile
+++ b/packages/esp32-projects/xbox-switch-bridge/justfile
@@ -185,10 +185,12 @@ flash-monitor: flash monitor
 # 2. Run this recipe
 [group: "device"]
 log-listen port="4444":
-    @echo "Listening for UDP logs on port {{port}} — Ctrl-C to stop"
-    @echo "Connect to WiFi: xbox-bridge-log (open, no password)"
-    @echo ""
-    socat UDP-RECV:{{port}} STDOUT
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Listening for UDP logs on port {{port}} — Ctrl-C to stop"
+    echo "Connect to WiFi: xbox-bridge-log (open, no password)"
+    echo ""
+    exec socat -u UDP-RECV:{{port}} -
 
 # Show project information
 [group: "info"]


### PR DESCRIPTION
- it-troubleshooter: auto-detect ESP32-S3 USB-Serial-JTAG port via
  ioreg, add detect-port/require-port/info recipes, modernize esptool
  flags to use dashes instead of underscores
- xbox-switch-bridge: fix log-listen recipe with proper shebang and
  exec socat -u flag for unidirectional UDP receive
- it-troubleshooter: add dependencies.lock for managed components

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Summary

<!-- What does this PR do? Why? -->

## Changes

<!-- Bullet list of the key changes -->
-

## Testing

<!-- How was this tested? -->
- [ ] Unit tests pass
- [ ] Manual testing done

## Related

<!-- Link issues: Fixes #N, Refs #N -->
