### PR TITLE
feat: add activity-based deep sleep for audiobook-player

### DIFF
--- a/packages/esp32-projects/audiobook-player/CLAUDE.md
+++ b/packages/esp32-projects/audiobook-player/CLAUDE.md
@@ -12,24 +12,25 @@ ESPHome-based RFID audiobook player for kids. Scan picture cards with RFID tags 
 
 ## Build and Development Commands
 
-### Using Makefile (Recommended)
+### Using justfile (Recommended)
 
 ```bash
 # Initial setup
-make install          # Install ESPHome
-make config          # Create secrets.yaml from template
+just install          # Install ESPHome
+just config           # Create secrets.yaml from template
 
 # Development workflow
-make compile         # Compile firmware only
-make upload          # Compile and upload via USB (auto-detects serial port)
-make wireless        # Upload via WiFi OTA after initial USB flash
-make logs            # View device logs in real-time
+just compile          # Compile firmware only
+just upload           # Compile and upload via USB (auto-detects serial port)
+just wireless         # Upload via WiFi OTA after initial USB flash
+just logs             # View device logs (auto-detects USB, falls back to OTA)
+just logs-wireless    # View device logs via WiFi OTA
 
 # Utilities
-make validate        # Validate YAML configuration
-make clean           # Remove build artifacts
-make status          # Show project status
-make pins            # Display pin assignment reference
+just validate         # Validate YAML configuration
+just clean            # Remove build artifacts
+just status           # Show project status
+just pins             # Display pin assignment reference
 ```
 
 ### Direct ESPHome Commands
@@ -124,8 +125,8 @@ Home Assistant automations listen for these events and control media players.
 
 ### Reading RFID Tag UIDs
 
-1. Upload firmware: `make upload`
-2. Monitor logs: `make logs`
+1. Upload firmware: `just upload`
+2. Monitor logs: `just logs`
 3. Scan RFID tags near the RC522 module
 4. Copy tag UIDs from logs (format: `XX-XX-XX-XX`)
 5. Use UIDs in Home Assistant automations
@@ -135,13 +136,13 @@ Home Assistant automations listen for these events and control media players.
 When changing GPIO pins:
 1. Update `audiobook-player.yaml` configuration
 2. Update `WIRING.md` documentation (diagrams and pin tables)
-3. Update `Makefile` pins target reference
+3. Update justfile `pins` recipe reference
 4. Verify pin is not a strapping pin (GPIO0, GPIO2, GPIO5, GPIO12, GPIO15)
 
 ### Troubleshooting Upload Issues
 
 **"Error resolving IP address"**: Device not on WiFi yet or mDNS not working
-- Solution: Use `make upload` (auto-detects USB port) or specify port manually
+- Solution: Use `just upload` (auto-detects USB port) or specify port manually
 
 **"No ESP32 device found on USB"**: Serial port not detected
 - Check USB cable is data-capable (not charge-only)
@@ -153,8 +154,8 @@ When changing GPIO pins:
 
 ### Testing Without Home Assistant
 
-1. Upload firmware: `make upload`
-2. Watch logs: `make logs`
+1. Upload firmware: `just upload`
+2. Watch logs: `just logs`
 3. Scan RFID tags - should see "Tag scanned: XX-XX-XX-XX" messages
 4. Press buttons - should see event logs even without HA connected
 5. Status LED should blink on tag detection

--- a/packages/esp32-projects/audiobook-player/audiobook-player.yaml
+++ b/packages/esp32-projects/audiobook-player/audiobook-player.yaml
@@ -24,6 +24,8 @@ ota:
     password: !secret ota_password
     on_begin:
       then:
+        - script.stop: sleep_countdown
+        - script.stop: extend_wake
         - deep_sleep.prevent: deep_sleep_control
 
 wifi:
@@ -41,9 +43,12 @@ wifi:
 captive_portal:
 
 # Deep sleep configuration for power management
+# No run_duration — sleep is controlled by activity-based scripts:
+#   - On wake: 15-second probe period to detect RFID/button activity
+#   - On activity: extends wake to 2 minutes from last interaction
+#   - No activity: sleeps after 15 seconds (saves battery on spurious tilt wakes)
 deep_sleep:
   id: deep_sleep_control
