### PR TITLE
feat: add Gemini Robotics-ER 1.5 as third AI backend for robocar-camera

### DIFF
--- a/packages/esp32-projects/robocar-camera/main/CMakeLists.txt
+++ b/packages/esp32-projects/robocar-camera/main/CMakeLists.txt
@@ -1,3 +1,3 @@
-idf_component_register(SRCS "main.c" "camera.c" "wifi_manager.c" "claude_api.c" "base64.c" "ai_response_parser.c" "i2c_master.c" "ai_backend.c" "ollama_backend.c" "ollama_discovery.c" "credentials_loader.c" "mqtt_logger.c" "system_state.c" "serial_comm.c" "ota_manager.c"
+idf_component_register(SRCS "main.c" "camera.c" "wifi_manager.c" "claude_api.c" "base64.c" "ai_response_parser.c" "i2c_master.c" "ai_backend.c" "ollama_backend.c" "ollama_discovery.c" "gemini_backend.c" "credentials_loader.c" "mqtt_logger.c" "system_state.c" "serial_comm.c" "ota_manager.c"
                     INCLUDE_DIRS "."
                     REQUIRES "esp32-camera" "esp_wifi" "esp_http_client" "json" "nvs_flash" "driver" "espressif__mdns" "mqtt" "esp_https_ota" "app_update" "robocar-i2c-protocol")

--- a/packages/esp32-projects/robocar-camera/main/Kconfig.projbuild
+++ b/packages/esp32-projects/robocar-camera/main/Kconfig.projbuild
@@ -16,6 +16,13 @@ menu "ESP32-CAM Robocar Configuration"
             help
                 Use local or remote Ollama server for image analysis.
                 Supports service discovery via mDNS.
+
+        config AI_BACKEND_GEMINI
+            bool "Gemini Robotics-ER"
+            help
+                Use Google Gemini Robotics-ER 1.5 for image analysis.
+                Optimized for spatial reasoning and robotics task planning.
+                Requires Gemini API key from Google AI Studio.
     endchoice
 
     config CONFIG_AI_BACKEND_CLAUDE
@@ -25,6 +32,10 @@ menu "ESP32-CAM Robocar Configuration"
     config CONFIG_AI_BACKEND_OLLAMA
         bool
         default y if AI_BACKEND_OLLAMA
+
+    config CONFIG_AI_BACKEND_GEMINI
+        bool
+        default y if AI_BACKEND_GEMINI
 
 endmenu
 

--- a/packages/esp32-projects/robocar-camera/main/ai_backend.c
+++ b/packages/esp32-projects/robocar-camera/main/ai_backend.c
@@ -11,6 +11,8 @@
 #include "claude_backend.h"
 #elif defined(CONFIG_AI_BACKEND_OLLAMA)
 #include "ollama_backend.h"
+#elif defined(CONFIG_AI_BACKEND_GEMINI)
+#include "gemini_backend.h"
 #endif
 
 const ai_backend_t *ai_backend_get_current(void)
@@ -19,6 +21,8 @@ const ai_backend_t *ai_backend_get_current(void)
     return claude_backend_get();
 #elif defined(CONFIG_AI_BACKEND_OLLAMA)
     return ollama_backend_get();
+#elif defined(CONFIG_AI_BACKEND_GEMINI)
+    return gemini_backend_get();
 #else
     // Default or error case
     return NULL;

--- a/packages/esp32-projects/robocar-camera/main/config.h
+++ b/packages/esp32-projects/robocar-camera/main/config.h
@@ -64,6 +64,10 @@
 #define OLLAMA_API_URL "http://192.168.0.115:11434/api/generate"
 #define OLLAMA_MODEL "gemma3:4b"
 
+// Gemini Robotics-ER Configuration
+#define GEMINI_API_URL "https://generativelanguage.googleapis.com/v1beta/models"
+#define GEMINI_MODEL "gemini-robotics-er-1.5-preview"
+
 // Ollama Service Discovery Configuration
 #define OLLAMA_USE_SERVICE_DISCOVERY 1                    // Enable SRV record discovery
 #define OLLAMA_SRV_RECORD "_ollama._tcp.local"            // SRV record for mDNS discovery

--- a/packages/esp32-projects/robocar-camera/main/credentials.h.example
+++ b/packages/esp32-projects/robocar-camera/main/credentials.h.example
@@ -12,7 +12,11 @@
 #define WIFI_SSID "your_wifi_network_name"
 #define WIFI_PASSWORD "your_wifi_password"
 
-// Claude API Configuration
+// Claude API Configuration (for Claude backend)
 #define CLAUDE_API_KEY "your_claude_api_key_from_anthropic"
+
+// Gemini API Configuration (for Gemini Robotics-ER backend)
+// Get your key from: https://aistudio.google.com/apikey
+#define GEMINI_API_KEY "your_gemini_api_key_from_google"
 
 #endif // CREDENTIALS_H

--- a/packages/esp32-projects/robocar-camera/main/credentials.h.template
+++ b/packages/esp32-projects/robocar-camera/main/credentials.h.template
@@ -24,12 +24,17 @@
 // CRITICAL: Rotate any exposed keys immediately
 #define CLAUDE_API_KEY "sk-ant-api03-YOUR_ACTUAL_API_KEY_HERE"
 
+// Gemini API Configuration
+// Get your API key from: https://aistudio.google.com/apikey
+#define GEMINI_API_KEY "YOUR_GEMINI_API_KEY_HERE"
+
 // Security Notes:
 // - Never share these credentials in public repositories
 // - Rotate API keys regularly (recommended: every 90 days)
 // - Use different credentials for development vs production
 // - For production deployment, use environment variables:
 //   export CLAUDE_API_KEY="your-key"
+//   export GEMINI_API_KEY="your-key"
 //   export WIFI_SSID="your-ssid"
 //   export WIFI_PASSWORD="your-password"
 

--- a/packages/esp32-projects/robocar-camera/main/credentials_loader.c
+++ b/packages/esp32-projects/robocar-camera/main/credentials_loader.c
@@ -58,10 +58,16 @@ static bool load_from_file(credentials_t *creds)
     strncpy(creds->claude_api_key, CLAUDE_API_KEY, MAX_API_KEY_LENGTH - 1);
     creds->claude_api_key[MAX_API_KEY_LENGTH - 1] = '\0';
     ESP_LOGI(TAG, "Loaded Claude API key from credentials.h");
-// Defensively clear any stack copy of the key string literal reference.
-// Future improvement: use NVS encryption to avoid storing keys in global RAM.
 #else
     ESP_LOGI(TAG, "Claude API key not configured - only required for Claude backend");
+#endif
+
+#ifdef GEMINI_API_KEY
+    strncpy(creds->gemini_api_key, GEMINI_API_KEY, MAX_API_KEY_LENGTH - 1);
+    creds->gemini_api_key[MAX_API_KEY_LENGTH - 1] = '\0';
+    ESP_LOGI(TAG, "Loaded Gemini API key from credentials.h");
+#else
+    ESP_LOGI(TAG, "Gemini API key not configured - only required for Gemini backend");
 #endif
 
     return true;
@@ -87,8 +93,9 @@ bool load_credentials(credentials_t *creds)
     if (!load_from_env("WIFI_PASSWORD", creds->wifi_password, MAX_PASSWORD_LENGTH)) {
         env_loaded = false;
     }
-    // Claude API key is optional (for Ollama backend)
+    // API keys are optional — only needed for their respective backends
     load_from_env("CLAUDE_API_KEY", creds->claude_api_key, MAX_API_KEY_LENGTH);
+    load_from_env("GEMINI_API_KEY", creds->gemini_api_key, MAX_API_KEY_LENGTH);
 
     if (env_loaded) {
         ESP_LOGI(TAG, "Successfully loaded credentials from environment variables");
@@ -141,6 +148,14 @@ bool validate_credentials(const credentials_t *creds)
     }
 #endif
 
+// Gemini API key validation (optional - only required for Gemini backend)
+#ifdef CONFIG_AI_BACKEND_GEMINI
+    if (strlen(creds->gemini_api_key) == 0) {
+        ESP_LOGE(TAG, "Gemini API key is required for Gemini backend but not provided");
+        return false;
+    }
+#endif
+
     ESP_LOGI(TAG, "Credentials validation successful");
     return true;
 }
