### PR TITLE
Refine test directory detection to exclude managed components

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,12 @@ jobs:
       - name: Check for test directories
         id: check-tests
         run: |
-          if find packages/esp32-projects -type d -name "test" | grep -q .; then
+          # Only look for host-test directories in project main trees,
+          # excluding managed_components (downloaded deps) and component
+          # internal test dirs which are not standalone host test projects.
+          if find packages/esp32-projects -type d -name "test" \
+               -not -path "*/managed_components/*" \
+               -not -path "*/components/*/test" | grep -q .; then
             echo "tests_exist=true" >> $GITHUB_OUTPUT
           else
             echo "tests_exist=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Updated the test directory detection logic in the CI workflow to be more precise about which test directories are considered valid host test projects.

## Key Changes
- Modified the `find` command to exclude `managed_components` directories (which contain downloaded dependencies)
- Added exclusion for component-internal test directories (`components/*/test`) that are not standalone host test projects
- Added clarifying comments explaining the rationale for the exclusions

## Implementation Details
The changes ensure that only host-test directories in project main trees are detected, preventing false positives from:
- Test directories within managed/downloaded component dependencies
- Internal test directories within component subdirectories that aren't meant to be run as standalone host tests

This makes the CI test detection more accurate and prevents unnecessary test runs or configuration issues.

https://claude.ai/code/session_0191iNEcj5pvuWKR6crS2Tny