### PR TITLE
chore: refresh docs and PRD statuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ mcu-tinkering-lab/
 │   └── esp32-projects/
 │       ├── robocar-main/           # Main controller (Heltec WiFi LoRa 32 V1)
 │       ├── robocar-camera/         # Vision system (ESP32-CAM + Claude/Ollama AI)
+│       ├── robocar-unified/        # Single-board ESP32-S3 Sense consolidated firmware
 │       ├── robocar-simulation/     # Python 3.11 physics simulation (Pymunk)
 │       ├── robocar-docs/           # Documentation and coordination justfile
 │       ├── esp32cam-llm-telegram/  # Telegram bot with LLM vision
@@ -28,7 +29,10 @@ mcu-tinkering-lab/
 │       ├── nfc-scavenger-hunt/     # NFC-based scavenger hunt game
 │       ├── esp32-wifitest/         # WiFi AP test firmware
 │       └── esp32-wireguard-ha-example/ # WireGuard + Home Assistant (ESPHome)
-├── .github/workflows/              # CI/CD (6 workflows)
+├── packages/shared-libs/
+│   ├── improv-wifi/                # Improv-WiFi BLE provisioning component
+│   └── robocar-i2c-protocol/       # Shared I2C protocol definitions + tests
+├── .github/workflows/              # CI/CD (31 workflows)
 ├── tools/scaffold/                 # Project scaffolding scripts
 ├── docs/blueprint/                 # Architecture docs (PRDs, ADRs)
 └── justfile                        # Build coordination (60+ targets)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ mcu-tinkering-lab/
 │   ├── esp32-projects/
 │   │   ├── robocar-main/           # 🤖 AI robot car controller (Heltec WiFi LoRa 32)
 │   │   ├── robocar-camera/         # 📹 ESP32-CAM vision with Claude/Ollama AI
+│   │   ├── robocar-unified/        # 🤖 Single-board ESP32-S3 Sense consolidated firmware
 │   │   ├── robocar-simulation/     # 🎮 Python 3.11 physics simulation
 │   │   ├── robocar-docs/           # 📚 Documentation and coordination justfile
 │   │   ├── esp32cam-llm-telegram/  # 💬 Telegram bot with LLM vision
@@ -90,7 +91,9 @@ mcu-tinkering-lab/
 │   │   └── esp32-wireguard-ha-example/ # 🔒 WireGuard + Home Assistant
 │   ├── arduino-projects/           # 🚧 Coming soon
 │   ├── stm32-projects/             # 🚧 Coming soon
-│   └── shared-libs/                # 📦 Shared code libraries (planned)
+│   └── shared-libs/                # 📦 Shared code libraries
+│       ├── improv-wifi/            # Improv-WiFi BLE provisioning
+│       └── robocar-i2c-protocol/   # Shared I2C protocol (with unit tests)
 ├── .github/workflows/              # 🔄 CI/CD pipelines
 ├── tools/                          # 🛠️ Build scripts and utilities
 ├── docs/                           # 📖 Documentation

--- a/docs/blueprint/prds/PRD-001-ai-robot-car-system.md
+++ b/docs/blueprint/prds/PRD-001-ai-robot-car-system.md
@@ -1,7 +1,7 @@
 ---
 id: PRD-001
 title: AI-Powered Robot Car System
-status: draft
+status: active
 created: 2026-03-05
 ---
 

--- a/docs/blueprint/prds/PRD-002-esp32cam-vision-ai-backend.md
+++ b/docs/blueprint/prds/PRD-002-esp32cam-vision-ai-backend.md
@@ -1,7 +1,7 @@
 ---
 id: PRD-002
 title: ESP32-CAM Vision and AI Backend
-status: draft
+status: active
 created: 2026-03-05
 ---
 

--- a/docs/blueprint/prds/PRD-003-robot-physics-simulation.md
+++ b/docs/blueprint/prds/PRD-003-robot-physics-simulation.md
@@ -1,7 +1,7 @@
 ---
 id: PRD-003
 title: Robot Car Physics Simulation
-status: draft
+status: active
 created: 2026-03-05
 ---
 

