### PR TITLE
docs: add datasheet reference index for all project hardware components

### DIFF
--- a/docs/datasheets/README.md
+++ b/docs/datasheets/README.md
@@ -1,0 +1,40 @@
+# Datasheets
+
+Reference index for all hardware components used in this project.
+
+## Naming Scheme
+
+Files use a flat `category--component-name.md` convention:
+
+| Prefix | Category |
+|--------|----------|
+| `board--` | Development boards and modules |
+| `mcu--` | Microcontroller/SoC silicon datasheets |
+| `camera--` | Image sensors |
+| `display--` | Display controllers |
+| `driver--` | Motor drivers, PWM controllers, LED drivers |
+| `actuator--` | Servos, motors |
+| `power--` | Voltage regulators, converters |
+| `radio--` | LoRa, WiFi, BLE transceivers |
+| `led--` | Addressable/smart LEDs |
+
+## Components
+
+### Boards
+- [Heltec WiFi LoRa 32 V1](board--heltec-wifi-lora-32-v1.md) — Main controller
+- [ESP32-CAM AI Thinker](board--esp32-cam-ai-thinker.md) — Camera module
+- [Waveshare ESP32-S3-Zero](board--waveshare-esp32-s3-zero.md) — IT troubleshooter / Xbox-Switch bridge
+
+### MCUs
+- [ESP32](mcu--esp32.md) — Dual-core LX6, WiFi + BT (Heltec, ESP32-CAM)
+- [ESP32-S3](mcu--esp32-s3.md) — Dual-core LX7, WiFi + BLE 5 (Waveshare S3-Zero)
+
+### Peripherals
+- [OV2640](camera--ov2640.md) — 2MP CMOS image sensor
+- [SSD1306](display--ssd1306.md) — 128x64 OLED controller
+- [PCA9685](driver--pca9685.md) — 16-ch 12-bit PWM/servo driver
+- [TB6612FNG](driver--tb6612fng.md) — Dual DC motor driver
+- [SG90](actuator--sg90.md) — 9g micro servo
+- [XL6009](power--xl6009.md) — DC-DC boost converter
+- [SX1276](radio--sx1276.md) — LoRa transceiver
+- [WS2812B](led--ws2812b.md) — Addressable RGB LED

--- a/docs/datasheets/actuator--sg90.md
+++ b/docs/datasheets/actuator--sg90.md
@@ -1,0 +1,34 @@
+# SG90 — 9g Micro Servo
+
+**Manufacturer:** TowerPro
+**Used in:** Robocar pan/tilt camera mount (via PCA9685 ch 6–7)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Weight | 9 g |
+| Dimensions | 22.2 x 11.8 x 31 mm |
+| Rotation | 180° |
+| Torque (4.8V) | 1.8 kg-cm |
+| Torque (6.0V) | 2.4 kg-cm |
+| Speed (4.8V) | 0.12 sec/60° |
+| Speed (6.0V) | 0.10 sec/60° |
+| Voltage | 4.8–6.0V |
+| PWM frequency | 50 Hz (20 ms period) |
+| Pulse range | 500–2400 µs |
+| Dead band | 1 µs |
+| Gear type | Plastic |
+
+## Wiring
+
+| Wire color | Function |
+|------------|----------|
+| Red | VCC (5V) |
+| Brown/Black | GND |
+| Orange | PWM signal |
+
+## Datasheets & References
+
+- **Datasheet PDF:** <https://handsontec.com/dataspecs/motor_fan/SG90-Servo.pdf>
+- **Datasheet PDF (alt):** <http://www.ee.ic.ac.uk/pcheung/teaching/DE1_EE/stores/sg90_datasheet.pdf>

