### PR TITLE
test(ota): add I2C protocol and OTA simulation tests

### DIFF
--- a/packages/esp32-projects/robocar-simulation/src/communication_bridge.py
+++ b/packages/esp32-projects/robocar-simulation/src/communication_bridge.py
@@ -37,6 +37,12 @@ class MessageType(Enum):
     STOP = 0x07
     SENSOR_DATA = 0x08
     AI_COMMAND = 0x09
+    # OTA Commands (matching firmware i2c_protocol.h)
+    ENTER_MAINTENANCE_MODE = 0x50
+    BEGIN_OTA = 0x51
+    GET_OTA_STATUS = 0x52
+    GET_VERSION = 0x53
+    REBOOT = 0x54
 
 
 @dataclass

--- a/packages/esp32-projects/robocar-simulation/tests/test_i2c_protocol.py
+++ b/packages/esp32-projects/robocar-simulation/tests/test_i2c_protocol.py
@@ -1,0 +1,92 @@
+"""Tests for I2C protocol message encoding/decoding."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from communication_bridge import I2CMessage, MessageType
+
+
+class TestMessageType:
+    """Test MessageType enum values match firmware protocol."""
+
+    def test_basic_command_values(self):
+        assert MessageType.MOVE.value == 0x01
+        assert MessageType.SOUND.value == 0x02
+        assert MessageType.SERVO.value == 0x03
+        assert MessageType.DISPLAY.value == 0x04
+        assert MessageType.STATUS.value == 0x05
+
+    def test_ota_command_values(self):
+        """OTA commands must match firmware i2c_protocol.h values."""
+        assert MessageType.ENTER_MAINTENANCE_MODE.value == 0x50
+        assert MessageType.BEGIN_OTA.value == 0x51
+        assert MessageType.GET_OTA_STATUS.value == 0x52
+        assert MessageType.GET_VERSION.value == 0x53
+        assert MessageType.REBOOT.value == 0x54
+
+    def test_no_duplicate_values(self):
+        """All message types must have unique values."""
+        values = [m.value for m in MessageType]
+        assert len(values) == len(set(values))
+
+
+class TestI2CMessage:
+    """Test I2C message construction and serialization."""
+
+    def test_construction_calculates_checksum(self):
+        msg = I2CMessage(MessageType.MOVE, b"\x01\x80")
+        assert msg.checksum != 0
+
+    def test_to_bytes_format(self):
+        """to_bytes should produce: type_byte + data + checksum_byte"""
+        msg = I2CMessage(MessageType.MOVE, b"\x01\x80")
+        raw = msg.to_bytes()
+        assert raw[0] == MessageType.MOVE.value
+        assert raw[1:-1] == b"\x01\x80"
+        assert raw[-1] == msg.checksum
+
+    def test_from_bytes_roundtrip(self):
+        """from_bytes(to_bytes()) should reconstruct the original message."""
+        original = I2CMessage(MessageType.SERVO, b"\x02\x5a")
+        raw = original.to_bytes()
+        restored = I2CMessage.from_bytes(raw)
+        assert restored.message_type == original.message_type
+        assert restored.data == original.data
+        assert restored.checksum == original.checksum
+
+    def test_from_bytes_too_short(self):
+        with pytest.raises(ValueError, match="too short"):
+            I2CMessage.from_bytes(b"\x01")
+
+    def test_empty_data(self):
+        msg = I2CMessage(MessageType.ENTER_MAINTENANCE_MODE, b"")
+        raw = msg.to_bytes()
+        assert len(raw) == 2  # type + checksum
+        restored = I2CMessage.from_bytes(raw)
+        assert restored.data == b""
+
+    def test_checksum_detects_corruption(self):
+        msg = I2CMessage(MessageType.MOVE, b"\x01\x80")
+        raw = bytearray(msg.to_bytes())
+        raw[1] ^= 0xFF  # corrupt data byte
+        restored = I2CMessage.from_bytes(bytes(raw))
+        expected_checksum = restored._calculate_checksum()
+        assert restored.checksum != expected_checksum
+
+    def test_ota_message_types(self):
+        """All OTA message types should be constructable."""
+        for mt in [
+            MessageType.ENTER_MAINTENANCE_MODE,
+            MessageType.BEGIN_OTA,
+            MessageType.GET_OTA_STATUS,
+            MessageType.GET_VERSION,
+            MessageType.REBOOT,
+        ]:
+            msg = I2CMessage(mt, b"\x00")
+            assert msg.message_type == mt
+            raw = msg.to_bytes()
+            assert len(raw) >= 2

--- a/packages/esp32-projects/robocar-simulation/tests/test_ota_simulation.py
+++ b/packages/esp32-projects/robocar-simulation/tests/test_ota_simulation.py
@@ -1,0 +1,167 @@
+"""Tests for OTA simulation module."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from ota_simulation import FirmwareInfo, OTASimulation, OTAState, OTAStatus
+
+
+class TestOTAState:
+    """Test OTA state enum."""
+
+    def test_state_values(self):
+        assert OTAState.IDLE.value == "idle"
+        assert OTAState.IN_PROGRESS.value == "in_progress"
+        assert OTAState.SUCCESS.value == "success"
+        assert OTAState.FAILED.value == "failed"
+        assert OTAState.ABORTED.value == "aborted"
+
+    def test_all_states_exist(self):
+        states = {s.value for s in OTAState}
+        assert states == {"idle", "in_progress", "success", "failed", "aborted"}
+
+
+class TestFirmwareInfo:
+    """Test FirmwareInfo dataclass."""
+
+    def test_construction(self):
+        fw = FirmwareInfo(
+            version="1.2.3",
+            build_date="2024-06-01",
+            size=1048576,
+            checksum="abc123",
+            description="Test firmware",
+        )
+        assert fw.version == "1.2.3"
+        assert fw.size == 1048576
+
+    def test_to_dict(self):
+        fw = FirmwareInfo(
+            version="1.0.0",
+            build_date="2024-01-01",
+            size=512000,
+            checksum="deadbeef",
+        )
+        d = fw.to_dict()
+        assert d["version"] == "1.0.0"
+        assert d["size"] == 512000
+        assert d["checksum"] == "deadbeef"
+        assert "description" in d
+
+
+class TestOTAStatus:
+    """Test OTAStatus dataclass."""
+
+    def test_idle_status(self):
+        status = OTAStatus(OTAState.IDLE, 0, 0, 0)
+        assert status.state == OTAState.IDLE
+        assert status.progress_percent == 0
+
+    def test_in_progress_status(self):
+        status = OTAStatus(OTAState.IN_PROGRESS, 50, 500000, 1000000)
+        assert status.progress_percent == 50
+        assert status.bytes_downloaded == 500000
+
+    def test_failed_status_with_error(self):
+        status = OTAStatus(
+            OTAState.FAILED, 30, 300000, 1000000, error_message="Download timeout"
+        )
+        assert status.error_message == "Download timeout"
+
+    def test_to_dict_with_firmware(self):
+        fw = FirmwareInfo("1.0.0", "2024-01-01", 1000000, "abc")
+        status = OTAStatus(OTAState.SUCCESS, 100, 1000000, 1000000, firmware_info=fw)
+        d = status.to_dict()
+        assert d["state"] == "success"
+        assert d["progress_percent"] == 100
+        assert "firmware_info" in d
+        assert d["firmware_info"]["version"] == "1.0.0"
+
+    def test_to_dict_without_firmware(self):
+        status = OTAStatus(OTAState.IDLE, 0, 0, 0)
+        d = status.to_dict()
+        assert "firmware_info" not in d
+
+
+class TestOTASimulation:
+    """Test OTASimulation class."""
+
+    @pytest.fixture
+    def ota(self):
+        config_path = str(Path(__file__).parent.parent / "config" / "robot_config.yaml")
+        return OTASimulation(config_path)
+
+    def test_initial_state(self, ota):
+        assert ota.current_state == OTAState.IDLE
+        assert ota.boot_partition == "factory"
+
+    def test_partition_table_loaded(self, ota):
+        assert "factory" in ota.partitions
+        assert "ota_0" in ota.partitions
+        assert "ota_1" in ota.partitions
+        assert "nvs" in ota.partitions
+
+    def test_factory_firmware_exists(self, ota):
+        assert "factory" in ota.firmware_versions
+        assert ota.firmware_versions["factory"].version == "1.0.0"
+
+    def test_get_next_ota_partition_from_factory(self, ota):
+        ota.boot_partition = "factory"
+        assert ota._get_next_ota_partition() == "ota_0"
+
+    def test_get_next_ota_partition_alternates(self, ota):
+        ota.boot_partition = "ota_0"
+        assert ota._get_next_ota_partition() == "ota_1"
+
+        ota.boot_partition = "ota_1"
+        assert ota._get_next_ota_partition() == "ota_0"
+
+    def test_not_ota_ready_without_wifi(self, ota):
+        """OTA should not be ready without a WiFi manager."""
+        assert not ota.is_ota_ready()
+
+    def test_start_update_fails_without_wifi(self, ota):
+        result = ota.start_update("https://example.com/firmware.bin", "2.0.0")
+        assert result is False
+        assert ota.current_status.error_message == "System not ready for OTA"
+
+    def test_set_boot_partition_valid(self, ota):
+        assert ota.set_boot_partition("ota_0") is True
+        assert ota.boot_partition == "ota_0"
+
+    def test_set_boot_partition_invalid_name(self, ota):
+        assert ota.set_boot_partition("nonexistent") is False
+
+    def test_set_boot_partition_invalid_ota1(self, ota):
+        """ota_1 is not valid initially, so setting boot to it should fail."""
+        assert ota.set_boot_partition("ota_1") is False
+
+    def test_rollback_to_factory(self, ota):
+        ota.boot_partition = "ota_0"
+        assert ota.rollback_to_factory() is True
+        assert ota.boot_partition == "factory"
+
+    def test_rollback_blocked_during_update(self, ota):
+        ota.current_state = OTAState.IN_PROGRESS
+        assert ota.rollback_to_factory() is False
+
+    def test_abort_when_not_in_progress(self, ota):
+        assert ota.abort_update() is False
+
+    def test_get_system_info(self, ota):
+        info = ota.get_system_info()
+        assert "current_state" in info
+        assert "boot_partition" in info
+        assert "partitions" in info
+        assert "firmware_versions" in info
+        assert info["current_state"] == "idle"
+
+    def test_get_partition_info(self, ota):
+        info = ota.get_partition_info()
+        assert "factory" in info
+        assert info["factory"]["type"] == "app"
+        assert info["factory"]["subtype"] == "factory"


### PR DESCRIPTION
## Summary

- Extend `MessageType` enum with OTA commands (0x50-0x54) matching firmware `i2c_protocol.h`
- Add `test_i2c_protocol.py`: message roundtrip, checksum validation, corruption detection (10 tests)
- Add `test_ota_simulation.py`: state machine transitions, partition management, firmware info, rollback (24 tests)

All 34 new tests pass.

Closes #28
Closes #29

## Test plan

- [ ] `cd packages/esp32-projects/robocar-simulation && uv run pytest tests/ -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)