--- a/docs/blueprint/prds/PRD-004-it-troubleshooter.md
+++ b/docs/blueprint/prds/PRD-004-it-troubleshooter.md
@@ -1,7 +1,7 @@
 ---
 id: PRD-004
 title: Autonomous IT Troubleshooter Device
-status: draft
+status: active
 created: 2026-03-09
 ---
 

--- a/docs/health-history.json
+++ b/docs/health-history.json
@@ -55,6 +55,20 @@
       },
       "fixed_count": 1,
       "remaining_count": 3
+    },
+    {
+      "date": "2026-04-13",
+      "overall_score": 88,
+      "grade": "B",
+      "category_scores": {
+        "docs": 20,
+        "tests": 10,
+        "security": 18,
+        "quality": 20,
+        "ci": 20
+      },
+      "fixed_count": 7,
+      "remaining_count": 7
     }
   ]
 }

--- a/packages/esp32-projects/robocar-docs/README.md
+++ b/packages/esp32-projects/robocar-docs/README.md
@@ -127,18 +127,18 @@ For a detailed technical overview of the architecture, see [docs/PLUGGABLE_AI.md
 
 ### Configuring the AI Backend
 
-To select and configure the AI backend, edit `esp32-cam-idf/main/config.h`:
+To select and configure the AI backend, edit `packages/esp32-projects/robocar-camera/main/config.h`:
 
 1.  **Choose your backend**: Comment out the backend you don't want to use and make sure the one you want is active.
     ```h
-    // In esp32-cam-idf/main/config.h
+    // In packages/esp32-projects/robocar-camera/main/config.h
 
     #define CONFIG_AI_BACKEND_CLAUDE
     // #define CONFIG_AI_BACKEND_OLLAMA
     ```
 2.  **Configure API Settings**:
-    - For **Claude**: Make sure your `CLAUDE_API_KEY` is set in `esp32-cam-idf/main/credentials.h`.
-    - For **Ollama**: Set the `OLLAMA_API_URL` and `OLLAMA_MODEL` in `esp32-cam-idf/main/config.h` to point to your local Ollama server.
+    - For **Claude**: Make sure your `CLAUDE_API_KEY` is set in `packages/esp32-projects/robocar-camera/main/credentials.h`.
+    - For **Ollama**: Set the `OLLAMA_API_URL` and `OLLAMA_MODEL` in `packages/esp32-projects/robocar-camera/main/config.h` to point to your local Ollama server.
 
 ## Getting Started
 
@@ -154,82 +154,64 @@ To select and configure the AI backend, edit `esp32-cam-idf/main/config.h`:
 
 1. **Clone and Setup**
    ```bash
-   git clone <repository>
-   cd robocar_test
-   make info  # Check system configuration
+   git clone https://github.com/laurigates/mcu-tinkering-lab.git
+   cd mcu-tinkering-lab
+   just --list              # List all available recipes
    ```
 
 2. **Configure Credentials**
    ```bash
-   cd esp32-cam-idf
+   cd packages/esp32-projects/robocar-camera
    cp main/credentials.h.example main/credentials.h
    # Edit credentials.h with your WiFi SSID and password. API keys are also stored here. See the "Pluggable AI Backend" section for more details.
    ```
 
-3. **Start Development Stack**
+3. **Build and Flash Main Controller**
    ```bash
-   make dev-stack-start     # Start Ollama AI + MQTT broker with service discovery
+   just robocar::build-main
+   PORT=/dev/ttyUSB0 just robocar::flash-main
    ```
 
-4. **Build and Flash Main Controller**
-   ```bash
-   make build-main
-   make flash-main
-   ```
-
-5. **Build and Flash ESP32-CAM**
+4. **Build and Flash ESP32-CAM**
    ```bash
    # Connect GPIO0 to GND for programming mode
-   make build-cam
-   make flash-cam
+   just robocar::build-cam
+   PORT=/dev/ttyUSB1 just robocar::flash-cam
    # Disconnect GPIO0 and reset
    ```
 
-6. **Monitor Operation**
+5. **Monitor Operation**
    ```bash
-   make monitor-main        # Monitor main controller
-   make monitor-cam         # Monitor camera module
+   just robocar::monitor-main   # Monitor main controller
+   just robocar::monitor-cam    # Monitor camera module
    # MQTT logs available at: mqtt://192.168.0.100:1883/robocar/logs
    ```
 
 ## Development Commands
 
-### Complete Development Stack
+### ESP-IDF Framework (containerized via Docker)
 ```bash
-make dev-stack-start     # Start Ollama AI + MQTT broker with service discovery
-make dev-stack-stop      # Stop complete development stack
-```
-
-### Individual Services
-```bash
-make ollama-start        # Start Ollama AI backend
-make mosquitto-start     # Start MQTT broker
-make ollama-stop         # Stop Ollama services
-make mosquitto-stop      # Stop MQTT services
-```
-
-### ESP-IDF Framework (Primary)
-```bash
-make build-main          # Build main controller
-make build-cam           # Build camera module
-make flash-main          # Flash main controller
-make flash-cam           # Flash camera module
-make monitor-main        # Monitor main controller
-make monitor-cam         # Monitor camera module
-make clean-main          # Clean main build
-make clean-cam           # Clean camera build
+just robocar::build-main            # Build main controller
+just robocar::build-cam             # Build camera module
+just robocar::build-all             # Build both controllers
+just robocar::flash-main PORT=...   # Flash main controller
+just robocar::flash-cam  PORT=...   # Flash camera module
+just robocar::monitor-main          # Monitor main controller
+just robocar::monitor-cam           # Monitor camera module
+just robocar::clean-main            # Clean main build
+just robocar::clean-cam             # Clean camera build
 ```
 
 ### Development Shortcuts
 ```bash
-make develop-main        # Build, flash, and monitor main controller
-make develop-cam         # Build, flash, and monitor camera module
+just robocar::develop-main   # Build, flash, and monitor main controller
+just robocar::develop-cam    # Build, flash, and monitor camera module
 ```
 
 ### System Information
 ```bash
-make info                # Show configuration and status
-make help                # Show all available commands
+just --list              # Show all available recipes
+just list-projects       # Show all projects in the monorepo
 ```
 
 ## System Architecture
@@ -320,15 +302,14 @@ mosquitto_sub -h 192.168.0.100 -t "robocar/logs" -v
 - **WiFi connection problems**: Verify credentials in credentials.h
 - **Motor not moving**: Check power supply and TB6612FNG connections
 - **OLED not displaying**: Verify I2C connections and address (0x3C)
-- **MQTT not connecting**: Check broker is running with `make mosquitto-start`
+- **MQTT not connecting**: Check that your MQTT broker is running and reachable
 - **Service discovery fails**: Verify mDNS is working on your network
 
 ### Debug Commands
 ```bash
-make monitor-main        # Check main controller logs
-make monitor-cam         # Check camera module logs
-make clean-cam && make build-cam  # Clean rebuild camera
-make dev-stack-start     # Start complete development environment
+just robocar::monitor-main                     # Check main controller logs
+just robocar::monitor-cam                      # Check camera module logs
+just robocar::clean-cam && just robocar::build-cam  # Clean rebuild camera
 ```
 
 ## Future Enhancements


### PR DESCRIPTION
## Summary
Maintenance pass applying auto-fixable findings from the git-repo-agent run.

- Add `robocar-unified` to the project listings in `CLAUDE.md` and `README.md`
- List `shared-libs/` contents (improv-wifi, robocar-i2c-protocol) in `CLAUDE.md`; correct workflow count (6 → 31)
- Replace stale `make` commands with `just` and fix `esp32-cam-idf/` path references in `packages/esp32-projects/robocar-docs/README.md`
- Mark PRD-001..004 as `status: active` (features are implemented)
- Append 2026-04-13 snapshot to `docs/health-history.json`

Non-fixable findings (security hardening in `esp32cam-llm-telegram`, MQTT TLS, duplication between `robocar-camera` and `robocar-unified`, broader test coverage) are deferred.

## Test plan
- [ ] CI passes
- [ ] Rendered docs look correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)