--- a/docs/datasheets/board--esp32-cam-ai-thinker.md
+++ b/docs/datasheets/board--esp32-cam-ai-thinker.md
@@ -1,0 +1,34 @@
+# ESP32-CAM (AI Thinker)
+
+**Role in project:** Camera module for robocar vision system (OV2640 capture, AI inference, MQTT)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| MCU | ESP32-S (dual-core LX6, 240 MHz) |
+| Flash | 4 MB |
+| PSRAM | 4 MB (IPUS) |
+| Camera | OV2640 (2MP) |
+| Storage | MicroSD slot |
+| WiFi | 802.11 b/g/n |
+| Bluetooth | BT 4.2 + BLE |
+| USB | None (requires external FTDI for programming) |
+
+## Pin Assignments (project-specific)
+
+- **UART to main controller:** TX=GPIO14, RX=GPIO15 (chosen to avoid PSRAM conflicts)
+- **Camera flash LED:** GPIO4
+- **Red status LED:** GPIO33 (active low)
+- **Camera power down:** GPIO32
+
+## Safe GPIOs for General Use
+
+GPIO2, GPIO16, GPIO17 (most flexible, no conflicts with camera/PSRAM)
+
+## Datasheets & References
+
+- **Pinout guide:** <https://randomnerdtutorials.com/esp32-cam-ai-thinker-pinout/>
+- **Datasheet & specs:** <https://components101.com/modules/esp32-cam-camera-module>
+- **Pin notes (detailed):** <https://github.com/raphaelbs/esp32-cam-ai-thinker/blob/master/docs/esp32cam-pin-notes.md>
+- **Pinout reference:** <https://lastminuteengineers.com/esp32-cam-pinout-reference/>

--- a/docs/datasheets/board--heltec-wifi-lora-32-v1.md
+++ b/docs/datasheets/board--heltec-wifi-lora-32-v1.md
@@ -1,0 +1,26 @@
+# Heltec WiFi LoRa 32 V1
+
+**Role in project:** Main controller for the robocar (motor control, OLED, buzzer, PCA9685)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| MCU | ESP32 (dual-core LX6, 240 MHz) |
+| Flash | 4 MB |
+| LoRa | SX1276 (868/915 MHz) |
+| Display | SSD1306 128x64 OLED (I2C) |
+| WiFi | 802.11 b/g/n |
+| Bluetooth | BT 4.2 + BLE |
+| USB | Micro-USB (CP2102 bridge) |
+
+## Pin Assignments (project-specific)
+
+- **OLED:** SDA=GPIO4, SCL=GPIO15, RST=GPIO16
+- **LoRa SPI:** SCK=GPIO5, MISO=GPIO19, MOSI=GPIO27, CS=GPIO18, RST=GPIO14, DIO0=GPIO26
+
+## Datasheets & References
+
+- **V1 Pinout PDF:** <https://resource.heltec.cn/download/WiFi_LoRa_32/WIFI_LoRa_32_V1.pdf>
+- **Official docs hub:** <https://docs.heltec.org/en/node/esp32/wifi_lora_32/index.html>
+- **Hardware revision log:** <https://docs.heltec.org/en/node/esp32/hardware_update_log.html>

--- a/docs/datasheets/board--waveshare-esp32-s3-zero.md
+++ b/docs/datasheets/board--waveshare-esp32-s3-zero.md
@@ -1,0 +1,29 @@
+# Waveshare ESP32-S3-Zero
+
+**Role in project:** IT troubleshooter, Xbox-Switch bridge
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| MCU | ESP32-S3FH4R2 (dual-core LX7, 240 MHz) |
+| Flash | 4 MB |
+| PSRAM | 2 MB |
+| WiFi | 802.11 b/g/n |
+| Bluetooth | BLE 5.0 |
+| USB | Type-C (native USB, no bridge chip) |
+| LED | WS2812 RGB on GPIO21 |
+| Antenna | Onboard ceramic |
+| Form factor | Castellated (stamp hole) |
+
+## Pin Notes
+
+- GPIO33–GPIO37 are **not exposed** (used for Octal PSRAM)
+- UART0: TX=GPIO43, RX=GPIO44
+
+## Datasheets & References
+
+- **Wiki:** <https://www.waveshare.com/wiki/ESP32-S3-Zero>
+- **Schematic PDF:** <https://files.waveshare.com/wiki/ESP32-S3-Zero/ESP32-S3-Zero-Sch.pdf>
+- **Product page:** <https://www.waveshare.com/esp32-s3-zero.htm>
+- **Documentation platform:** <https://docs.waveshare.com/ESP32-S3-Zero>

