### PR TITLE
fix: stop timer stamp from corrupting 0x81 USB handshake replies

### DIFF
--- a/packages/esp32-projects/switch-usb-proxy/main/main.c
+++ b/packages/esp32-projects/switch-usb-proxy/main/main.c
@@ -513,7 +513,11 @@ static void input_report_task(void *arg)
     while (1) {
         /* Priority 1: retry a previously failed reply send */
         if (have_pending_reply && tud_hid_ready()) {
-            pending_reply.data[0] = s_timer_counter++;
+            /* Only stamp timer for 0x21 reports — 0x81 replies use data[0]
+             * as the sub-command echo byte and must not be overwritten. */
+            if (pending_reply.report_id == REPORT_ID_SUBCMD_REPLY) {
+                pending_reply.data[0] = s_timer_counter++;
+            }
             bool ok = tud_hid_report(pending_reply.report_id, pending_reply.data,
                                      pending_reply.len);
             if (ok) {
@@ -535,7 +539,9 @@ static void input_report_task(void *arg)
                 vTaskDelay(1);
                 continue;
             }
-            pending_reply.data[0] = s_timer_counter++;
+            if (pending_reply.report_id == REPORT_ID_SUBCMD_REPLY) {
+                pending_reply.data[0] = s_timer_counter++;
+            }
             bool ok = tud_hid_report(pending_reply.report_id, pending_reply.data,
                                      pending_reply.len);
             if (ok) {
@@ -548,7 +554,10 @@ static void input_report_task(void *arg)
             continue;
         }
 
-        /* Priority 3: wait for handshake before sending 0x30 reports */
+        /* Priority 3: wait for handshake before sending 0x30 reports.
+         * The Switch needs continuous 0x30 keepalive reports to proceed
+         * with setup (SPI reads, IMU, player lights). The reply queue
+         * priority above ensures 0x21 replies are sent first. */
         if (!tud_mounted() || !s_handshake_complete) {
             vTaskDelay(pdMS_TO_TICKS(1));
             continue;


### PR DESCRIPTION
## Summary

- Fix `input_report_task` unconditionally overwriting `data[0]` with `s_timer_counter` for all queued replies, including 0x81 USB handshake replies where `data[0]` must be the sub-command echo byte
- Guard timer stamp to only apply to 0x21 subcommand replies (where `data[0]` is a timer placeholder)
- The bug caused the Switch to not recognize the Status reply and stall the USB handshake at Phase 1

## Root cause

`data[0]` has different semantics per report type:
- **0x21 reports**: `data[0]` = timer counter (placeholder, should be stamped)
- **0x81 reports**: `data[0]` = sub-command echo (0x01=Status, 0x02=Handshake — must not be overwritten)

The unconditional `pending_reply.data[0] = s_timer_counter++` corrupted 0x81 replies, so the Switch received `[0x81, <timer>, ...]` instead of `[0x81, 0x01, ...]` for Status.

## Test plan

- [ ] USB handshake completes: Status → Handshake → Force USB
- [ ] Setup subcommands flow: device info, SPI reads, IMU, vibration, player lights
- [ ] Controller registers on Switch (L+R press after setup)
- [ ] No Switch crash (error 2162-0002) on connect

🤖 Generated with [Claude Code](https://claude.com/claude-code)