-  run_duration: 2min        # Stay awake for 2 minutes after wake
   wakeup_pin: GPIO27        # Tilt switch wakes device
   wakeup_pin_mode: INVERT_WAKEUP  # Wake when tilt switch closes (connects to GND)
 
@@ -67,6 +72,7 @@ rc522_spi:
   # When a tag is detected, send it to Home Assistant
   on_tag:
     then:
+      - script.execute: extend_wake
       - text_sensor.template.publish:
           id: last_rfid_tag
           state: !lambda 'return x;'
@@ -115,6 +121,7 @@ binary_sensor:
       - delayed_off: 50ms
     on_press:
       then:
+        - script.execute: extend_wake
         - homeassistant.event:
             event: esphome.audiobook_control
             data:
@@ -135,6 +142,7 @@ binary_sensor:
       - delayed_off: 50ms
     on_press:
       then:
+        - script.execute: extend_wake
         - homeassistant.event:
             event: esphome.audiobook_control
             data:
@@ -166,6 +174,24 @@ rtttl:
 
 # Scripts for feedback sequences
 script:
+  # Short probe period after wake — if no RFID/button activity, go back to sleep
+  - id: sleep_countdown
+    mode: restart
+    then:
+      - delay: 15s
+      - logger.log: "No activity detected, going to sleep"
+      - deep_sleep.enter: deep_sleep_control
+
+  # Activity detected — cancel probe, stay awake for 2 minutes from last interaction
+  - id: extend_wake
+    mode: restart
+    then:
+      - script.stop: sleep_countdown
+      - logger.log: "Activity detected, staying awake for 2 minutes"
+      - delay: 2min
+      - logger.log: "Inactivity timeout, going to sleep"
+      - deep_sleep.enter: deep_sleep_control
+
   # Fast blink loop (100ms on/off) - runs until stopped
   - id: led_fast_blink
     mode: restart
@@ -192,9 +218,10 @@ script:
             - output.turn_off: status_led_output
             - delay: 500ms
 
-  # Boot sequence - gentle ascending arpeggio
+  # Boot sequence - gentle ascending arpeggio, starts sleep countdown
   - id: play_boot_sequence
     then:
+      - script.execute: sleep_countdown
       - script.execute: led_fast_blink
       - rtttl.play: "boot:d=16,o=5,b=120:c,d,e,g"
       - delay: 1s

--- a/packages/esp32-projects/audiobook-player/justfile
+++ b/packages/esp32-projects/audiobook-player/justfile
@@ -76,10 +76,24 @@ first-flash: config upload
     @echo ""
     @echo "First flash complete! Future updates: just wireless"
 
-# View device logs in real-time
+# View device logs via USB (auto-detects serial port)
 [group: "monitor"]
 logs:
-    esphome logs {{config_file}}
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PORT=$(ls /dev/cu.* 2>/dev/null | grep -E "(usbserial|SLAB|wchusbserial)" | head -1)
+    if [ -z "$PORT" ]; then
+        echo "No USB device found, trying OTA..."
+        esphome logs {{config_file}} --device {{device_name}}.local
+    else
+        echo "Monitoring $PORT"
+        esphome logs {{config_file}} --device "$PORT"
+    fi
+
+# View device logs via WiFi OTA
+[group: "monitor"]
+logs-wireless:
+    esphome logs {{config_file}} --device {{device_name}}.local
 
 # Alias for logs
 [group: "monitor"]


### PR DESCRIPTION
## Summary

- Replace fixed 2-minute `run_duration` with activity-based sleep management: 15-second probe period after wake, extending to 2 minutes on RFID scan or button press
- Spurious tilt wakes (no user interaction) now sleep after just 15 seconds instead of staying awake for the full 2 minutes, significantly improving battery life
- Update CLAUDE.md references from `make` to `just` and add smart USB auto-detection with OTA fallback to the `logs` justfile recipe

## Test plan

- [ ] Flash firmware and verify device wakes on tilt, stays awake 15s with no interaction, then sleeps
- [ ] Scan RFID tag after wake — verify wake extends to 2 minutes from last scan
- [ ] Press play/pause buttons — verify wake timer resets on each press
- [ ] Verify OTA prevention still blocks deep sleep during updates
- [ ] Test `just logs` auto-detects USB port and falls back to OTA when no USB connected
- [ ] Test `just logs-wireless` connects via OTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)