--- a/docs/datasheets/camera--ov2640.md
+++ b/docs/datasheets/camera--ov2640.md
@@ -1,0 +1,23 @@
+# OV2640 — 2MP CMOS Image Sensor
+
+**Manufacturer:** OmniVision Technologies
+**Used in:** ESP32-CAM module (robocar vision system)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Resolution | UXGA 1632x1232 (2MP) |
+| Technology | OmniPixel2 |
+| Output formats | YUV, RGB565/555, GRB422, Raw RGB |
+| Interface | SCCB (I2C-compatible) |
+| I2C address | 0x30 (write: 0x60, read: 0x61) |
+| Package | 38-ball CSP2 |
+| Supply | AVDD 2.8V, DVDD 1.3V, DOVDD 1.8–3.0V |
+| Features | Built-in JPEG compression engine |
+
+## Datasheets & References
+
+- **Datasheet (2007 rev):** <https://www.uctronics.com/download/OV2640_DS.pdf>
+- **Datasheet (v1.6, Feb 2006):** <https://www.uctronics.com/download/cam_module/OV2640DS.pdf>
+- **OmniVision product brief:** <https://www.ovt.com/wp-content/uploads/2021/01/OV2640-Volume-Production-FINAL.pdf>

--- a/docs/datasheets/display--ssd1306.md
+++ b/docs/datasheets/display--ssd1306.md
@@ -1,0 +1,23 @@
+# SSD1306 — 128x64 OLED/PLED Controller
+
+**Manufacturer:** Solomon Systech
+**Used in:** Heltec WiFi LoRa 32 V1 (integrated OLED)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Resolution | 128 segments x 64 commons |
+| Type | Common cathode OLED/PLED |
+| Interfaces | I2C, SPI (3/4-wire), 6800/8080 parallel |
+| I2C address | 0x3C (default on Heltec) |
+| Supply | 1.65–3.3V (logic), 7–15V (panel via charge pump) |
+| Charge pump | Built-in, supports 2.2V minimum Vcc |
+| Brightness | 256-step contrast control |
+| RAM | 128x64 bit display RAM (GDDRAM) |
+
+## Datasheets & References
+
+- **Datasheet PDF (Adafruit mirror):** <https://cdn-shop.adafruit.com/datasheets/SSD1306.pdf>
+- **Solomon Systech product page:** <https://www.solomon-systech.com/product/ssd1306>
+- **Datasheet PDF (BuyDisplay, v1.1):** <https://www.buydisplay.com/download/ic/SSD1306.pdf>

--- a/docs/datasheets/driver--pca9685.md
+++ b/docs/datasheets/driver--pca9685.md
@@ -1,0 +1,22 @@
+# PCA9685 — 16-Channel 12-bit PWM/Servo Driver
+
+**Manufacturer:** NXP Semiconductors
+**Used in:** Robocar main controller (RGB LED control on ch 0–5, pan/tilt servos on ch 6–7)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Channels | 16 independent PWM outputs |
+| Resolution | 12-bit (4096 steps) |
+| PWM frequency | 24 Hz – 1526 Hz (adjustable) |
+| Interface | I2C (Fm+ up to 1 MHz) |
+| I2C address | 0x40 (default), up to 62 devices via A0–A5 |
+| Supply | 2.3–5.5V, I/O 5.5V tolerant |
+| Output drive | 25 mA sink, 10 mA source (totem pole) |
+| Oscillator | Internal 25 MHz, external clock input up to 50 MHz |
+
+## Datasheets & References
+
+- **Datasheet PDF (NXP, Rev. 4):** <https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf>
+- **Adafruit tutorial:** <https://cdn-learn.adafruit.com/downloads/pdf/16-channel-pwm-servo-driver.pdf>