@@ -184,4 +199,13 @@ const char *get_claude_api_key(void)
         return NULL;
     }
     return g_credentials.claude_api_key;
+}
+
+const char *get_gemini_api_key(void)
+{
+    if (!are_credentials_available()) {
+        ESP_LOGE(TAG, "Credentials not available");
+        return NULL;
+    }
+    return g_credentials.gemini_api_key;
 }

--- a/packages/esp32-projects/robocar-camera/main/credentials_loader.h
+++ b/packages/esp32-projects/robocar-camera/main/credentials_loader.h
@@ -25,6 +25,7 @@ typedef struct {
     char wifi_ssid[MAX_SSID_LENGTH];
     char wifi_password[MAX_PASSWORD_LENGTH];
     char claude_api_key[MAX_API_KEY_LENGTH];
+    char gemini_api_key[MAX_API_KEY_LENGTH];
     bool credentials_loaded;
 } credentials_t;
 
@@ -68,6 +69,13 @@ const char *get_wifi_password(void);
  * @return Pointer to Claude API key string
  */
 const char *get_claude_api_key(void);
+
+/**
+ * @brief Get Gemini API key
+ *
+ * @return Pointer to Gemini API key string
+ */
+const char *get_gemini_api_key(void);
 
 /**
  * @brief Check if credentials are available

--- a/packages/esp32-projects/robocar-camera/main/gemini_backend.c
+++ b/packages/esp32-projects/robocar-camera/main/gemini_backend.c
@@ -1,0 +1,330 @@
+/**
+ * @file gemini_backend.c
+ * @brief Google Gemini Robotics-ER backend for the AI interface
+ *
+ * Uses the Gemini API generateContent endpoint with inline image data.
+ * Gemini Robotics-ER 1.5 is optimized for spatial reasoning and robotics
+ * task planning.
+ *
+ * NOTE: s_response_buffer and s_response_len are accessed only from the single
+ * HTTP event handler callback, which is invoked synchronously during
+ * esp_http_client_perform(). Do not call gemini_analyze_image() from multiple
+ * tasks concurrently.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include "ai_backend.h"
+#include "base64.h"
+#include "cJSON.h"
+#include "config.h"
+#include "esp_http_client.h"
+#include "esp_log.h"
+#include "gemini_backend.h"
+
+static const char *TAG = "gemini_backend";
+static const ai_config_t *s_config = NULL;
+static char *s_response_buffer = NULL;
+static size_t s_response_len = 0;
+
+/** Maximum response buffer size (shared with other backends). */
+#define GEMINI_RESPONSE_BUFFER_SIZE 4096
+
+static esp_err_t http_event_handler(esp_http_client_event_t *evt)
+{
+    switch (evt->event_id) {
+        case HTTP_EVENT_ERROR:
+            ESP_LOGD(TAG, "HTTP_EVENT_ERROR");
+            break;
+        case HTTP_EVENT_ON_CONNECTED:
+            ESP_LOGD(TAG, "HTTP_EVENT_ON_CONNECTED");
+            break;
+        case HTTP_EVENT_HEADER_SENT:
+            ESP_LOGD(TAG, "HTTP_EVENT_HEADER_SENT");
+            break;
+        case HTTP_EVENT_ON_HEADER:
+            ESP_LOGD(TAG, "HTTP_EVENT_ON_HEADER, key=%s, value=%s", evt->header_key,
+                     evt->header_value);
+            break;
+        case HTTP_EVENT_ON_DATA:
+            ESP_LOGD(TAG, "HTTP_EVENT_ON_DATA, len=%d", evt->data_len);
+            if (s_response_buffer && evt->data && evt->data_len > 0) {
+                size_t available_space = (GEMINI_RESPONSE_BUFFER_SIZE - 1) - s_response_len;
+                size_t bytes_to_copy =
+                    (evt->data_len <= available_space) ? (size_t)evt->data_len : available_space;
+
+                if (bytes_to_copy > 0) {
+                    memcpy(s_response_buffer + s_response_len, evt->data, bytes_to_copy);
+                    s_response_len += bytes_to_copy;
+                    s_response_buffer[s_response_len] = '\0';
+
+                    if (bytes_to_copy < (size_t)evt->data_len) {
+                        ESP_LOGW(
+                            TAG,
+                            "HTTP response truncated: received %d bytes, only %zu bytes available",
+                            evt->data_len, available_space);
+                    }
+                } else {
+                    ESP_LOGW(TAG, "HTTP response buffer full, discarding %d bytes", evt->data_len);
+                }
+            }
+            break;
+        case HTTP_EVENT_ON_FINISH:
+            ESP_LOGD(TAG, "HTTP_EVENT_ON_FINISH");
+            break;
+        case HTTP_EVENT_DISCONNECTED:
+            ESP_LOGD(TAG, "HTTP_EVENT_DISCONNECTED");
+            break;
+        case HTTP_EVENT_REDIRECT:
+            ESP_LOGD(TAG, "HTTP_EVENT_REDIRECT");
+            break;
+    }
+    return ESP_OK;
+}
+
+static esp_err_t gemini_init(const ai_config_t *config)
+{
+    if (!config || !config->api_key || !config->api_url || !config->model) {
+        ESP_LOGE(TAG, "Gemini API key, URL, and model are required");
+        return ESP_ERR_INVALID_ARG;
+    }
+    s_config = config;
+
+    s_response_buffer = malloc(GEMINI_RESPONSE_BUFFER_SIZE);
+    if (!s_response_buffer) {
+        ESP_LOGE(TAG, "Failed to allocate response buffer");
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(TAG, "Gemini backend initialized with model %s", s_config->model);
+    return ESP_OK;
+}
+
+/**
+ * @brief Build the full Gemini API URL with API key as query parameter.
+ *
+ * Gemini API uses the format:
+ *   https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={apiKey}
+ */
+static char *build_gemini_url(void)
+{
+    // api_url already contains the base + model path, just append ?key=
+    size_t url_len = strlen(s_config->api_url) + strlen(":generateContent?key=") +
+                     strlen(s_config->api_key) + 1;
+    char *url = malloc(url_len);
+    if (!url) {
+        return NULL;
+    }
+    snprintf(url, url_len, "%s:generateContent?key=%s", s_config->api_url, s_config->api_key);
+    return url;
+}
+
+static esp_err_t gemini_analyze_image(const uint8_t *image_data, size_t image_size,
+                                      ai_response_t *response)
+{
+    if (!image_data || !response || !s_config) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    ESP_LOGI(TAG, "Analyzing image with Gemini Robotics-ER (size: %zu bytes)", image_size);
+
+    // Encode image to base64
+    char *base64_image = base64_encode_alloc(image_data, image_size);
+    if (!base64_image) {
+        ESP_LOGE(TAG, "Failed to encode image to base64");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Build Gemini API request JSON
+    // Format: { "contents": [{ "parts": [{ "inlineData": {...} }, { "text": "..." }] }],
+    //           "generationConfig": { "temperature": 0.5 } }
+    cJSON *json = cJSON_CreateObject();
+    cJSON *contents = cJSON_CreateArray();
+    cJSON *content_item = cJSON_CreateObject();
+    cJSON *parts = cJSON_CreateArray();
+
+    // Image part
+    cJSON *image_part = cJSON_CreateObject();
+    cJSON *inline_data = cJSON_CreateObject();
+    cJSON_AddStringToObject(inline_data, "mimeType", "image/jpeg");
+    cJSON_AddStringToObject(inline_data, "data", base64_image);
+    cJSON_AddItemToObject(image_part, "inlineData", inline_data);
+    cJSON_AddItemToArray(parts, image_part);
+
+    // Text prompt part — uses the same robotics navigation prompt as other backends
+    cJSON *text_part = cJSON_CreateObject();
+    cJSON_AddStringToObject(
+        text_part, "text",
+        "You are an embodied reasoning model controlling a robot with a camera. "
+        "Use your spatial understanding to analyze this image and help the robot navigate. "
+        "Identify objects and their positions (left, center, right) in the scene. "
+        "Determine if there are obstacles to avoid or clear paths to follow. "
+        "Respond with ONLY a simple JSON object with these keys:\n"
+        "- objects: array of detected objects with name and position (e.g., [{\"name\":\"cup\", "
+        "\"position\":\"left\"}])\n"
+        "- recommendation: one of [forward, backward, left, right, rotate_cw, rotate_ccw, stop]\n"
+        "- sound: optional sound command [beep, melody, alert, custom:freq:duration, "
+        "morse:TEXT:message, rtttl:name]\n"
+        "- pan: optional camera pan angle (0-180, default 90)\n"
+        "- tilt: optional camera tilt angle (0-180, default 90)\n"
+        "Respond ONLY with the JSON object, no explanations.");
+    cJSON_AddItemToArray(parts, text_part);
+
+    cJSON_AddItemToObject(content_item, "parts", parts);
+    cJSON_AddItemToArray(contents, content_item);
+    cJSON_AddItemToObject(json, "contents", contents);
+
+    // Generation config
+    cJSON *gen_config = cJSON_CreateObject();
+    cJSON_AddNumberToObject(gen_config, "temperature", 0.5);
+    cJSON_AddItemToObject(json, "generationConfig", gen_config);
+
+    char *json_string = cJSON_Print(json);
+    if (!json_string) {
+        ESP_LOGE(TAG, "Failed to create JSON request");
+        free(base64_image);
+        cJSON_Delete(json);
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGD(TAG, "JSON request size: %zu bytes", strlen(json_string));
+
+    // Build full URL with API key
+    char *full_url = build_gemini_url();
+    if (!full_url) {
+        ESP_LOGE(TAG, "Failed to build Gemini API URL");
+        free(base64_image);
+        free(json_string);
+        cJSON_Delete(json);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Configure HTTP client
+    esp_http_client_config_t config = {
+        .url = full_url,
+        .method = HTTP_METHOD_POST,
+        .timeout_ms = 30000,
+        .event_handler = http_event_handler,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&config);
+    if (!client) {
+        ESP_LOGE(TAG, "Failed to initialize HTTP client");
+        free(base64_image);
+        free(json_string);
+        free(full_url);
+        cJSON_Delete(json);
+        return ESP_FAIL;
+    }
+
+    // Set headers — Gemini uses API key in URL, not in headers
+    esp_http_client_set_header(client, "Content-Type", "application/json");
+
+    // Reset response buffer
+    s_response_len = 0;
+    if (s_response_buffer) {
+        s_response_buffer[0] = '\0';
+    }
+
+    // Send request
+    esp_http_client_set_post_field(client, json_string, strlen(json_string));
+    esp_err_t err = esp_http_client_perform(client);
+
+    int status_code = esp_http_client_get_status_code(client);
+    ESP_LOGI(TAG, "HTTP Status: %d, Response length: %zu", status_code, s_response_len);
+
+    if (err == ESP_OK && status_code == 200) {
+        // Parse Gemini response format:
+        // { "candidates": [{ "content": { "parts": [{ "text": "..." }] } }] }
+        cJSON *root = cJSON_Parse(s_response_buffer);
+        if (root) {
+            cJSON *candidates = cJSON_GetObjectItem(root, "candidates");
+            if (cJSON_IsArray(candidates) && cJSON_GetArraySize(candidates) > 0) {
+                cJSON *first_candidate = cJSON_GetArrayItem(candidates, 0);
+                cJSON *candidate_content = cJSON_GetObjectItem(first_candidate, "content");
+                cJSON *candidate_parts = cJSON_GetObjectItem(candidate_content, "parts");
+                if (cJSON_IsArray(candidate_parts) && cJSON_GetArraySize(candidate_parts) > 0) {
+                    cJSON *first_part = cJSON_GetArrayItem(candidate_parts, 0);
+                    cJSON *text_item = cJSON_GetObjectItem(first_part, "text");
+                    if (cJSON_IsString(text_item)) {
+                        const char *response_str = cJSON_GetStringValue(text_item);
+                        if (response_str) {
+                            size_t len = strlen(response_str);
+                            response->response_text = malloc(len + 1);
+                            if (response->response_text) {
+                                memcpy(response->response_text, response_str, len + 1);
+                                response->response_length = len;
+                                ESP_LOGI(TAG, "Successfully parsed Gemini response");
+                            } else {
+                                ESP_LOGE(TAG, "Failed to allocate memory for response text");
+                                err = ESP_ERR_NO_MEM;
+                            }
+                        } else {
+                            ESP_LOGE(TAG, "Null string value in Gemini response text field");
+                            err = ESP_FAIL;
+                        }
+                    } else {
+                        ESP_LOGE(TAG, "No text field in Gemini response parts");
+                        err = ESP_FAIL;
+                    }
+                } else {
+                    ESP_LOGE(TAG, "No parts array in Gemini response candidate content");
+                    err = ESP_FAIL;
+                }
+            } else {
+                ESP_LOGE(TAG, "No candidates array in Gemini response");
+                err = ESP_FAIL;
+            }
+            cJSON_Delete(root);
+        } else {
+            ESP_LOGE(TAG, "Failed to parse Gemini JSON response");
+            err = ESP_FAIL;
+        }
+    } else {
+        ESP_LOGE(TAG, "HTTP request failed: %s, status: %d", esp_err_to_name(err), status_code);
+        if (s_response_len > 0) {
+            ESP_LOGE(TAG, "Error response: %.*s", (int)s_response_len, s_response_buffer);
+        }
+        err = ESP_FAIL;
+    }
+
+    // Cleanup
+    esp_http_client_cleanup(client);
+    free(base64_image);
+    free(json_string);
+    free(full_url);
+    cJSON_Delete(json);
+
+    return err;
+}
+
+static void gemini_free_response(ai_response_t *response)
+{
+    if (response && response->response_text) {
+        free(response->response_text);
+        response->response_text = NULL;
+        response->response_length = 0;
+    }
+}
+
+static void gemini_deinit(void)
+{
+    s_config = NULL;
+    if (s_response_buffer) {
+        free(s_response_buffer);
+        s_response_buffer = NULL;
+    }
+    ESP_LOGI(TAG, "Gemini backend deinitialized");
+}
+
+static const ai_backend_t s_gemini_backend = {
+    .init = gemini_init,
+    .analyze_image = gemini_analyze_image,
+    .free_response = gemini_free_response,
+    .deinit = gemini_deinit,
+};
+
+const ai_backend_t *gemini_backend_get(void)
+{
+    return &s_gemini_backend;
+}

--- a/packages/esp32-projects/robocar-camera/main/gemini_backend.h
+++ b/packages/esp32-projects/robocar-camera/main/gemini_backend.h
@@ -1,0 +1,12 @@
+#ifndef GEMINI_BACKEND_H
+#define GEMINI_BACKEND_H
+
+#include "ai_backend.h"
+
+/**
+ * @brief Get the AI backend interface for Google Gemini Robotics-ER.
+ * @return A pointer to the AI backend interface for Gemini.
+ */
+const ai_backend_t *gemini_backend_get(void);
+
+#endif  // GEMINI_BACKEND_H

--- a/packages/esp32-projects/robocar-camera/main/main.c
+++ b/packages/esp32-projects/robocar-camera/main/main.c
@@ -330,9 +330,12 @@ static esp_err_t init_ai_backend(void)
 #else
     ESP_LOGI(TAG, "Service discovery disabled, using static URL only");
 #endif
+#elif defined(CONFIG_AI_BACKEND_GEMINI)
+    ESP_LOGI(TAG, "Configuration: Gemini Robotics-ER backend selected");
+    ESP_LOGI(TAG, "Gemini model: %s", GEMINI_MODEL);
 #else
-    ESP_LOGE(TAG, "ERROR: No AI backend defined in config.h! Check CONFIG_AI_BACKEND_CLAUDE or "
-                  "CONFIG_AI_BACKEND_OLLAMA");
+    ESP_LOGE(TAG, "ERROR: No AI backend defined in config.h! Check CONFIG_AI_BACKEND_CLAUDE, "
+                  "CONFIG_AI_BACKEND_OLLAMA, or CONFIG_AI_BACKEND_GEMINI");
     return ESP_FAIL;
 #endif
 
@@ -344,9 +347,12 @@ static esp_err_t init_ai_backend(void)
         ESP_LOGE(TAG, "  - Claude backend should be available but isn't compiled in");
 #elif defined(CONFIG_AI_BACKEND_OLLAMA)
         ESP_LOGE(TAG, "  - Ollama backend should be available but isn't compiled in");
+#elif defined(CONFIG_AI_BACKEND_GEMINI)
+        ESP_LOGE(TAG, "  - Gemini backend should be available but isn't compiled in");
 #else
         ESP_LOGE(TAG, "  - No backend is defined in config.h");
-        ESP_LOGE(TAG, "  - Add #define CONFIG_AI_BACKEND_OLLAMA or CONFIG_AI_BACKEND_CLAUDE");
+        ESP_LOGE(TAG, "  - Add CONFIG_AI_BACKEND_OLLAMA, CONFIG_AI_BACKEND_CLAUDE, or "
+                      "CONFIG_AI_BACKEND_GEMINI");
 #endif
         return ESP_FAIL;
     }
@@ -369,6 +375,19 @@ static esp_err_t init_ai_backend(void)
     ai_config.api_key = NULL;  // Ollama doesn't require a key
     ai_config.api_url = OLLAMA_API_URL;
     ai_config.model = OLLAMA_MODEL;
+#elif defined(CONFIG_AI_BACKEND_GEMINI)
+    ESP_LOGI(TAG, "Configuring Gemini Robotics-ER backend...");
+    const char *gemini_api_key = get_gemini_api_key();
+    if (!gemini_api_key || strlen(gemini_api_key) == 0) {
+        ESP_LOGE(TAG, "Gemini API key not available - cannot initialize Gemini backend");
+        return ESP_FAIL;
+    }
+    ai_config.api_key = gemini_api_key;
+    // Build model-specific base URL: .../v1beta/models/{model}
+    static char gemini_url[256];
+    snprintf(gemini_url, sizeof(gemini_url), "%s/%s", GEMINI_API_URL, GEMINI_MODEL);
+    ai_config.api_url = gemini_url;
+    ai_config.model = GEMINI_MODEL;
 #endif
 
     ESP_LOGI(TAG, "Calling backend initialization...");
@@ -390,6 +409,11 @@ static esp_err_t init_ai_backend(void)
         ESP_LOGE(TAG, "  1. Check API key is valid");
         ESP_LOGE(TAG, "  2. Verify internet connectivity");
         ESP_LOGE(TAG, "  3. Test /v1/messages endpoint");
+#elif defined(CONFIG_AI_BACKEND_GEMINI)
+        ESP_LOGE(TAG, "Gemini troubleshooting:");
+        ESP_LOGE(TAG, "  1. Check Gemini API key from Google AI Studio");
+        ESP_LOGE(TAG, "  2. Verify internet connectivity");
+        ESP_LOGE(TAG, "  3. Check model availability: %s", GEMINI_MODEL);
 #endif
         i2c_send_sound_command(SOUND_ALERT);
         return ESP_FAIL;


### PR DESCRIPTION
Add Google Gemini Robotics-ER 1.5 support alongside existing Claude and
Ollama backends. This model is optimized for spatial reasoning and
robotics task planning, making it well-suited for robot navigation.

New files:
- gemini_backend.h/c: Full backend implementation using the Gemini API
  generateContent endpoint with inline base64 image data

Updated files:
- Kconfig.projbuild: Added AI_BACKEND_GEMINI menu choice
- ai_backend.c: Gemini compile-time selection
- config.h: GEMINI_API_URL and GEMINI_MODEL defaults
- CMakeLists.txt: Added gemini_backend.c to build
- credentials_loader.h/c: GEMINI_API_KEY support (env var + credentials.h)
- main.c: Gemini backend init, config, and troubleshooting
- credentials.h.template/.example: Gemini API key placeholder

To use: set CONFIG_AI_BACKEND_GEMINI=y in sdkconfig.defaults or select
"Gemini Robotics-ER" in idf.py menuconfig, then add your Gemini API key
from https://aistudio.google.com/apikey to credentials.h.

https://claude.ai/code/session_01KNLrLVYsLhWUAsxGcyrzUe