### PR TITLE
Add board documentation for XIAO ESP32-S3, RP2350, and variants

### DIFF
--- a/docs/boards/xiao-esp32s3-plus.md
+++ b/docs/boards/xiao-esp32s3-plus.md
@@ -1,0 +1,160 @@
+# Seeed Studio XIAO ESP32-S3 Plus
+
+An upgraded [XIAO ESP32-S3](xiao-esp32s3.md) with doubled flash (16 MB), 9 additional castellated GPIO pads on the bottom, and a second UART and SPI interface — all in the same 21 x 17.8 mm footprint. Designed for GPIO-constrained projects where the standard XIAO's 11 pins aren't enough but a full-size DevKitC is too big.
+
+## Why XIAO ESP32-S3 Plus
+
+- **18 usable GPIOs** — 11 through-hole pins on the side headers (same as standard XIAO) plus 9 castellated SMD pads on the bottom. Enough for I2C sensors + SPI display + UART peripheral + spare GPIOs simultaneously.
+- **16 MB flash** — Double the standard XIAO's 8 MB. Room for large firmware binaries, OTA dual-partition schemes, SPIFFS/LittleFS file systems, or embedded web assets.
+- **2× UART, 2× SPI** — The extra bottom pads expose a second hardware UART and second SPI bus, enabling concurrent communication with multiple peripherals without software multiplexing.
+- **B2B connector** — Board-to-board connector for carrier board integration, enabling SMD soldering for production-scale assembly.
+- **Same compact footprint** — Identical 21 x 17.8 mm dimensions and side-header pinout as the standard XIAO. Drop-in replacement in existing carrier boards; extra GPIOs are a bonus via bottom pads.
+- **~$9 USD** — Only ~$1 more than the standard XIAO ESP32-S3 for double the flash and nearly double the GPIOs.
+
+### When to pick something else
+
+| Need | Better choice |
+|------|---------------|
+| Camera + microphone | [XIAO ESP32-S3 Sense](xiao-esp32s3-sense.md) |
+| Fewest possible GPIOs, lowest cost | [XIAO ESP32-S3](xiao-esp32s3.md) (~$8) |
+| Wi-Fi 6 / Thread / Zigbee | [XIAO ESP32-C6](xiao-esp32c6.md) |
+| 26+ GPIOs | ESP32-S3 DevKitC (full-size) |
+| PIO state machines / RISC-V | [XIAO RP2350](xiao-rp2350.md) |
+| LoRa radio | [TTGO LoRa32](ttgo-lora32-v2.md) |
+
+## Specifications
+
+| Feature | Details |
+|---------|---------|
+| MCU | ESP32-S3R8 — Xtensa LX7 dual-core @ 240 MHz |
+| SRAM | 512 KB |
+| Flash | 16 MB (quad SPI) |
+| PSRAM | 8 MB (octal SPI, separate bus) |
+| Wi-Fi | 802.11 b/g/n (Wi-Fi 4, 2.4 GHz) |
+| Bluetooth | Bluetooth 5.0 LE (no Classic BT) |
+| USB | USB-C (USB 1.1 OTG + USB-Serial-JTAG) |
+| GPIO | 18 usable (11 through-hole + 9 castellated bottom pads) |
+| ADC | 9 channels (12-bit SAR) |
+| Touch | 9 capacitive touch pins |
+| PWM | 18 channels (LEDC, any GPIO) |
+| SPI | 2× (1 on side headers, 1 on bottom pads) |
+| I2C | 1× (SDA: GPIO5/D4, SCL: GPIO6/D5) |
+| UART | 2× (UART0 on side headers, UART1 on bottom pads) |
+| Antenna | U.FL connector with detachable external antenna |
+| Battery | 3.7V LiPo via bottom pads, 50–100 mA charge IC |
+| Onboard LED | User LED on GPIO21 |
+| Buttons | BOOT, RESET |
+| B2B connector | Board-to-board for carrier board integration |
+| Dimensions | 21 x 17.8 mm |
+| Operating temp | -40°C to 65°C |
+
+## Pinout
+
+### Side Headers (same as standard XIAO ESP32-S3)
+
+```
+           ┌──────────────────────┐
+           │  XIAO ESP32-S3 Plus  │
+           │                      │
+           │        [antenna]     │
+           │                 [U.FL]│
+           │  [RST]    [BOOT]     │
+           ├──┬───────────────┬───┤
+    D0/A0  │● │               │ ●│  5V
+    D1/A1  │● │               │ ●│  GND
+    D2/A2  │● │               │ ●│  3V3
+    D3/A3  │● │               │ ●│  D10/MOSI
+    D4/SDA │● │               │ ●│  D9/MISO
+    D5/SCL │● │               │ ●│  D8/SCK
+    D6/TX  │● │               │ ●│  D7/RX
+           ├──┴───────────────┴───┤
+           │      [USB-C]         │
+           └──────────────────────┘
+```
+
+### Side Header Pin Mapping
+
+| XIAO Pin | GPIO | Default Function | Alternate Functions |
+|----------|------|------------------|---------------------|
+| D0 | GPIO1 | Analog input | ADC1_CH0, Touch1 |
+| D1 | GPIO2 | Analog input | ADC1_CH1, Touch2 |
+| D2 | GPIO3 | Analog input | ADC1_CH2, Touch3 (strapping) |
+| D3 | GPIO4 | Analog input | ADC1_CH3, Touch4 |
+| D4 | GPIO5 | I2C SDA | ADC1_CH4, Touch5 |
+| D5 | GPIO6 | I2C SCL | ADC1_CH5, Touch6 |
+| D6 | GPIO43 | UART0 TX | — |
+| D7 | GPIO44 | UART0 RX | — |
+| D8 | GPIO7 | SPI0 SCK | ADC1_CH6, Touch7 |
+| D9 | GPIO8 | SPI0 MISO | ADC1_CH7, Touch8 |
+| D10 | GPIO9 | SPI0 MOSI | ADC1_CH8, Touch9 |
+
+### Bottom Castellated Pads (9 additional GPIOs)
+
+The 9 castellated pads use 1.27 mm pitch and are designed for SMD soldering onto carrier boards.
+
+These extra pads provide a second UART and second SPI bus, plus additional digital I/O. Specific GPIO assignments follow the ESP32-S3's secondary peripheral mapping. Consult the [Seeed Studio Wiki](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/) for the definitive bottom-pad pin table.
+
+## Power Consumption
+
+Same ESP32-S3R8 silicon as the standard XIAO ESP32-S3:
+
+| State | Current | Notes |
+|-------|---------|-------|
+| Active (Wi-Fi TX) | ~310 mA peak | Depends on TX power level |
+| Active (Wi-Fi RX) | ~100 mA | |
+| Modem sleep | ~30 mA | CPU active, radio off |
+| Light sleep | ~5 mA | |
+| Deep sleep | ~14 µA | RTC memory retained |
+
+## Use Cases
+
+The Plus variant is strongest when you need the compact XIAO footprint but run out of pins on the standard board:
+
+- **I2C + SPI + UART simultaneously** — Connect an I2C sensor on D4/D5, SPI display on D8–D10, and UART GPS on D6/D7, with the second UART on bottom pads for a secondary serial peripheral.
+- **Carrier board integration** — SMD-solder the XIAO onto a custom PCB via castellated holes. The bottom pads provide additional I/O without flying wires.
+- **Large firmware projects** — 16 MB flash provides ample space for OTA with dual app partitions, embedded web servers with static assets, or LittleFS data storage.
+- **Bluetooth gateway with expansion** — BLE scanning + WiFi MQTT forwarding, with bottom-pad GPIOs driving status LEDs, relays, or additional sensors.
+
+## ESP-IDF Configuration
+
+### sdkconfig.defaults for XIAO ESP32-S3 Plus
+
+```ini
+# Target
+CONFIG_IDF_TARGET="esp32s3"
+
+# PSRAM (8 MB octal)
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# 16 MB flash — adjust partition table accordingly
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+
+# USB OTG (for HID/CDC projects)
+CONFIG_TINYUSB=y
+
+# CPU frequency
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+```
+
+### CMake target
+
+```bash
+idf.py set-target esp32s3
+```
+
+## In This Repository
+
+The XIAO ESP32-S3 Plus is not currently used in any project. It is a candidate for:
+
+- Projects that outgrow the standard XIAO's 11 GPIOs but don't need the Sense expansion board's camera/mic
+- Custom carrier board designs for production prototypes
+- Projects requiring large firmware binaries or embedded file systems (16 MB flash)
+
+## References
+
+- [XIAO ESP32-S3 Plus Product Page](https://www.seeedstudio.com/Seeed-Studio-XIAO-ESP32S3-Plus-p-6361.html)
+- [XIAO Plus Series — CNX Software](https://www.cnx-software.com/2025/01/13/seeed-studio-xiao-plus-series-adds-more-gpio-castellated-holes/)
+- [XIAO ESP32-S3 Getting Started (Seeed Studio Wiki)](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/)
+- [ESP32-S3 Series Datasheet (Espressif)](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf)

--- a/docs/boards/xiao-esp32s3-sense.md
+++ b/docs/boards/xiao-esp32s3-sense.md
@@ -1,0 +1,223 @@
+# Seeed Studio XIAO ESP32-S3 Sense
+
+The XIAO ESP32-S3 with an expansion board that adds an OV2640 camera (1600x1200), PDM digital microphone, and microSD card slot. All the AI/ML capabilities of the [base XIAO ESP32-S3](xiao-esp32s3.md) — dual-core LX7, 8 MB PSRAM, USB OTG — plus vision and audio input in a 21 x 17.8 x 15 mm stack. The smallest ESP32 camera board available at ~$14–18.
+
+## Why XIAO ESP32-S3 Sense
+
+- **Camera + AI in a thumb** — OV2640 camera with 8 MB PSRAM for frame buffers. Run TensorFlow Lite Micro face detection, person detection, or image classification on-device without cloud API calls.
+- **Digital microphone** — MSM261D3526H1CPM PDM mic for wake word detection (ESP-SR), audio classification, or voice recording to SD card.
+- **MicroSD card** — Up to 32 GB FAT32 for data logging, image capture, or audio recording.
+- **Detachable expansion** — The camera/mic/SD board connects via B2B connector. Remove it and you have a standard XIAO ESP32-S3. Reattach when you need sensors.
+- **Single-board robocar** — Selected as the target for unifying the dual-board robocar into one board ([ADR-013](../blueprint/adrs/ADR-013-single-board-xiao-esp32s3.md)).
+
+### When to pick something else
+
+| Need | Better choice |
+|------|---------------|
+| Higher resolution camera | ESP32-S3-EYE (2MP + LCD) or Linux SBC with CSI |
+| More GPIOs (>11) | [XIAO ESP32-S3 Plus](xiao-esp32s3-plus.md) (no camera, but 18 GPIOs) |
+| No camera/mic needed | [XIAO ESP32-S3](xiao-esp32s3.md) (same board, ~$8) |
+| Wi-Fi 6 / Thread / Zigbee | [XIAO ESP32-C6](xiao-esp32c6.md) |
+| LoRa radio | [TTGO LoRa32](ttgo-lora32-v2.md) |
+| On-device NPU inference | [Luckfox Pico Ultra](luckfox-pico-ultra.md) (1 TOPS NPU) |
+
+## Specifications
+
+| Feature | Details |
+|---------|---------|
+| MCU | ESP32-S3R8 — Xtensa LX7 dual-core @ 240 MHz |
+| SRAM | 512 KB |
+| Flash | 8 MB (quad SPI) |
+| PSRAM | 8 MB (octal SPI, separate bus) |
+| Wi-Fi | 802.11 b/g/n (Wi-Fi 4, 2.4 GHz) |
+| Bluetooth | Bluetooth 5.0 LE (no Classic BT) |
+| USB | USB-C (USB 1.1 OTG + USB-Serial-JTAG) |
+| Camera | OV2640 (1600x1200) or OV3660 (2048x1536) via DVP |
+| Microphone | MSM261D3526H1CPM PDM digital MEMS |
+| SD card | MicroSD slot, up to 32 GB FAT32 |
+| GPIO | 11 usable pins (D0–D10), 2 bottom pads (D11/D12) |
+| ADC | 9 channels (12-bit SAR) |
+| Touch | 9 capacitive touch pins |
+| PWM | 11 channels (LEDC, any GPIO) |
+| SPI | 1× user-accessible |
+| I2C | 1× (SDA: GPIO5/D4, SCL: GPIO6/D5) |
+| UART | 1× (TX: GPIO43/D6, RX: GPIO44/D7) |
+| Antenna | U.FL connector with detachable external antenna |
+| Battery | 3.7V LiPo via bottom pads, 50–100 mA charge IC |
+| Dimensions | 21 x 17.8 x 15 mm (with expansion board) |
+| Operating temp | -40°C to 65°C |
+
+## Pinout
+
+Same external pinout as the [base XIAO ESP32-S3](xiao-esp32s3.md). The expansion board connects via the B2B connector on the bottom, using internal GPIOs that are not broken out on the side headers.
+
+```
+           ┌──────────────────────┐
+           │  XIAO ESP32-S3 Sense │
+           │  ┌──────────────┐    │
+           │  │  OV2640       │    │
+           │  │  Camera       │    │
+           │  └──────────────┘    │
+           │  [RST]    [BOOT]     │
+           ├──┬───────────────┬───┤
+    D0/A0  │● │               │ ●│  5V
+    D1/A1  │● │               │ ●│  GND
+    D2/A2  │● │               │ ●│  3V3
+    D3/A3  │● │               │ ●│  D10/MOSI
+    D4/SDA │● │               │ ●│  D9/MISO
+    D5/SCL │● │               │ ●│  D8/SCK
+    D6/TX  │● │               │ ●│  D7/RX
+           ├──┴───────────────┴───┤
+           │      [USB-C]         │
+           └──────────────────────┘
+```
+
+### Expansion Board Internal GPIO Usage
+
+The camera, microphone, and SD card use GPIOs that are not on the side headers. These are routed through the B2B connector on the bottom of the main board.
+
+#### Camera (OV2640/OV3660) — 14 GPIOs
+
+| Function | GPIO |
+|----------|------|
+| XMCLK (clock out) | GPIO10 |
+| DVP_Y2 | GPIO15 |
+| DVP_Y3 | GPIO17 |
+| DVP_Y4 | GPIO18 |
+| DVP_Y5 | GPIO16 |
+| DVP_Y6 | GPIO14 |
+| DVP_Y7 | GPIO12 |
+| DVP_Y8 | GPIO11 |
+| DVP_Y9 | GPIO48 |
+| PCLK | GPIO13 |
+| VSYNC | GPIO38 |
+| HREF | GPIO47 |
+| SIOC (I2C SCL) | GPIO39 |
+| SIOD (I2C SDA) | GPIO40 |
+
+#### Microphone — 2 GPIOs
+
+| Function | GPIO |
+|----------|------|
+| PDM CLK | GPIO42 (D12) |
+| PDM DATA | GPIO41 (D11) |
+
+D11 and D12 are on the bottom of the expansion board and are reserved for the microphone by default. To reclaim them for other uses, cut the solder jumpers J1/J2 on the back of the expansion board.
+
+#### SD Card — 1 GPIO
+
+| Function | GPIO |
+|----------|------|
+| CS (chip select) | GPIO21 |
+
+The SD card shares the SPI bus with D8/D9/D10 (SCK/MISO/MOSI). GPIO21 is the dedicated chip select, so SPI peripherals on D8–D10 coexist with the SD card if you manage CS lines.
+
+### Pull-up Resistors
+
+The Sense expansion board includes three pull-up resistors (R4–R6) connected to the SD card slot. These can cause conflicts if you also attach SPI peripherals that have their own pull-ups. Desolder R4–R6 if needed.
+
+## Camera Usage
+
+### ESP-IDF Camera Pin Configuration
+
+```c
+#define CAMERA_PIN_PWDN    -1   // Not connected
+#define CAMERA_PIN_RESET   -1   // Not connected
+#define CAMERA_PIN_XCLK    10
+#define CAMERA_PIN_SIOD    40
+#define CAMERA_PIN_SIOC    39
+#define CAMERA_PIN_D7      48
+#define CAMERA_PIN_D6      11
+#define CAMERA_PIN_D5      12
+#define CAMERA_PIN_D4      14
+#define CAMERA_PIN_D3      16
+#define CAMERA_PIN_D2      18
+#define CAMERA_PIN_D1      17
+#define CAMERA_PIN_D0      15
+#define CAMERA_PIN_VSYNC   38
+#define CAMERA_PIN_HREF    47
+#define CAMERA_PIN_PCLK    13
+```
+
+### Camera Notes
+
+- The OV2640 has been discontinued on newer production runs; replacement boards ship with the OV3660 (2048x1536). Both use the same DVP interface and pin assignments.
+- With 8 MB PSRAM, you can buffer multiple frames for AI inference at a few FPS.
+- Camera DMA and PSRAM use separate SPI buses from user-facing SPI, so there is no resource contention with I2C or SPI peripherals on D4–D10.
+
+## Microphone Usage
+
+The PDM microphone is configured via I2S in PDM RX mode:
+
+```c
+#include <driver/i2s_pdm.h>
+
+i2s_pdm_rx_config_t pdm_rx_cfg = {
+    .clk_cfg = I2S_PDM_RX_CLK_DEFAULT_CONFIG(16000),  // 16 kHz sample rate
+    .slot_cfg = I2S_PDM_RX_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
+    .gpio_cfg = {
+        .clk = GPIO_NUM_42,
+        .din = GPIO_NUM_41,
+    },
+};
+```
+
+## Power Consumption
+
+| State | Current | Notes |
+|-------|---------|-------|
+| Active (Wi-Fi TX) | ~310 mA peak | Depends on TX power level |
+| Active (camera streaming) | ~200 mA | Continuous capture |
+| Modem sleep | ~30 mA | CPU active, radio off |
+| Light sleep | ~5 mA | |
+| Deep sleep | ~14 µA | Camera/mic powered down |
+
+## ESP-IDF Configuration
+
+### sdkconfig.defaults for XIAO ESP32-S3 Sense
+
+```ini
+# Target
+CONFIG_IDF_TARGET="esp32s3"
+
+# PSRAM (8 MB octal — required for camera buffers)
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# Camera
+CONFIG_CAMERA_MODEL_XIAO_ESP32S3=y
+
+# CPU frequency
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+
+# Stack size (camera + WiFi + AI needs headroom)
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+```
+
+### CMake target
+
+```bash
+idf.py set-target esp32s3
+```
+
+## In This Repository
+
+The XIAO ESP32-S3 Sense is the target for:
+
+- **[Unified Robocar](../../packages/esp32-projects/robocar-unified/)** — Single-board replacement for the dual Heltec + ESP32-CAM architecture ([ADR-013](../blueprint/adrs/ADR-013-single-board-xiao-esp32s3.md)). Camera for vision, I2C to TCA9548A/PCA9685 for motor control, WiFi for MQTT/OTA.
+
+Future candidates:
+- Standalone AI doorbell / security camera with on-device inference
+- Voice-controlled device with wake word detection (ESP-SR)
+- Environmental audio classifier (bird songs, baby cry detection)
+
+## References
+
+- [XIAO ESP32-S3 Sense Getting Started (Seeed Studio Wiki)](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/)
+- [XIAO ESP32-S3 Camera Usage (Seeed Studio Wiki)](https://wiki.seeedstudio.com/xiao_esp32s3_camera_usage/)
+- [XIAO ESP32-S3 Microphone Usage (Seeed Studio Wiki)](https://wiki.seeedstudio.com/xiao_esp32s3_sense_mic/)
+- [XIAO ESP32-S3 Sense Product Page](https://www.seeedstudio.com/XIAO-ESP32S3-Sense-p-5639.html)
+- [XIAO ESP32-S3 Sense Pinout & Specs (espboards.dev)](https://www.espboards.dev/esp32/xiao-esp32s3-sense/)
+- [XIAO ESP32-S3 Sense — DroneBot Workshop](https://dronebotworkshop.com/xiao-esp32s3-sense/)
+- [ESP32-S3 Series Datasheet (Espressif)](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf)

--- a/docs/boards/xiao-esp32s3.md
+++ b/docs/boards/xiao-esp32s3.md
@@ -1,0 +1,200 @@
+# Seeed Studio XIAO ESP32-S3
+
+Thumb-sized dual-core ESP32-S3 board with 8 MB octal PSRAM, 8 MB flash, native USB OTG, and Wi-Fi + BLE 5.0 in a 21 x 17.8 mm package. Packs the full ESP32-S3 feature set — vector instructions for AI/ML, camera DVP interface, USB HID — into the compact XIAO form factor at ~$8.
+
+## Why XIAO ESP32-S3
+
+- **Dual-core + AI acceleration** — Xtensa LX7 at 240 MHz with vector instructions for TensorFlow Lite Micro inference (keyword spotting, face detection) without an external accelerator.
+- **8 MB octal PSRAM** — Enough for camera frame buffers, audio processing, or ML model weights. On a separate SPI bus from user-facing SPI, so no GPIO conflicts.
+- **USB OTG** — Native USB 1.1 host/device via TinyUSB. HID keyboards, CDC-ACM serial, MSC storage — no external USB-UART bridge.
+- **Ultra-compact** — 21 x 17.8 mm with castellated pads on the bottom. Fits inside enclosures, on carrier boards, and in wearables.
+- **Battery-friendly** — 14 µA deep sleep, onboard LiPo charge management (50–100 mA), charge indicator LED.
+- **~$8 USD** — One of the cheapest ways to get an ESP32-S3 with 8 MB PSRAM.
+
+### When to pick something else
+
+| Need | Better choice |
+|------|---------------|
+| Camera + microphone built in | [XIAO ESP32-S3 Sense](xiao-esp32s3-sense.md) (same board + expansion) |
+| More GPIOs (>11) | [XIAO ESP32-S3 Plus](xiao-esp32s3-plus.md) (18 GPIOs) or ESP32-S3 DevKitC |
+| Wi-Fi 6 / Thread / Zigbee / Matter | [XIAO ESP32-C6](xiao-esp32c6.md) |
+| Classic Bluetooth (A2DP, SPP) | Original ESP32 |
+| LoRa radio | [TTGO LoRa32](ttgo-lora32-v2.md) |
+| Cheaper disposable IoT node | [ESP32-C3 Super Mini](esp32-c3-super-mini.md) (~$2–3) |
+| PIO state machines / RISC-V | [XIAO RP2350](xiao-rp2350.md) |
+
+## Specifications
+
+| Feature | Details |
+|---------|---------|
+| MCU | ESP32-S3R8 — Xtensa LX7 dual-core @ 240 MHz |
+| SRAM | 512 KB |
+| Flash | 8 MB (quad SPI) |
+| PSRAM | 8 MB (octal SPI, separate bus) |
+| Wi-Fi | 802.11 b/g/n (Wi-Fi 4, 2.4 GHz) |
+| Bluetooth | Bluetooth 5.0 LE (no Classic BT) |
+| USB | USB-C (USB 1.1 OTG + USB-Serial-JTAG) |
+| GPIO | 11 usable pins (D0–D10) |
+| ADC | 9 channels (12-bit SAR) |
+| Touch | 9 capacitive touch pins (A0–A5, A8–A10) |
+| PWM | 11 channels (LEDC, any GPIO) |
+| SPI | 1× user-accessible (SCK/MISO/MOSI on D8/D9/D10) |
+| I2C | 1× (SDA: GPIO5/D4, SCL: GPIO6/D5) |
+| UART | 1× (TX: GPIO43/D6, RX: GPIO44/D7) |
+| Antenna | U.FL connector with detachable external antenna |
+| Battery | 3.7V LiPo via bottom pads, 50–100 mA charge IC |
+| Onboard LED | User LED on GPIO21 |
+| Buttons | BOOT, RESET |
+| Dimensions | 21 x 17.8 mm |
+| Operating temp | -40°C to 65°C |
+
+## Pinout
+
+```
+           ┌──────────────────────┐
+           │  XIAO ESP32-S3       │
+           │                      │
+           │        [antenna]     │
+           │                 [U.FL]│
+           │  [RST]    [BOOT]     │
+           ├──┬───────────────┬───┤
+    D0/A0  │● │               │ ●│  5V
+    D1/A1  │● │               │ ●│  GND
+    D2/A2  │● │               │ ●│  3V3
+    D3/A3  │● │               │ ●│  D10/MOSI
+    D4/SDA │● │               │ ●│  D9/MISO
+    D5/SCL │● │               │ ●│  D8/SCK
+    D6/TX  │● │               │ ●│  D7/RX
+           ├──┴───────────────┴───┤
+           │      [USB-C]         │
+           └──────────────────────┘
+```
+
+### Pin Mapping
+
+| XIAO Pin | GPIO | Default Function | Alternate Functions |
+|----------|------|------------------|---------------------|
+| D0 | GPIO1 | Analog input | ADC1_CH0, Touch1 |
+| D1 | GPIO2 | Analog input | ADC1_CH1, Touch2 |
+| D2 | GPIO3 | Analog input | ADC1_CH2, Touch3 (strapping) |
+| D3 | GPIO4 | Analog input | ADC1_CH3, Touch4 |
+| D4 | GPIO5 | I2C SDA | ADC1_CH4, Touch5 |
+| D5 | GPIO6 | I2C SCL | ADC1_CH5, Touch6 |
+| D6 | GPIO43 | UART TX | — |
+| D7 | GPIO44 | UART RX | — |
+| D8 | GPIO7 | SPI SCK | ADC1_CH6, Touch7 |
+| D9 | GPIO8 | SPI MISO | ADC1_CH7, Touch8 |
+| D10 | GPIO9 | SPI MOSI | ADC1_CH8, Touch9 |
+
+### Safe Pins for General Use
+
+GPIO1, GPIO2, GPIO4, GPIO5, GPIO6, GPIO7, GPIO8, GPIO43 — no boot sequence involvement, no flash/PSRAM connections. Use these first for external peripherals.
+
+### Pins to Use with Caution
+
+| GPIO | Issue |
+|------|-------|
+| GPIO3 | Strapping pin — sampled at reset for JTAG interface selection |
+| GPIO9 | Connected to external flash hold signal |
+| GPIO10 | Connected to external flash chip select |
+| GPIO20 | USB D+ — avoid if using USB OTG |
+
+### USB Pin Sharing
+
+The USB OTG peripheral uses GPIO19 (D-) and GPIO20 (D+). When USB OTG is active (TinyUSB for HID, CDC, etc.), the USB-Serial-JTAG debug interface is unavailable. Use UART on D6/D7 with an external USB-UART adapter for logging in USB OTG mode.
+
+## Power Consumption
+
+| State | Current | Notes |
+|-------|---------|-------|
+| Active (Wi-Fi TX) | ~310 mA peak | Depends on TX power level |
+| Active (Wi-Fi RX) | ~100 mA | |
+| Modem sleep | ~30 mA | CPU active, radio off |
+| Light sleep | ~5 mA | Auto wake on timer/GPIO |
+| Deep sleep | ~14 µA | RTC memory retained |
+
+## Battery Charging
+
+The board has onboard LiPo charge management accessible via solder pads on the bottom:
+
+- Connect a 3.7V lithium battery to the positive/negative pads
+- Charges via USB-C at 50–100 mA
+- Orange LED indicates charging; LED off when complete
+- Read battery voltage via ADC on one of the analog pins with a voltage divider
+
+## Known Issues and Quirks
+
+### USB-Serial-JTAG Reset Behavior
+
+Same ESP32-S3 silicon quirk as other S3 boards: `esptool --after hard_reset` does not reliably trigger a chip reset over USB-Serial-JTAG. After flashing, the board may continue running old firmware until manually reset. See the [ESP32-S3 board doc](esp32-s3.md) for the pyserial reset workaround.
+
+### Pins A11/A12 Lack ADC
+
+GPIO41 and GPIO42 (accessible on the Sense expansion board bottom pads) are assigned as A11/A12 but do not support ADC functionality due to ESP32-S3 chip architecture. They work fine as digital I/O.
+
+### Octal PSRAM Pins Reserved
+
+GPIO33–37 are used internally for the octal PSRAM bus. These pins are not broken out and cannot be used for external peripherals.
+
+## ESP-IDF Configuration
+
+### sdkconfig.defaults for XIAO ESP32-S3
+
+```ini
+# Target
+CONFIG_IDF_TARGET="esp32s3"
+
+# PSRAM (8 MB octal)
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+
+# USB OTG (for HID/CDC projects)
+CONFIG_TINYUSB=y
+CONFIG_TINYUSB_HID_ENABLED=y
+
+# USB Serial JTAG console (when not using USB OTG)
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
+# CPU frequency
+CONFIG_ESP32S3_DEFAULT_CPU_FREQ_240=y
+```
+
+### CMake target
+
+```bash
+idf.py set-target esp32s3
+```
+
+## XIAO ESP32-S3 Family Comparison
+
+| Feature | XIAO S3 (this board) | [XIAO S3 Sense](xiao-esp32s3-sense.md) | [XIAO S3 Plus](xiao-esp32s3-plus.md) |
+|---------|---------------------|--------------------------------------|--------------------------------------|
+| MCU | ESP32-S3R8 dual-core 240 MHz | Same | Same |
+| Flash | 8 MB | 8 MB | 16 MB |
+| PSRAM | 8 MB octal | 8 MB octal | 8 MB octal |
+| GPIO | 11 (D0–D10) | 11 + 2 bottom pads | 11 + 9 castellated (18 total) |
+| Camera | No | OV2640/OV3660 via expansion board | No |
+| Microphone | No | PDM digital mic via expansion board | No |
+| SD card | No | MicroSD via expansion board | No |
+| Size | 21 x 17.8 mm | 21 x 17.8 x 15 mm (with expansion) | 21 x 17.8 mm |
+| Price | ~$8 | ~$14–18 | ~$9 |
+| Best for | General USB/AI/IoT | Camera + audio projects | GPIO-heavy projects |
+
+## In This Repository
+
+The XIAO ESP32-S3 Sense variant is the target for the unified single-board robocar ([ADR-013](../blueprint/adrs/ADR-013-single-board-xiao-esp32s3.md)). The base XIAO ESP32-S3 is a candidate for:
+
+- USB HID automation projects (alternative to Waveshare ESP32-S3-Zero)
+- BLE-to-WiFi gateway nodes
+- On-device ML inference (keyword spotting, gesture recognition)
+- Compact IoT controllers needing more RAM than ESP32-C3/C6
+
+## References
+
+- [XIAO ESP32-S3 Getting Started (Seeed Studio Wiki)](https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/)
+- [XIAO ESP32-S3 Pin Multiplexing (Seeed Studio Wiki)](https://wiki.seeedstudio.com/xiao_esp32s3_pin_multiplexing/)
+- [XIAO ESP32-S3 Product Page](https://www.seeedstudio.com/XIAO-ESP32S3-p-5627.html)
+- [ESP32-S3 Series Datasheet (Espressif)](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf)
+- [XIAO ESP32-S3 Pinout & Specs (espboards.dev)](https://www.espboards.dev/esp32/xiao-esp32s3/)
+- [XIAO ESP32-S3 Pinout, Datasheet & Guide (components101)](https://components101.com/development-boards/xiao-esp32-s3-sense-datasheet-pinout)

--- a/docs/boards/xiao-rp2350.md
+++ b/docs/boards/xiao-rp2350.md
@@ -1,0 +1,209 @@
+# Seeed Studio XIAO RP2350
+
+Raspberry Pi RP2350-based board in the XIAO form factor (21 x 17.8 mm). Dual-architecture — boot either dual Cortex-M33 or dual RISC-V Hazard3 cores at 150 MHz. Features 19 GPIOs (11 through-hole + 8 bottom pads), PIO state machines for deterministic I/O, ARM TrustZone security, and an onboard RGB LED. The first non-ESP32 XIAO in this collection.
+
+## Why XIAO RP2350
+
+- **Dual-architecture CPU** — Switch between ARM Cortex-M33 and RISC-V Hazard3 cores at build time. Experiment with RISC-V without buying separate hardware.
+- **PIO state machines** — Programmable I/O blocks that bit-bang any digital protocol (WS2812, custom UART, I2S, VGA, logic analyzer) at deterministic timing, independent of the CPU. No DMA/interrupt jitter.
+- **19 GPIOs** — 11 on side headers + 8 on bottom castellated pads. More I/O than any XIAO ESP32 variant in the same footprint.
+- **Hardware security** — ARM TrustZone, Secure Boot with signed firmware, OTP memory for keys, hardware SHA-256. Production-grade security on a $5 board.
+- **Broad SDK support** — Raspberry Pi Pico SDK (C/C++), MicroPython, CircuitPython, Arduino, Zephyr, NuttX. The RP2350 ecosystem is mature.
+- **~$5 USD** — Cheapest XIAO board. Hard to beat for the GPIO count and PIO capability.
+
+### When to pick something else
+
+| Need | Better choice |
+|------|---------------|
+| Wi-Fi / Bluetooth | [XIAO ESP32-S3](xiao-esp32s3.md) or [XIAO ESP32-C6](xiao-esp32c6.md) |
+| Wi-Fi + camera + AI | [XIAO ESP32-S3 Sense](xiao-esp32s3-sense.md) |
+| On-device ML inference | [XIAO ESP32-S3](xiao-esp32s3.md) (vector instructions, PSRAM) |
+| LoRa radio | [TTGO LoRa32](ttgo-lora32-v2.md) |
+| Linux userspace | [Raspberry Pi Zero 2W](raspberry-pi-zero-2w.md) or [Radxa ZERO 3W](radxa-zero-3w.md) |
+| Wi-Fi + PIO + more GPIOs | [Raspberry Pi Pico 2 W](raspberry-pi-pico-2w.md) (26 GPIOs, Wi-Fi, $7) |
+
+## Specifications
+
+| Feature | Details |
+|---------|---------|
+| SoC | RP2350 — dual Cortex-M33 or dual RISC-V Hazard3 @ 150 MHz |
+| SRAM | 520 KB (10 banks) |
+| Flash | 2 MB external QSPI (XIP) |
+| PSRAM | None |
+| Wi-Fi | None |
+| Bluetooth | None |
+| USB | USB-C (USB 1.1 device/host) |
+| GPIO | 19 multi-function (11 through-hole + 8 bottom pads) |
+| ADC | 3 channels (12-bit) + internal temp sensor |
+| PWM | 16 channels (8 slices x 2) |
+| PIO | 3 PIO blocks (12 state machines total) |
+| SPI | 2× (SPI0 on side headers, SPI1 on bottom pads) |
+| I2C | 2× (I2C0 on bottom pads, I2C1 on side headers) |
+| UART | 2× (UART0 on side headers, UART1 on bottom pads) |
+| Onboard LEDs | User LED (GPIO25, yellow, active LOW), RGB LED (GPIO22/23) |
+| Buttons | RESET (bottom, labeled "B"), BOOT |
+| Battery | LiPo charge management (~370 mA), voltage sense on GPIO29 |
+| Dimensions | 21 x 17.8 mm |
+| Operating temp | -20°C to 85°C |
+
+## Pinout
+
+```
+           ┌──────────────────────┐
+           │  XIAO RP2350         │
+           │                      │
+           │        [RGB LED]     │
+           │                      │
+           │           [BOOT]     │
+           ├──┬───────────────┬───┤
+    D0/A0  │● │               │ ●│  5V
+    D1/A1  │● │               │ ●│  GND
+    D2/A2  │● │               │ ●│  3V3
+    D3     │● │               │ ●│  D10/MOSI
+    D4/SDA │● │               │ ●│  D9/MISO
+    D5/SCL │● │               │ ●│  D8/SCK
+    D6/TX  │● │               │ ●│  D7/RX
+           ├──┴───────────────┴───┤
+           │      [USB-C]  [RST]  │
+           └──────────────────────┘
+```
+
+### Side Header Pin Mapping
+
+| XIAO Pin | GPIO | Default Function | Alternate Functions |
+|----------|------|------------------|---------------------|
+| D0 | GPIO26 | Analog input | ADC0 |
+| D1 | GPIO27 | Analog input | ADC1 |
+| D2 | GPIO28 | Analog input | ADC2 |
+| D3 | GPIO5 | Digital I/O | SPI0 CS |
+| D4 | GPIO6 | I2C1 SDA | Digital I/O |
+| D5 | GPIO7 | I2C1 SCL | Digital I/O |
+| D6 | GPIO0 | UART0 TX | Digital I/O |
+| D7 | GPIO1 | UART0 RX | Digital I/O |
+| D8 | GPIO2 | SPI0 SCK | Digital I/O |
+| D9 | GPIO4 | SPI0 MISO | Digital I/O |
+| D10 | GPIO3 | SPI0 MOSI | Digital I/O |
+
+### Bottom Castellated Pads
+
+| XIAO Pin | GPIO | Default Function | Alternate Functions |
+|----------|------|------------------|---------------------|
+| D11 | GPIO21 | UART1 RX | Digital I/O |
+| D12 | GPIO20 | UART1 TX | Digital I/O |
+| D13 | GPIO17 | I2C0 SCL | Digital I/O |
+| D14 | GPIO16 | I2C0 SDA | Digital I/O |
+| D15 | GPIO11 | SPI1 MOSI | Digital I/O |
+| D16 | GPIO12 | SPI1 MISO | Digital I/O |
+| D17 | GPIO10 | SPI1 SCK | Digital I/O |
+| D18 | GPIO9 | SPI1 SS | Digital I/O |
+
+### Internal Pins
+
+| GPIO | Function | Notes |
+|------|----------|-------|
+| GPIO19 | Battery ADC enable | Set HIGH to read battery voltage |
+| GPIO22 | RGB LED data | WS2812-compatible |
+| GPIO23 | RGB LED power | Set HIGH to enable RGB LED |
+| GPIO25 | User LED (yellow) | Active LOW |
+| GPIO29 | Battery voltage ADC | Read via ADC when GPIO19 is HIGH |
+
+## Power Consumption
+
+| State | Current | Notes |
+|-------|---------|-------|
+| Active (both cores) | ~25 mA | No wireless — much lower than ESP32 |
+| Single core active | ~15 mA | Second core in WFI |
+| Sleep | ~27–50 µA | RTC maintained |
+| Dormant | ~5 µA | Wake on GPIO edge |
+
+The absence of a wireless radio means significantly lower active power draw compared to any ESP32 board. For battery-powered projects that don't need Wi-Fi, this board lasts much longer.
+
+## Battery Monitoring
+
+Read battery voltage via the internal ADC:
+
+```c
+// Enable battery voltage reading
+gpio_init(19);
+gpio_set_dir(19, GPIO_OUT);
+gpio_put(19, 1);
+
+// Read battery voltage on GPIO29 (ADC3)
+adc_init();
+adc_gpio_init(29);
+adc_select_input(3);
+uint16_t raw = adc_read();
+float voltage = raw * 3.3f / 4096.0f * 2.0f;  // Voltage divider
+```
+
+## PIO State Machines
+
+The RP2350 has 12 PIO state machines (3 PIO blocks × 4 SMs each), up from the RP2040's 8. PIO programs execute at clock speed with deterministic timing, independent of the CPU:
+
+- **WS2812/NeoPixel** — Drive LED strips without DMA or CPU intervention
+- **Custom serial protocols** — Bit-bang any protocol at precise timing
+- **Logic analyzer** — Sample up to 8 pins simultaneously at full clock speed
+- **VGA/DVI output** — Generate video signals
+- **Rotary encoder** — Hardware quadrature decoding
+
+Each PIO program is written in a simple assembly language and loaded at runtime.
+
+## Security Features
+
+The RP2350 brings production-grade security to a $5 board:
+
+- **ARM TrustZone** — Privilege separation between secure and non-secure worlds (Cortex-M33 only)
+- **Secure Boot** — Boot from signed firmware only. OTP fuses lock down the boot chain.
+- **OTP Memory** — One-time programmable storage for encryption keys and configuration
+- **Hardware SHA-256** — Accelerated hash computation
+- **Glitch detectors** — Hardware fault injection countermeasures
+
+## SDK Options
+
+| SDK | Language | Notes |
+|-----|----------|-------|
+| Pico SDK | C/C++ | Official, most complete |
+| MicroPython | Python | Good for prototyping |
+| CircuitPython | Python | Adafruit ecosystem, USB workflow |
+| Arduino | C++ | Via arduino-pico core |
+| Zephyr | C | RTOS, industrial-grade |
+| NuttX | C | POSIX-compatible RTOS |
+
+## XIAO RP2350 vs XIAO ESP32-S3 Comparison
+
+| Feature | XIAO RP2350 (this board) | [XIAO ESP32-S3](xiao-esp32s3.md) |
+|---------|--------------------------|----------------------------------|
+| CPU | Cortex-M33 / Hazard3, dual 150 MHz | Xtensa LX7 dual-core 240 MHz |
+| SRAM | 520 KB | 512 KB |
+| Flash | 2 MB | 8 MB |
+| PSRAM | None | 8 MB octal |
+| Wi-Fi | None | 802.11 b/g/n |
+| Bluetooth | None | BLE 5.0 |
+| USB | USB 1.1 host/device | USB 1.1 OTG |
+| GPIO | 19 (11 + 8 bottom) | 11 |
+| PIO | 12 state machines | None |
+| ADC | 3 channels | 9 channels |
+| Security | TrustZone, Secure Boot, OTP | Secure Boot v2, Flash Encryption |
+| Deep sleep | ~27 µA | ~14 µA |
+| Price | ~$5 | ~$8 |
+| Best for | PIO protocols, GPIO-heavy, no wireless | AI/ML, camera, wireless IoT |
+
+## In This Repository
+
+The XIAO RP2350 is not currently used in any project. It is a candidate for:
+
+- PIO-driven LED strip controllers (WS2812 without DMA jitter)
+- USB HID devices where Wi-Fi is not needed (cheaper than ESP32-S3)
+- Logic analyzer / protocol decoder tools
+- Carrier board designs needing compact form factor with many GPIOs
+- RISC-V experimentation projects
+
+## References
+
+- [XIAO RP2350 Getting Started (Seeed Studio Wiki)](https://wiki.seeedstudio.com/getting-started-xiao-rp2350/)
+- [XIAO RP2350 Product Page](https://www.seeedstudio.com/Seeed-XIAO-RP2350-p-5944.html)
+- [XIAO RP2350 Pinout & Specs (Mischianti)](https://mischianti.org/seeed-studio-xiao-rp2350-pinout-datasheet-schema-and-specifications/)
+- [XIAO RP2350 Zephyr Support](https://docs.zephyrproject.org/latest/boards/seeed/xiao_rp2350/doc/index.html)
+- [XIAO RP2350 NuttX Support](https://nuttx.apache.org/docs/latest/platforms/arm/rp23xx/boards/xiao-rp2350/index.html)
+- [RP2350 Datasheet (Raspberry Pi)](https://datasheets.raspberrypi.com/rp2350/rp2350-datasheet.pdf)
+- [XIAO RP2350 OSHW Documentation (GitHub)](https://github.com/Seeed-Studio/OSHW-XIAO-Series/blob/main/document/SeeedStudio_XIAO_RP2350/XIAO-RP2350.md)


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for four microcontroller boards to the `docs/boards/` directory:

1. **XIAO ESP32-S3** — Base dual-core ESP32-S3 board with 8 MB PSRAM, USB OTG, and Wi-Fi/BLE
2. **XIAO ESP32-S3 Sense** — Extended variant with OV2640 camera, PDM microphone, and microSD card slot
3. **XIAO ESP32-S3 Plus** — Upgraded variant with 16 MB flash and 18 total GPIOs (11 + 9 castellated pads)
4. **XIAO RP2350** — Raspberry Pi RP2350-based board with dual-architecture CPU (Cortex-M33 or RISC-V), 12 PIO state machines, and 19 GPIOs

## Key Changes

- **XIAO ESP32-S3 (xiao-esp32s3.md)** — 200 lines documenting the base board with specifications, pinout, power consumption, battery charging, known USB-Serial-JTAG quirks, ESP-IDF configuration, and family comparison table
- **XIAO ESP32-S3 Sense (xiao-esp32s3-sense.md)** — 223 lines covering the camera/mic/SD expansion variant, including detailed GPIO mappings for internal peripherals, camera pin configuration for ESP-IDF, microphone I2S setup, and power consumption profiles
- **XIAO ESP32-S3 Plus (xiao-esp32s3-plus.md)** — 160 lines describing the GPIO-expanded variant with castellated pads, dual UART/SPI support, and use cases for carrier board integration
- **XIAO RP2350 (xiao-rp2350.md)** — 209 lines documenting the non-ESP32 XIAO with RP2350 SoC, PIO state machines, security features (TrustZone, Secure Boot), battery monitoring, and SDK options (Pico SDK, MicroPython, CircuitPython, Arduino, Zephyr, NuttX)

## Notable Implementation Details

- Each board document includes a "Why [board]" section with key differentiators and a comparison table of alternatives
- Detailed pinout diagrams and GPIO mapping tables for all variants
- Power consumption tables showing active, sleep, and deep sleep states
- ESP-IDF configuration snippets (sdkconfig.defaults) for each board
- Cross-references between related boards (e.g., XIAO S3 family comparison)
- References section with links to official datasheets, wiki pages, and community resources
- "In This Repository" section noting current and future use cases within the project
- For Sense variant: specific camera pin configuration for OV2640/OV3660, I2S PDM microphone setup, and SD card GPIO usage
- For RP2350: detailed explanation of PIO state machines, security features, and SDK ecosystem
- For Plus variant: emphasis on carrier board integration via castellated pads and dual peripheral buses

All documentation follows a consistent structure and provides practical guidance for developers selecting and implementing these boards in embedded projects.

https://claude.ai/code/session_01K8TVhsTUyeYcTgja2HyVQ7