### PR TITLE
feat: add host-based unit tests for i2c_protocol and status_led

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .aider*
 # Build artifacts
 build/
+# Host test binaries (produced by make test in test/ directories)
+test_runner
 target/
 *.o
 *.a

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/Makefile
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/Makefile
@@ -1,0 +1,35 @@
+# Makefile for status_led host-based unit tests
+#
+# Compiles status_led.c for Linux/macOS using gcc with mocked hardware
+# drivers. No ESP-IDF or hardware required.
+#
+# Usage:
+#   make test     — build and run tests (default)
+#   make clean    — remove build artefacts
+
+CC     = gcc
+CFLAGS = -std=c11 -Wall -Wextra \
+         -Wno-unused-function \
+         -I../include \
+         -Istubs \
+         -Istubs/freertos \
+         -I.
+
+SRCS   = test_status_led.c mocks.c ../status_led.c
+TARGET = test_runner
+
+.PHONY: all test clean
+
+all: test
+
+test: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS) unity_compat.h \
+           stubs/esp_err.h stubs/esp_log.h stubs/esp_timer.h \
+           stubs/led_strip.h stubs/freertos/FreeRTOS.h stubs/freertos/task.h \
+           ../status_led.c
+	$(CC) $(CFLAGS) -o $@ $(SRCS)
+
+clean:
+	rm -f $(TARGET)

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/mocks.c
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/mocks.c
@@ -1,0 +1,67 @@
+/**
+ * @file mocks.c
+ * @brief Mock implementations for led_strip hardware driver.
+ *
+ * Provides stub functions that record their arguments so tests can
+ * verify the LED colour and refresh behaviour without hardware.
+ */
+
+#include "led_strip.h"
+
+#include <stddef.h>
+
+/* ---------------------------------------------------------------------- */
+/* Mock state — defined here, declared extern in led_strip.h              */
+/* ---------------------------------------------------------------------- */
+uint8_t mock_led_r         = 0;
+uint8_t mock_led_g         = 0;
+uint8_t mock_led_b         = 0;
+int     mock_set_pixel_calls = 0;
+int     mock_refresh_calls   = 0;
+
+/** Controllable time for esp_timer_get_time() stub (declared in esp_timer.h). */
+int64_t mock_timer_us = 0;
+
+/* ---------------------------------------------------------------------- */
+/* Mock implementations                                                    */
+/* ---------------------------------------------------------------------- */
+
+static int dummy_handle;
+
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t     *strip_config,
+                                   const led_strip_rmt_config_t *rmt_config,
+                                   led_strip_handle_t           *ret_strip)
+{
+    (void)strip_config;
+    (void)rmt_config;
+    *ret_strip = &dummy_handle;
+    return ESP_OK;
+}
+
+esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index,
+                              uint8_t red, uint8_t green, uint8_t blue)
+{
+    (void)strip;
+    (void)index;
+    mock_led_r = red;
+    mock_led_g = green;
+    mock_led_b = blue;
+    mock_set_pixel_calls++;
+    return ESP_OK;
+}
+
+esp_err_t led_strip_refresh(led_strip_handle_t strip)
+{
+    (void)strip;
+    mock_refresh_calls++;
+    return ESP_OK;
+}
+
+esp_err_t led_strip_clear(led_strip_handle_t strip)
+{
+    (void)strip;
+    mock_led_r = 0;
+    mock_led_g = 0;
+    mock_led_b = 0;
+    return ESP_OK;
+}

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/esp_err.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/esp_err.h
@@ -1,0 +1,15 @@
+/**
+ * @file esp_err.h
+ * @brief Stub for ESP-IDF esp_err types used in host tests.
+ */
+#pragma once
+
+typedef int esp_err_t;
+
+#define ESP_OK   0
+#define ESP_FAIL (-1)
+
+static inline const char *esp_err_to_name(esp_err_t e)
+{
+    return e == ESP_OK ? "ESP_OK" : "ESP_FAIL";
+}

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/esp_log.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/esp_log.h
@@ -1,0 +1,13 @@
+/**
+ * @file esp_log.h
+ * @brief Stub for ESP-IDF logging used in host tests.
+ */
+#pragma once
+
+#include <stdio.h>
+
+#define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "[E][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "[W][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) fprintf(stdout, "[I][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) /* debug suppressed */
+#define ESP_LOGV(tag, fmt, ...) /* verbose suppressed */

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/esp_timer.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/esp_timer.h
@@ -1,0 +1,18 @@
+/**
+ * @file esp_timer.h
+ * @brief Stub for ESP-IDF high-resolution timer used in host tests.
+ *
+ * mock_timer_us is externally controlled by the test file so blink
+ * timing can be driven deterministically.
+ */
+#pragma once
+
+#include <stdint.h>
+
+/** Controllable mock time source. Set before calling status_led_update(). */
+extern int64_t mock_timer_us;
+
+static inline int64_t esp_timer_get_time(void)
+{
+    return mock_timer_us;
+}

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/freertos/FreeRTOS.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/freertos/FreeRTOS.h
@@ -1,0 +1,12 @@
+/**
+ * @file FreeRTOS.h
+ * @brief Minimal FreeRTOS stub for host-based unit tests.
+ */
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef uint32_t TickType_t;
+
+#define pdMS_TO_TICKS(ms) ((TickType_t)(ms))

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/freertos/task.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/freertos/task.h
@@ -1,0 +1,14 @@
+/**
+ * @file task.h
+ * @brief FreeRTOS task stub for host-based unit tests.
+ *
+ * vTaskDelay is a no-op so status_led_flash() returns immediately in tests.
+ */
+#pragma once
+
+#include "FreeRTOS.h"
+
+static inline void vTaskDelay(TickType_t ticks)
+{
+    (void)ticks;
+}

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/led_strip.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/stubs/led_strip.h
@@ -1,0 +1,56 @@
+/**
+ * @file led_strip.h
+ * @brief Stub for espressif/led_strip component used in host tests.
+ *
+ * Mock implementations record the last colour written and the number of
+ * refresh calls so tests can verify LED behaviour without hardware.
+ */
+#pragma once
+
+#include "esp_err.h"
+#include <stdint.h>
+
+typedef void *led_strip_handle_t;
+
+typedef enum {
+    LED_MODEL_WS2812 = 0,
+} led_strip_led_model_t;
+
+typedef enum {
+    LED_STRIP_COLOR_COMPONENT_FMT_GRB = 0,
+} led_strip_color_component_format_t;
+
+typedef struct {
+    int                                 strip_gpio_num;
+    int                                 max_leds;
+    led_strip_led_model_t               led_model;
+    led_strip_color_component_format_t  color_component_format;
+} led_strip_config_t;
+
+typedef struct {
+    int resolution_hz;
+    int mem_block_symbols;
+    struct {
+        int with_dma;
+    } flags;
+} led_strip_rmt_config_t;
+
+/* ---------------------------------------------------------------------- */
+/* Mock state — written by mock functions, read by tests                   */
+/* ---------------------------------------------------------------------- */
+extern uint8_t mock_led_r;
+extern uint8_t mock_led_g;
+extern uint8_t mock_led_b;
+extern int     mock_set_pixel_calls;
+extern int     mock_refresh_calls;
+
+/* ---------------------------------------------------------------------- */
+/* Mock function declarations                                              */
+/* ---------------------------------------------------------------------- */
+esp_err_t led_strip_new_rmt_device(const led_strip_config_t     *strip_config,
+                                   const led_strip_rmt_config_t *rmt_config,
+                                   led_strip_handle_t           *ret_strip);
+esp_err_t led_strip_set_pixel(led_strip_handle_t strip, uint32_t index,
+                              uint8_t red, uint8_t green, uint8_t blue);
+esp_err_t led_strip_refresh(led_strip_handle_t strip);
+esp_err_t led_strip_clear(led_strip_handle_t strip);

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/test_status_led.c
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/test_status_led.c
@@ -1,0 +1,321 @@
+/**
+ * @file test_status_led.c
+ * @brief Host-based unit tests for the status_led component.
+ *
+ * Tests the LED mode state machine and blink timing logic using mocked
+ * hardware drivers (led_strip, esp_timer, FreeRTOS). No hardware required.
+ *
+ * Build and run: make test
+ */
+
+#include "unity_compat.h"
+#include "status_led.h"
+
+/* Mock state from mocks.c */
+extern uint8_t mock_led_r;
+extern uint8_t mock_led_g;
+extern uint8_t mock_led_b;
+extern int     mock_set_pixel_calls;
+extern int     mock_refresh_calls;
+extern int64_t mock_timer_us;
+
+/* Must match the constants in status_led.c */
+#define LED_BRIGHTNESS  32
+#define BLINK_SLOW_US   (500 * 1000)
+#define BLINK_FAST_US   (200 * 1000)
+
+/* ---------------------------------------------------------------------- */
+/* Helpers                                                                 */
+/* ---------------------------------------------------------------------- */
+
+static void reset_mocks(void)
+{
+    mock_led_r           = 0;
+    mock_led_g           = 0;
+    mock_led_b           = 0;
+    mock_set_pixel_calls = 0;
+    mock_refresh_calls   = 0;
+    mock_timer_us        = 0;
+}
+
+/**
+ * Initialise the LED driver (uses mock hardware) and switch to OFF mode.
+ * Call at the start of each test that exercises status_led_update().
+ */
+static void setup(void)
+{
+    reset_mocks();
+    status_led_init();
+    status_led_set_mode(STATUS_LED_OFF);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tests: initialisation                                                   */
+/* ---------------------------------------------------------------------- */
+
+static void test_init_returns_ok(void)
+{
+    reset_mocks();
+    esp_err_t ret = status_led_init();
+    TEST_ASSERT_EQUAL(ESP_OK, ret);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tests: solid-colour modes                                               */
+/* ---------------------------------------------------------------------- */
+
+static void test_mode_off_output_dark(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_OFF);
+    mock_timer_us = 10 * 1000 * 1000LL; /* 10 s — well past any blink period */
+    status_led_update();
+
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+static void test_mode_usb_error_output_red_solid(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_USB_ERROR);
+    mock_timer_us = 10 * 1000 * 1000LL;
+    status_led_update();
+
+    TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_r);
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+static void test_mode_bridging_output_green_solid(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_BRIDGING);
+    mock_timer_us = 10 * 1000 * 1000LL;
+    status_led_update();
+
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+static void test_usb_error_stays_red_across_multiple_updates(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_USB_ERROR);
+
+    for (int i = 0; i < 10; i++) {
+        mock_timer_us = (int64_t)i * 100 * 1000; /* advance 100 ms each iteration */
+        status_led_update();
+        TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_r);
+        TEST_ASSERT_EQUAL(0, mock_led_g);
+        TEST_ASSERT_EQUAL(0, mock_led_b);
+    }
+}
+
+static void test_bridging_stays_green_across_multiple_updates(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_BRIDGING);
+
+    for (int i = 0; i < 10; i++) {
+        mock_timer_us = (int64_t)i * 100 * 1000;
+        status_led_update();
+        TEST_ASSERT_EQUAL(0, mock_led_r);
+        TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_g);
+        TEST_ASSERT_EQUAL(0, mock_led_b);
+    }
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tests: refresh is called on every update                                */
+/* ---------------------------------------------------------------------- */
+
+static void test_update_calls_refresh(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_BRIDGING);
+    int before = mock_refresh_calls;
+    status_led_update();
+    TEST_ASSERT_TRUE(mock_refresh_calls > before);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tests: mode transitions                                                 */
+/* ---------------------------------------------------------------------- */
+
+static void test_mode_transition_off_to_bridging(void)
+{
+    setup();
+    mock_timer_us = 5 * 1000 * 1000LL;
+
+    status_led_set_mode(STATUS_LED_OFF);
+    status_led_update();
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+
+    status_led_set_mode(STATUS_LED_BRIDGING);
+    status_led_update();
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+static void test_mode_transition_error_to_off(void)
+{
+    setup();
+    mock_timer_us = 5 * 1000 * 1000LL;
+
+    status_led_set_mode(STATUS_LED_USB_ERROR);
+    status_led_update();
+    TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_r);
+
+    status_led_set_mode(STATUS_LED_OFF);
+    status_led_update();
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tests: blink toggling                                                   */
+/*                                                                         */
+/* Blink tests advance mock_timer_us by more than one full period so that  */
+/* at least one toggle is guaranteed regardless of internal blink state.   */
+/* We verify that the LED value CHANGES between two consecutive samples    */
+/* separated by exactly one blink period, which confirms toggling.        */
+/* ---------------------------------------------------------------------- */
+
+static void test_scanning_blink_toggles_over_slow_period(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_SCANNING);
+
+    /* Sample at a large absolute time so s_last_toggle_us is stable. */
+    mock_timer_us = 10 * 1000 * 1000LL; /* 10 s */
+    status_led_update();
+    uint8_t blue_at_T = mock_led_b;
+    /* r and g must always be 0 in SCANNING mode */
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+
+    /* Advance exactly one slow blink period + 1 µs to trigger toggle. */
+    mock_timer_us += BLINK_SLOW_US + 1;
+    status_led_update();
+    uint8_t blue_after_period = mock_led_b;
+
+    /* The two samples must differ (one ON, one OFF). */
+    TEST_ASSERT_NOT_EQUAL(blue_at_T, blue_after_period);
+    /* Both values must be valid (either 0 or LED_BRIGHTNESS). */
+    TEST_ASSERT_TRUE(blue_at_T == 0 || blue_at_T == LED_BRIGHTNESS);
+    TEST_ASSERT_TRUE(blue_after_period == 0 || blue_after_period == LED_BRIGHTNESS);
+}
+
+static void test_connected_no_usb_blink_toggles_slow(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_CONNECTED_NO_USB);
+
+    mock_timer_us = 20 * 1000 * 1000LL;
+    status_led_update();
+    uint8_t r0 = mock_led_r;
+    uint8_t b0 = mock_led_b;
+
+    mock_timer_us += BLINK_SLOW_US + 1;
+    status_led_update();
+    uint8_t r1 = mock_led_r;
+    uint8_t b1 = mock_led_b;
+
+    /* Purple blink: r and b move together, g is always 0. */
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+    TEST_ASSERT_NOT_EQUAL(r0, r1);
+    TEST_ASSERT_NOT_EQUAL(b0, b1);
+}
+
+static void test_connected_usb_blink_toggles_fast(void)
+{
+    setup();
+    status_led_set_mode(STATUS_LED_CONNECTED_USB);
+
+    mock_timer_us = 30 * 1000 * 1000LL;
+    status_led_update();
+    uint8_t r0 = mock_led_r;
+
+    /* Fast period is 200 ms — advance by that plus a safety margin. */
+    mock_timer_us += BLINK_FAST_US + 1;
+    status_led_update();
+    uint8_t r1 = mock_led_r;
+
+    TEST_ASSERT_NOT_EQUAL(r0, r1);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Tests: status_led_flash                                                 */
+/* ---------------------------------------------------------------------- */
+
+static void test_flash_sets_color_then_clears(void)
+{
+    setup();
+    /* flash calls vTaskDelay (stubbed as no-op) then clears the LED */
+    status_led_flash(255, 128, 64, 10);
+    /* After flash completes the LED should be dark */
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(0, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+static void test_flash_does_not_affect_current_mode(void)
+{
+    /* After flash, the next update should honour the current mode, not the
+     * flash colour. */
+    setup();
+    status_led_set_mode(STATUS_LED_BRIDGING);
+    status_led_flash(255, 0, 0, 1);
+
+    mock_timer_us = 5 * 1000 * 1000LL;
+    status_led_update();
+
+    TEST_ASSERT_EQUAL(0, mock_led_r);
+    TEST_ASSERT_EQUAL(LED_BRIGHTNESS, mock_led_g);
+    TEST_ASSERT_EQUAL(0, mock_led_b);
+}
+
+/* ---------------------------------------------------------------------- */
+/* main                                                                    */
+/* ---------------------------------------------------------------------- */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    /* Initialisation */
+    RUN_TEST(test_init_returns_ok);
+
+    /* Solid-colour modes */
+    RUN_TEST(test_mode_off_output_dark);
+    RUN_TEST(test_mode_usb_error_output_red_solid);
+    RUN_TEST(test_mode_bridging_output_green_solid);
+    RUN_TEST(test_usb_error_stays_red_across_multiple_updates);
+    RUN_TEST(test_bridging_stays_green_across_multiple_updates);
+
+    /* Refresh call */
+    RUN_TEST(test_update_calls_refresh);
+
+    /* Mode transitions */
+    RUN_TEST(test_mode_transition_off_to_bridging);
+    RUN_TEST(test_mode_transition_error_to_off);
+
+    /* Blink toggling */
+    RUN_TEST(test_scanning_blink_toggles_over_slow_period);
+    RUN_TEST(test_connected_no_usb_blink_toggles_slow);
+    RUN_TEST(test_connected_usb_blink_toggles_fast);
+
+    /* Flash */
+    RUN_TEST(test_flash_sets_color_then_clears);
+    RUN_TEST(test_flash_does_not_affect_current_mode);
+
+    int failures = UNITY_END();
+    return (failures > 0) ? 1 : 0;
+}

--- a/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/unity_compat.h
+++ b/packages/esp32-projects/xbox-switch-bridge/components/status_led/test/unity_compat.h
@@ -1,0 +1,86 @@
+/**
+ * @file unity_compat.h
+ * @brief Minimal Unity-compatible test framework for host-based testing.
+ *
+ * Provides a subset of the Unity API that compiles without the full Unity
+ * library. This allows running hardware-driver tests on the host (Linux/macOS)
+ * without ESP-IDF. Compatible macro names make migration to full ESP-IDF Unity
+ * straightforward.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int _unity_total    = 0;
+static int _unity_failures = 0;
+
+static void _unity_begin(void)
+{
+    _unity_total    = 0;
+    _unity_failures = 0;
+    printf("\n-----------------------\n");
+    printf("Running host unit tests\n");
+    printf("-----------------------\n\n");
+}
+
+static int _unity_end(void)
+{
+    printf("\n-----------------------\n");
+    printf("%d Tests %d Failures\n", _unity_total, _unity_failures);
+    printf("%s\n", _unity_failures == 0 ? "OK" : "FAIL");
+    printf("-----------------------\n\n");
+    return _unity_failures;
+}
+
+#define UNITY_BEGIN() _unity_begin()
+#define UNITY_END()   _unity_end()
+
+#define RUN_TEST(fn)                 \
+    do {                             \
+        printf("TEST(%s)\n", #fn);   \
+        fn();                        \
+    } while (0)
+
+#define _UNITY_FAIL(fmt, ...)                                                      \
+    do {                                                                           \
+        _unity_failures++;                                                         \
+        printf("  FAIL at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    } while (0)
+
+#define TEST_ASSERT_TRUE(cond)       \
+    do {                             \
+        _unity_total++;              \
+        if (!(cond))                 \
+            _UNITY_FAIL("expected TRUE was FALSE"); \
+    } while (0)
+
+#define TEST_ASSERT_FALSE(cond) TEST_ASSERT_TRUE(!(cond))
+
+#define TEST_ASSERT_EQUAL(expected, actual)                             \
+    do {                                                                \
+        _unity_total++;                                                 \
+        if ((int64_t)(expected) != (int64_t)(actual))                  \
+            _UNITY_FAIL("expected %lld was %lld",                      \
+                        (long long)(expected), (long long)(actual));   \
+    } while (0)
+
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                         \
+    do {                                                                \
+        _unity_total++;                                                 \
+        if ((int64_t)(expected) == (int64_t)(actual))                  \
+            _UNITY_FAIL("expected values to differ (both %lld)",       \
+                        (long long)(actual));                           \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_UINT8  TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT    TEST_ASSERT_EQUAL
+
+#define TEST_ASSERT_NOT_NULL(ptr)                       \
+    do {                                                \
+        _unity_total++;                                 \
+        if ((ptr) == NULL)                              \
+            _UNITY_FAIL("expected non-NULL pointer");  \
+    } while (0)

--- a/packages/shared-libs/robocar-i2c-protocol/include/i2c_protocol.h
+++ b/packages/shared-libs/robocar-i2c-protocol/include/i2c_protocol.h
@@ -82,7 +82,7 @@ typedef struct __attribute__((packed)) {
 // Display command data
 typedef struct __attribute__((packed)) {
     uint8_t line;      // Display line 0-7
-    char message[27];  // Message text (null-terminated)
+    char message[25];  // Message text (null-terminated, max 24 chars)
 } display_data_t;
 
 // Status response data

--- a/packages/shared-libs/robocar-i2c-protocol/test/Makefile
+++ b/packages/shared-libs/robocar-i2c-protocol/test/Makefile
@@ -1,0 +1,31 @@
+# Makefile for robocar-i2c-protocol host-based unit tests
+#
+# Compiles i2c_protocol.c for Linux/macOS using gcc and runs Unity-compatible
+# tests without ESP-IDF or hardware. Suitable for CI and local development.
+#
+# Usage:
+#   make test     — build and run tests (default)
+#   make clean    — remove build artefacts
+
+CC     = gcc
+CFLAGS = -std=c11 -Wall -Wextra \
+         -Wno-unused-function \
+         -I../include \
+         -Istubs \
+         -I.
+
+SRCS   = test_i2c_protocol.c ../i2c_protocol.c
+TARGET = test_runner
+
+.PHONY: all test clean
+
+all: test
+
+test: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS) unity_compat.h stubs/esp_log.h
+	$(CC) $(CFLAGS) -o $@ $(SRCS)
+
+clean:
+	rm -f $(TARGET)

--- a/packages/shared-libs/robocar-i2c-protocol/test/stubs/esp_log.h
+++ b/packages/shared-libs/robocar-i2c-protocol/test/stubs/esp_log.h
@@ -1,0 +1,14 @@
+/**
+ * @file esp_log.h
+ * @brief Stub for ESP-IDF logging — prints to stderr/stdout for host tests.
+ */
+#pragma once
+
+#include <stdio.h>
+
+/* cppcheck-suppress [missingIncludeSystem] */
+#define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "[E][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "[W][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) fprintf(stdout, "[I][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) /* debug suppressed in host tests */
+#define ESP_LOGV(tag, fmt, ...) /* verbose suppressed in host tests */

--- a/packages/shared-libs/robocar-i2c-protocol/test/test_i2c_protocol.c
+++ b/packages/shared-libs/robocar-i2c-protocol/test/test_i2c_protocol.c
@@ -1,0 +1,537 @@
+/**
+ * @file test_i2c_protocol.c
+ * @brief Host-based unit tests for the robocar i2c_protocol component.
+ *
+ * Tests pure protocol logic: XOR checksum, packet construction, value
+ * clamping, null-safety, and struct sizes. No hardware required.
+ *
+ * Build and run: make test
+ */
+
+#include <string.h>
+
+#include "i2c_protocol.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Verify that a packet's checksum field matches its content. */
+static void assert_packet_checksum_valid(const i2c_command_packet_t *p)
+{
+    uint8_t computed = calculate_checksum((const uint8_t *)p, sizeof(*p) - 1);
+    TEST_ASSERT_EQUAL(computed, p->checksum);
+}
+
+/* ------------------------------------------------------------------ */
+/* calculate_checksum                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_checksum_empty_buffer(void)
+{
+    /* XOR identity: empty input → 0 */
+    TEST_ASSERT_EQUAL(0, calculate_checksum((const uint8_t *)"", 0));
+}
+
+static void test_checksum_single_byte(void)
+{
+    uint8_t buf[] = {0xAB};
+    TEST_ASSERT_EQUAL(0xAB, calculate_checksum(buf, 1));
+}
+
+static void test_checksum_xor_cancels(void)
+{
+    /* 0xFF ^ 0xFF == 0x00 */
+    uint8_t buf[] = {0xFF, 0xFF};
+    TEST_ASSERT_EQUAL(0x00, calculate_checksum(buf, 2));
+}
+
+static void test_checksum_multi_byte(void)
+{
+    /* 0x01 ^ 0x02 = 0x03, 0x03 ^ 0x04 = 0x07 */
+    uint8_t buf[] = {0x01, 0x02, 0x04};
+    TEST_ASSERT_EQUAL(0x07, calculate_checksum(buf, 3));
+}
+
+static void test_checksum_full_byte_range(void)
+{
+    uint8_t buf[] = {0x00, 0xFF, 0xAA, 0x55};
+    /* 0x00 ^ 0xFF = 0xFF, 0xFF ^ 0xAA = 0x55, 0x55 ^ 0x55 = 0x00 */
+    TEST_ASSERT_EQUAL(0x00, calculate_checksum(buf, 4));
+}
+
+/* ------------------------------------------------------------------ */
+/* verify_checksum                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_verify_checksum_correct(void)
+{
+    uint8_t buf[] = {0x01, 0x02, 0x04};
+    uint8_t cs    = calculate_checksum(buf, 3);
+    TEST_ASSERT_TRUE(verify_checksum(buf, 3, cs));
+}
+
+static void test_verify_checksum_wrong(void)
+{
+    uint8_t buf[] = {0x01, 0x02, 0x04};
+    TEST_ASSERT_FALSE(verify_checksum(buf, 3, 0xFF));
+}
+
+static void test_verify_checksum_zero_length(void)
+{
+    /* Empty buffer: XOR of nothing is 0, checksum 0 is correct */
+    TEST_ASSERT_TRUE(verify_checksum((const uint8_t *)"", 0, 0));
+}
+
+static void test_verify_checksum_round_trip(void)
+{
+    /* Any buffer should round-trip correctly */
+    uint8_t buf[] = {0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x42};
+    uint8_t cs    = calculate_checksum(buf, sizeof(buf));
+    TEST_ASSERT_TRUE(verify_checksum(buf, sizeof(buf), cs));
+}
+
+/* ------------------------------------------------------------------ */
+/* prepare_movement_command                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_movement_command_fields(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_movement_command(&pkt, MOVE_FORWARD, 128, 0x01);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_MOVEMENT, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x01, pkt.sequence_number);
+    TEST_ASSERT_EQUAL(sizeof(movement_data_t), pkt.data_length);
+
+    const movement_data_t *d = (const movement_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(MOVE_FORWARD, d->movement);
+    TEST_ASSERT_EQUAL(128, d->speed);
+}
+
+static void test_movement_command_checksum_valid(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_movement_command(&pkt, MOVE_BACKWARD, 255, 0x42);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_movement_command_null_packet(void)
+{
+    /* Must not crash */
+    prepare_movement_command(NULL, MOVE_FORWARD, 100, 0);
+}
+
+static void test_movement_all_commands_round_trip(void)
+{
+    movement_command_t cmds[] = {MOVE_FORWARD,    MOVE_BACKWARD, MOVE_LEFT,
+                                 MOVE_RIGHT,      MOVE_ROTATE_CW, MOVE_ROTATE_CCW,
+                                 MOVE_STOP};
+    for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+        i2c_command_packet_t pkt = {0};
+        prepare_movement_command(&pkt, cmds[i], (uint8_t)(i * 32), (uint8_t)i);
+
+        const movement_data_t *d = (const movement_data_t *)pkt.data;
+        TEST_ASSERT_EQUAL(cmds[i], d->movement);
+        assert_packet_checksum_valid(&pkt);
+    }
+}
+
+static void test_movement_speed_max(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_movement_command(&pkt, MOVE_FORWARD, 255, 0x00);
+
+    const movement_data_t *d = (const movement_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(255, d->speed);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_movement_speed_zero(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_movement_command(&pkt, MOVE_STOP, 0, 0x00);
+
+    const movement_data_t *d = (const movement_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(0, d->speed);
+    assert_packet_checksum_valid(&pkt);
+}
+
+/* ------------------------------------------------------------------ */
+/* prepare_sound_command                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_sound_command_beep(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_sound_command(&pkt, SOUND_BEEP, 0x10);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_SOUND, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x10, pkt.sequence_number);
+    TEST_ASSERT_EQUAL(sizeof(sound_data_t), pkt.data_length);
+
+    const sound_data_t *d = (const sound_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(SOUND_BEEP, d->sound_type);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_sound_command_all_types(void)
+{
+    sound_command_t sounds[] = {SOUND_BEEP, SOUND_MELODY, SOUND_ALERT};
+    for (size_t i = 0; i < sizeof(sounds) / sizeof(sounds[0]); i++) {
+        i2c_command_packet_t pkt = {0};
+        prepare_sound_command(&pkt, sounds[i], (uint8_t)i);
+
+        const sound_data_t *d = (const sound_data_t *)pkt.data;
+        TEST_ASSERT_EQUAL(sounds[i], d->sound_type);
+        assert_packet_checksum_valid(&pkt);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* prepare_servo_command — angle clamping                             */
+/* ------------------------------------------------------------------ */
+
+static void test_servo_command_normal_angle(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_servo_command(&pkt, SERVO_PAN, 90, 0x05);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_SERVO, pkt.command_type);
+    const servo_data_t *d = (const servo_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(SERVO_PAN, d->servo_type);
+    TEST_ASSERT_EQUAL(90, d->angle);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_servo_command_clamps_over_180(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_servo_command(&pkt, SERVO_TILT, 200, 0x06);
+
+    const servo_data_t *d = (const servo_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(180, d->angle);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_servo_command_accepts_180(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_servo_command(&pkt, SERVO_TILT, 180, 0x07);
+
+    const servo_data_t *d = (const servo_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(180, d->angle);
+}
+
+static void test_servo_command_accepts_0(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_servo_command(&pkt, SERVO_PAN, 0, 0x08);
+
+    const servo_data_t *d = (const servo_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(0, d->angle);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_servo_command_extreme_over_180(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_servo_command(&pkt, SERVO_PAN, 255, 0x09);
+
+    const servo_data_t *d = (const servo_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(180, d->angle);
+}
+
+/* ------------------------------------------------------------------ */
+/* prepare_display_command — line clamping, string handling           */
+/* ------------------------------------------------------------------ */
+
+static void test_display_command_normal(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_display_command(&pkt, 3, "Hello", 0x20);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_DISPLAY, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x20, pkt.sequence_number);
+
+    const display_data_t *d = (const display_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(3, d->line);
+    TEST_ASSERT_EQUAL_STRING("Hello", d->message);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_display_command_clamps_line_over_7(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_display_command(&pkt, 10, "Test", 0x21);
+
+    const display_data_t *d = (const display_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(7, d->line);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_display_command_accepts_line_7(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_display_command(&pkt, 7, "Max line", 0x22);
+
+    const display_data_t *d = (const display_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(7, d->line);
+}
+
+static void test_display_command_accepts_line_0(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_display_command(&pkt, 0, "Min line", 0x23);
+
+    const display_data_t *d = (const display_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(0, d->line);
+}
+
+static void test_display_command_truncates_long_message(void)
+{
+    i2c_command_packet_t pkt = {0};
+    /* 30 'A' chars — longer than the message field allows */
+    prepare_display_command(&pkt, 0, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", 0x24);
+
+    const display_data_t *d = (const display_data_t *)pkt.data;
+    /* Message must always be null-terminated within its array */
+    TEST_ASSERT_EQUAL('\0', d->message[sizeof(d->message) - 1]);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_display_command_empty_message(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_display_command(&pkt, 2, "", 0x25);
+
+    const display_data_t *d = (const display_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL('\0', d->message[0]);
+}
+
+static void test_display_command_null_message_no_crash(void)
+{
+    /* Should return early without crashing */
+    i2c_command_packet_t pkt = {0};
+    prepare_display_command(&pkt, 0, NULL, 0x26);
+}
+
+static void test_display_command_null_packet_no_crash(void)
+{
+    prepare_display_command(NULL, 0, "test", 0x27);
+}
+
+/* ------------------------------------------------------------------ */
+/* prepare_ping_command                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_ping_command(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_ping_command(&pkt, 0xFF);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_PING, pkt.command_type);
+    TEST_ASSERT_EQUAL(0xFF, pkt.sequence_number);
+    TEST_ASSERT_EQUAL(0, pkt.data_length);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_ping_command_null_no_crash(void)
+{
+    prepare_ping_command(NULL, 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* OTA commands                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_enter_maintenance_command(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_enter_maintenance_command(&pkt, 0x30);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_ENTER_MAINTENANCE_MODE, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x30, pkt.sequence_number);
+    TEST_ASSERT_EQUAL(0, pkt.data_length);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_begin_ota_command_short_tag(void)
+{
+    i2c_command_packet_t pkt  = {0};
+    uint8_t             hash[] = {0xAB, 0xCD, 0xEF, 0x12};
+    prepare_begin_ota_command(&pkt, "v1.2.3", hash, 0x31);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_BEGIN_OTA, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x31, pkt.sequence_number);
+
+    const ota_begin_data_t *d = (const ota_begin_data_t *)pkt.data;
+    TEST_ASSERT_EQUAL(6, d->tag_length); /* strlen("v1.2.3") = 6 */
+    TEST_ASSERT_EQUAL_MEMORY(hash, d->hash, OTA_HASH_LEN);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_begin_ota_command_null_hash_zeroed(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_begin_ota_command(&pkt, "v0.1.0", NULL, 0x32);
+
+    const ota_begin_data_t *d  = (const ota_begin_data_t *)pkt.data;
+    uint8_t                 zeros[OTA_HASH_LEN] = {0};
+    TEST_ASSERT_EQUAL_MEMORY(zeros, d->hash, OTA_HASH_LEN);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_begin_ota_command_null_tag_no_crash(void)
+{
+    i2c_command_packet_t pkt  = {0};
+    uint8_t             hash[] = {0, 0, 0, 0};
+    prepare_begin_ota_command(&pkt, NULL, hash, 0x33);
+}
+
+static void test_get_ota_status_command(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_get_ota_status_command(&pkt, 0x40);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_GET_OTA_STATUS, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x40, pkt.sequence_number);
+    TEST_ASSERT_EQUAL(0, pkt.data_length);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_get_version_command(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_get_version_command(&pkt, 0x41);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_GET_VERSION, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x41, pkt.sequence_number);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_reboot_command(void)
+{
+    i2c_command_packet_t pkt = {0};
+    prepare_reboot_command(&pkt, 0x42);
+
+    TEST_ASSERT_EQUAL(CMD_TYPE_REBOOT, pkt.command_type);
+    TEST_ASSERT_EQUAL(0x42, pkt.sequence_number);
+    TEST_ASSERT_EQUAL(0, pkt.data_length);
+    assert_packet_checksum_valid(&pkt);
+}
+
+/* ------------------------------------------------------------------ */
+/* Packet layout and sizes                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_command_packet_size(void)
+{
+    /* command_type(1) + sequence_number(1) + data_length(1)
+     * + data[26](26) + checksum(1) = 30 bytes */
+    TEST_ASSERT_EQUAL(30, (int)sizeof(i2c_command_packet_t));
+}
+
+static void test_response_packet_size(void)
+{
+    /* status(1) + sequence_number(1) + data_length(1)
+     * + data[13](13) + checksum(1) = 17 bytes */
+    TEST_ASSERT_EQUAL(17, (int)sizeof(i2c_response_packet_t));
+}
+
+static void test_data_structs_fit_in_max_data_len(void)
+{
+    TEST_ASSERT_TRUE((int)sizeof(movement_data_t) <= I2C_MAX_DATA_LEN);
+    TEST_ASSERT_TRUE((int)sizeof(sound_data_t) <= I2C_MAX_DATA_LEN);
+    TEST_ASSERT_TRUE((int)sizeof(servo_data_t) <= I2C_MAX_DATA_LEN);
+    TEST_ASSERT_TRUE((int)sizeof(display_data_t) <= I2C_MAX_DATA_LEN);
+    TEST_ASSERT_TRUE((int)sizeof(ota_begin_data_t) <= I2C_MAX_DATA_LEN);
+}
+
+static void test_sequence_number_stored_correctly(void)
+{
+    i2c_command_packet_t pkt = {0};
+
+    prepare_ping_command(&pkt, 0xAB);
+    TEST_ASSERT_EQUAL(0xAB, pkt.sequence_number);
+
+    prepare_ping_command(&pkt, 0x00);
+    TEST_ASSERT_EQUAL(0x00, pkt.sequence_number);
+
+    prepare_ping_command(&pkt, 0xFF);
+    TEST_ASSERT_EQUAL(0xFF, pkt.sequence_number);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    /* calculate_checksum */
+    RUN_TEST(test_checksum_empty_buffer);
+    RUN_TEST(test_checksum_single_byte);
+    RUN_TEST(test_checksum_xor_cancels);
+    RUN_TEST(test_checksum_multi_byte);
+    RUN_TEST(test_checksum_full_byte_range);
+
+    /* verify_checksum */
+    RUN_TEST(test_verify_checksum_correct);
+    RUN_TEST(test_verify_checksum_wrong);
+    RUN_TEST(test_verify_checksum_zero_length);
+    RUN_TEST(test_verify_checksum_round_trip);
+
+    /* Movement command */
+    RUN_TEST(test_movement_command_fields);
+    RUN_TEST(test_movement_command_checksum_valid);
+    RUN_TEST(test_movement_command_null_packet);
+    RUN_TEST(test_movement_all_commands_round_trip);
+    RUN_TEST(test_movement_speed_max);
+    RUN_TEST(test_movement_speed_zero);
+
+    /* Sound command */
+    RUN_TEST(test_sound_command_beep);
+    RUN_TEST(test_sound_command_all_types);
+
+    /* Servo command */
+    RUN_TEST(test_servo_command_normal_angle);
+    RUN_TEST(test_servo_command_clamps_over_180);
+    RUN_TEST(test_servo_command_accepts_180);
+    RUN_TEST(test_servo_command_accepts_0);
+    RUN_TEST(test_servo_command_extreme_over_180);
+
+    /* Display command */
+    RUN_TEST(test_display_command_normal);
+    RUN_TEST(test_display_command_clamps_line_over_7);
+    RUN_TEST(test_display_command_accepts_line_7);
+    RUN_TEST(test_display_command_accepts_line_0);
+    RUN_TEST(test_display_command_truncates_long_message);
+    RUN_TEST(test_display_command_empty_message);
+    RUN_TEST(test_display_command_null_message_no_crash);
+    RUN_TEST(test_display_command_null_packet_no_crash);
+
+    /* Ping command */
+    RUN_TEST(test_ping_command);
+    RUN_TEST(test_ping_command_null_no_crash);
+
+    /* OTA commands */
+    RUN_TEST(test_enter_maintenance_command);
+    RUN_TEST(test_begin_ota_command_short_tag);
+    RUN_TEST(test_begin_ota_command_null_hash_zeroed);
+    RUN_TEST(test_begin_ota_command_null_tag_no_crash);
+    RUN_TEST(test_get_ota_status_command);
+    RUN_TEST(test_get_version_command);
+    RUN_TEST(test_reboot_command);
+
+    /* Packet layout */
+    RUN_TEST(test_command_packet_size);
+    RUN_TEST(test_response_packet_size);
+    RUN_TEST(test_data_structs_fit_in_max_data_len);
+    RUN_TEST(test_sequence_number_stored_correctly);
+
+    int failures = UNITY_END();
+    return (failures > 0) ? 1 : 0;
+}

--- a/packages/shared-libs/robocar-i2c-protocol/test/unity_compat.h
+++ b/packages/shared-libs/robocar-i2c-protocol/test/unity_compat.h
@@ -1,0 +1,116 @@
+/**
+ * @file unity_compat.h
+ * @brief Minimal Unity-compatible test framework for host-based testing.
+ *
+ * Provides a subset of the Unity API that compiles without the full Unity
+ * library. This allows running protocol and logic tests on the host (Linux/macOS)
+ * without ESP-IDF. Compatible macro names make migration to full ESP-IDF Unity
+ * straightforward.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int _unity_total    = 0;
+static int _unity_failures = 0;
+
+static void _unity_begin(void)
+{
+    _unity_total    = 0;
+    _unity_failures = 0;
+    printf("\n-----------------------\n");
+    printf("Running host unit tests\n");
+    printf("-----------------------\n\n");
+}
+
+static int _unity_end(void)
+{
+    printf("\n-----------------------\n");
+    printf("%d Tests %d Failures\n", _unity_total, _unity_failures);
+    printf("%s\n", _unity_failures == 0 ? "OK" : "FAIL");
+    printf("-----------------------\n\n");
+    return _unity_failures;
+}
+
+#define UNITY_BEGIN() _unity_begin()
+#define UNITY_END()   _unity_end()
+
+#define RUN_TEST(fn)                 \
+    do {                             \
+        printf("TEST(%s)\n", #fn);   \
+        fn();                        \
+    } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Internal failure reporter                                               */
+/* ---------------------------------------------------------------------- */
+#define _UNITY_FAIL(fmt, ...)                                                      \
+    do {                                                                           \
+        _unity_failures++;                                                         \
+        printf("  FAIL at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Assertion macros                                                        */
+/* ---------------------------------------------------------------------- */
+#define TEST_ASSERT_TRUE(cond)       \
+    do {                             \
+        _unity_total++;              \
+        if (!(cond))                 \
+            _UNITY_FAIL("expected TRUE was FALSE"); \
+    } while (0)
+
+#define TEST_ASSERT_FALSE(cond) TEST_ASSERT_TRUE(!(cond))
+
+#define TEST_ASSERT_EQUAL(expected, actual)                             \
+    do {                                                                \
+        _unity_total++;                                                 \
+        if ((int64_t)(expected) != (int64_t)(actual))                  \
+            _UNITY_FAIL("expected %lld was %lld",                      \
+                        (long long)(expected), (long long)(actual));   \
+    } while (0)
+
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                         \
+    do {                                                                \
+        _unity_total++;                                                 \
+        if ((int64_t)(expected) == (int64_t)(actual))                  \
+            _UNITY_FAIL("expected values to differ (both %lld)",       \
+                        (long long)(actual));                           \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_UINT8  TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_UINT16 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_UINT32 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT    TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT8   TEST_ASSERT_EQUAL
+
+#define TEST_ASSERT_NULL(ptr)                           \
+    do {                                                \
+        _unity_total++;                                 \
+        if ((ptr) != NULL)                              \
+            _UNITY_FAIL("expected NULL pointer");       \
+    } while (0)
+
+#define TEST_ASSERT_NOT_NULL(ptr)                       \
+    do {                                                \
+        _unity_total++;                                 \
+        if ((ptr) == NULL)                              \
+            _UNITY_FAIL("expected non-NULL pointer");  \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_STRING(expected, actual)                               \
+    do {                                                                         \
+        _unity_total++;                                                          \
+        if (strcmp((expected), (actual)) != 0)                                   \
+            _UNITY_FAIL("expected \"%s\" was \"%s\"", (expected), (actual));    \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)             \
+    do {                                                            \
+        _unity_total++;                                             \
+        if (memcmp((expected), (actual), (size_t)(len)) != 0)      \
+            _UNITY_FAIL("memory blocks differ (%d bytes)", (int)(len)); \
+    } while (0)


### PR DESCRIPTION
Closes #114

Adds host-based unit tests for two key components using gcc + Makefile (no ESP-IDF or hardware needed):

- `robocar-i2c-protocol`: 102 tests (checksum, packet building, clamping, OTA commands, struct sizes)
- `status_led`: 96 tests (solid modes, blink toggling, mode transitions, flash)

Also fixes a pre-existing bug where `display_data_t.message[27]` overflowed the 26-byte `I2C_MAX_DATA_LEN` packet data field (the `_Static_assert` in i2c_protocol.c correctly caught this but ESP32 builds weren't running in CI).

> **Note:** The `.github/workflows/test.yml` CI update to run these tests automatically requires the `workflows` permission - see the issue comment for the diff to apply manually.

Generated with [Claude Code](https://claude.ai/code)