### PR TITLE
ci(ota): add MQTT release notification and binary size check

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -54,6 +54,25 @@ jobs:
           echo "main_size=$MAIN_SIZE" >> $GITHUB_OUTPUT
           echo "camera_size=$CAMERA_SIZE" >> $GITHUB_OUTPUT
 
+      - name: Check binary sizes against OTA partition limit
+        run: |
+          OTA_LIMIT=1887436  # 1.8MB OTA partition
+          MAIN_SIZE=${{ steps.hashes.outputs.main_size }}
+          CAMERA_SIZE=${{ steps.hashes.outputs.camera_size }}
+
+          if [ $MAIN_SIZE -gt $OTA_LIMIT ]; then
+            echo "ERROR: robocar-main binary ($MAIN_SIZE bytes) exceeds OTA partition limit ($OTA_LIMIT bytes)"
+            exit 1
+          fi
+
+          if [ $CAMERA_SIZE -gt $OTA_LIMIT ]; then
+            echo "ERROR: robocar-camera binary ($CAMERA_SIZE bytes) exceeds OTA partition limit ($OTA_LIMIT bytes)"
+            exit 1
+          fi
+
+          echo "✓ robocar-main: $MAIN_SIZE bytes"
+          echo "✓ robocar-camera: $CAMERA_SIZE bytes"
+
       - name: Get version from tag
         id: version
         run: |
@@ -88,6 +107,21 @@ jobs:
             robocar-main.bin
             robocar-camera.bin
             manifest.json
+
+      - name: Notify robots of new firmware via MQTT
+        if: github.event_name == 'release' && vars.MQTT_ENABLED == 'true'
+        continue-on-error: true
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq mosquitto-clients
+
+          BROKER_PORT="${{ secrets.MQTT_BROKER_PORT }}"
+          mosquitto_pub \
+            -h "${{ secrets.MQTT_BROKER_HOST }}" \
+            -p "${BROKER_PORT:-1883}" \
+            -t "robocar/ota/notify" \
+            -m "${{ github.event.release.tag_name }}" \
+            -q 1
 
       - name: Generate build summary
         run: |


### PR DESCRIPTION
Closes #107

## Summary

- Add MQTT notification step to alert robots of new firmware releases, reducing update latency from 6-hour polling to minutes
- Add binary size validation against OTA partition limit (1.8MB / 1887436 bytes)
- MQTT step is optional: requires MQTT_BROKER_HOST secret and MQTT_ENABLED repo variable
- Uses continue-on-error so MQTT failures never block a release

## Setup Required

1. Set repository variable: MQTT_ENABLED=true
2. Set repository secrets: MQTT_BROKER_HOST, MQTT_BROKER_PORT (optional, defaults to 1883)

## Test plan

- [ ] Verify binary size check passes for current firmware builds
- [ ] Verify MQTT step only runs on release events
- [ ] Verify MQTT step skipped gracefully when secrets not configured
- [ ] Verify workflow still succeeds if MQTT broker is unreachable