--- a/docs/datasheets/driver--tb6612fng.md
+++ b/docs/datasheets/driver--tb6612fng.md
@@ -1,0 +1,24 @@
+# TB6612FNG — Dual DC Motor Driver
+
+**Manufacturer:** Toshiba
+**Used in:** Robocar main controller (left/right DC motor H-bridge control)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Channels | 2 (dual H-bridge) |
+| Output current | 1.2A avg / 3.2A peak per channel |
+| Supply voltage | VM up to 15V |
+| Logic voltage | 2.7–5.5V |
+| ON resistance | 0.5 Ω typical (upper + lower) |
+| Switching freq | Up to 100 kHz |
+| Control modes | CW, CCW, short brake, stop |
+| Package | SSOP24 (0.65mm pitch) |
+| Protection | Thermal shutdown, undervoltage lockout |
+
+## Datasheets & References
+
+- **Datasheet PDF (Toshiba official):** <https://toshiba.semicon-storage.com/info/TB6612FNG_datasheet_en_20141001.pdf?did=10660&prodName=TB6612FNG>
+- **Product page:** <https://toshiba.semicon-storage.com/us/semiconductor/product/motor-driver-ics/brushed-dc-motor-driver-ics/detail.TB6612FNG.html>
+- **SparkFun mirror:** <https://cdn.sparkfun.com/datasheets/Robotics/TB6612FNG.pdf>

--- a/docs/datasheets/led--ws2812b.md
+++ b/docs/datasheets/led--ws2812b.md
@@ -1,0 +1,24 @@
+# WS2812B — Addressable RGB LED
+
+**Manufacturer:** WorldSemi
+**Used in:** Waveshare ESP32-S3-Zero (status LED on GPIO21)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Type | Intelligent control LED (integrated driver + RGB) |
+| Package | 5050 SMD (also 2020, 3535 variants) |
+| Color depth | 256 levels/channel (16.7M colors) |
+| Data rate | 800 Kbps (NZR protocol) |
+| Cascade | 1024+ pixels at 30 fps |
+| Supply | 3.5–5.3V |
+| Current | ~60 mA max (RGB all on full) |
+| Refresh | ≥400 Hz |
+| Protection | Reverse polarity protection |
+| Signal | Built-in reshape circuit (no accumulation of distortion) |
+
+## Datasheets & References
+
+- **Datasheet PDF (WorldSemi):** <https://cdn.sparkfun.com/assets/e/6/1/f/4/WS2812B-LED-datasheet.pdf>
+- **Datasheet PDF (Adafruit mirror):** <https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf>

--- a/docs/datasheets/mcu--esp32-s3.md
+++ b/docs/datasheets/mcu--esp32-s3.md
@@ -1,0 +1,24 @@
+# ESP32-S3 (Xtensa LX7)
+
+**Used in:** Waveshare ESP32-S3-Zero
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Cores | Dual Xtensa 32-bit LX7 |
+| Clock | Up to 240 MHz |
+| SRAM | 512 KB |
+| ROM | 384 KB |
+| WiFi | 802.11 b/g/n |
+| Bluetooth | BLE 5.0 |
+| USB | USB OTG 1.1 |
+| Flash | External, up to 16 MB (Octal SPI) |
+| PSRAM | External, up to 16 MB (Octal SPI) |
+| AI acceleration | Vector instructions for neural networks |
+
+## Datasheets & References
+
+- **ESP32-S3 SoC datasheet (Espressif):** <https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf>
+- **ESP32-S3-WROOM-1 module datasheet:** <https://www.espressif.com/sites/default/files/documentation/esp32-s3-wroom-1_wroom-1u_datasheet_en.pdf>
+- **ESP32-S3 Technical Reference Manual:** <https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf>

