### PR TITLE
chore: gitignore ESP-IDF managed_components directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ target/
 # ESP-IDF
 sdkconfig
 sdkconfig.old
+managed_components/
 
 # Credentials and sensitive files
 **/credentials.h


### PR DESCRIPTION
## Summary
- Add `managed_components/` to `.gitignore` under the ESP-IDF section
- This is an auto-generated directory created by the ESP-IDF component manager during builds (similar to `node_modules/`)

## Test plan
- [x] Verify `managed_components/` no longer shows as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)