### PR TITLE
fix: update esphome/build-action from v4 to v7

### DIFF
--- a/.github/workflows/_build-esphome-firmware.yml
+++ b/.github/workflows/_build-esphome-firmware.yml
@@ -75,7 +75,7 @@ jobs:
           cat "$SECRETS_FILE"
 
       - name: Build ESPHome firmware
-        uses: esphome/build-action@v4
+        uses: esphome/build-action@v7
         id: build
         with:
           yaml-file: packages/esp32-projects/${{ inputs.project }}/${{ inputs.yaml_file }}

--- a/.github/workflows/esp32-build.yml
+++ b/.github/workflows/esp32-build.yml
@@ -331,7 +331,7 @@ jobs:
 
       - name: Build ESPHome firmware
         if: steps.should-build.outputs.build == 'true'
-        uses: esphome/build-action@v4
+        uses: esphome/build-action@v7
         id: build
         with:
           yaml-file: ${{ matrix.device.yaml }}


### PR DESCRIPTION
The v4 action internally depends on actions/cache v4.1.2, which GitHub
has deprecated and now rejects. Version v6.0.0 removed caching steps
entirely, and v7 is the latest stable release with updated dependencies.

Closes #159

https://claude.ai/code/session_01M7KgSTKcasaTstDjMj7voU