--- a/docs/datasheets/mcu--esp32.md
+++ b/docs/datasheets/mcu--esp32.md
@@ -1,0 +1,24 @@
+# ESP32 (Xtensa LX6)
+
+**Used in:** Heltec WiFi LoRa 32 V1, ESP32-CAM AI Thinker
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Cores | Dual Xtensa 32-bit LX6 |
+| Clock | Up to 240 MHz |
+| SRAM | 520 KB |
+| WiFi | 802.11 b/g/n |
+| Bluetooth | BT 4.2 + BLE |
+| Flash | External, typically 4–16 MB |
+| ADC | Two 12-bit SAR ADCs, 18 channels |
+| GPIOs | 34 programmable |
+| Interfaces | SPI, I2C, I2S, UART, SDIO, PWM, etc. |
+
+## Datasheets & References
+
+- **ESP32 SoC datasheet (Espressif):** <https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf>
+- **ESP32-WROOM-32 module datasheet:** <https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32_datasheet_en.pdf>
+- **ESP32-WROOM-32D/32U module datasheet:** <https://www.espressif.com/sites/default/files/documentation/esp32-wroom-32d_esp32-wroom-32u_datasheet_en.pdf>
+- **ESP32 Technical Reference Manual:** <https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf>

--- a/docs/datasheets/power--xl6009.md
+++ b/docs/datasheets/power--xl6009.md
@@ -1,0 +1,23 @@
+# XL6009 — DC-DC Boost Converter
+
+**Manufacturer:** XLSEMI
+**Used in:** Robocar power system (7.4V LiPo → 5V for ESP32, motor driver, PCA9685, servos)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Topology | Boost / Buck-boost / Inverting |
+| Input voltage | 3.6–36V |
+| Output voltage | 5–35V (adjustable via potentiometer) |
+| Switching current | 4A max |
+| Switching frequency | 400 kHz (fixed) |
+| Efficiency | Up to 94% |
+| Load regulation | 0.5% |
+| Protection | Overcurrent, thermal |
+
+## Datasheets & References
+
+- **Datasheet PDF:** <https://www.haoyuelectronics.com/Attachment/XL6009/XL6009-DC-DC-Converter-Datasheet.pdf>
+- **Datasheet PDF (XLSEMI):** <https://beriled.biz/data/files/XL6009.pdf>
+- **Module datasheet:** <https://www.handsontec.com/dataspecs/power%20supply/XL6009-Buck-Boost.pdf>

--- a/docs/datasheets/radio--sx1276.md
+++ b/docs/datasheets/radio--sx1276.md
@@ -1,0 +1,27 @@
+# SX1276 — LoRa Transceiver
+
+**Manufacturer:** Semtech
+**Used in:** Heltec WiFi LoRa 32 V1 (integrated LoRa radio)
+
+## Key Specs
+
+| Parameter | Value |
+|-----------|-------|
+| Frequency | 137–1020 MHz |
+| Modulation | LoRa, FSK, GFSK, MSK, GMSK, OOK |
+| Link budget | 168 dB max |
+| TX power | +20 dBm (100 mW) |
+| Sensitivity | Down to -148 dBm |
+| Bit rate (FSK) | Up to 300 kbps |
+| Interface | SPI |
+| Packet engine | Up to 256 bytes with CRC |
+| RX current | 9.9 mA |
+| Sleep current | 200 nA (register retention) |
+| Package | QFN-28 |
+| Temperature | -40°C to +85°C |
+
+## Datasheets & References
+
+- **Semtech product page:** <https://www.semtech.com/products/wireless-rf/lora-connect/sx1276>
+- **Datasheet PDF (Rev. 7, May 2020):** <https://cdn.sparkfun.com/assets/7/7/3/2/2/SX1276_Datasheet.pdf>
+- **Datasheet PDF (Adafruit mirror):** <https://cdn-shop.adafruit.com/product-files/3179/sx1276_77_78_79.pdf>


### PR DESCRIPTION
Flat hierarchy using category--component-name.md naming convention.
Covers 12 components: 3 boards (Heltec, ESP32-CAM, Waveshare S3-Zero),
2 MCUs (ESP32, ESP32-S3), and 7 peripherals (OV2640, SSD1306, PCA9685,
TB6612FNG, SG90, XL6009, SX1276, WS2812B). Each file includes key specs,
project-specific notes, and links to official datasheets.

https://claude.ai/code/session_01CBgE8jHqVA9JEJXmnFygnf