### PR TITLE
docs(robocar-unified): add README, CLAUDE, and WIRING

### DIFF
--- a/packages/esp32-projects/robocar-unified/CLAUDE.md
+++ b/packages/esp32-projects/robocar-unified/CLAUDE.md
@@ -1,0 +1,82 @@
+# CLAUDE.md - robocar-unified
+
+Project-specific guidance for Claude Code. See repo-root `CLAUDE.md` for monorepo-wide conventions.
+
+## What this project is
+
+Single-board consolidation of the dual-ESP32 robocar onto a **XIAO ESP32-S3 Sense**. Replaces the separate `robocar-main` (Heltec) + `robocar-camera` (ESP32-CAM) boards — camera, AI, motors, peripherals, WiFi, MQTT, and OTA all run on one module.
+
+## Architecture
+
+Core affinity is load-bearing — do not change without understanding the trade-offs:
+
+- **Core 0** (motor-critical, timing-sensitive): `motor_task`, `peripheral_task`, `command_task`
+- **Core 1** (bursty, I/O-bound): `camera_task`, `ai_task`, `network_task`, OTA
+- Camera DMA is pinned to Core 1 via `CONFIG_CAMERA_CORE1=y` so motor PWM isn't jittered by frame captures
+
+Tasks communicate via FreeRTOS queues (see `motor_cmd_t`, `peripheral_cmd_t` in `main.c`).
+
+## I2C topology
+
+All I2C devices hang off a **TCA9548A multiplexer** on GPIO5/6. Don't talk to devices directly on the primary bus — always select the channel first via `i2c_bus.c`. Current channel map in `pin_config.h`:
+
+- ch0: PCA9685 (motors, servos, LEDs)
+- ch1: SSD1306 OLED
+- ch2-7: reserved
+
+## PCA9685 channel layout
+
+All motor direction, motor PWM, servo, and LED outputs go through the PCA9685 — the ESP32-S3 only drives STBY (GPIO1), the buzzer (GPIO2), and I2C. GPIO budget on XIAO headers is tight (11 pins). See the channel table in `main/pin_config.h` before reassigning.
+
+Motor direction uses PCA9685 "full-on" (4096) / "full-off" (0) values on IN1/IN2 channels.
+
+## AI backends
+
+Selected at **compile time** via sdkconfig:
+
+- `CONFIG_AI_BACKEND_OLLAMA` (default) — self-hosted, discovered via mDNS
+- `CONFIG_AI_BACKEND_CLAUDE` — Anthropic API
+- `CONFIG_AI_BACKEND_GEMINI` — Google Gemini Robotics-ER
+
+`ai_backend.c` provides the abstraction; each backend has its own `.c/.h` pair. `ai_response_parser.c` extracts motor commands from the AI response.
+
+## WiFi provisioning
+
+Uses **Improv WiFi** BLE provisioning by default — no credentials compiled in. `CMakeLists.txt` auto-generates a stub `credentials.h` at configure time if one doesn't exist, so CI and the web flasher don't need credentials. For local dev with hardcoded creds, copy `main/credentials.h.example` to `main/credentials.h` (gitignored).
+
+NVS stores runtime-provisioned credentials — don't wipe NVS unless you want to re-provision.
+
+## OTA
+
+`ota_manager.c` pulls releases from the `laurigates/mcu-tinkering-lab` GitHub repo. `version.txt` is the single source of truth for the running version (read at CMake-configure time into `PROJECT_VER`). Release-please manages version bumps — do not edit `version.txt` manually.
+
+Partition layout is OTA-capable (see `partitions.csv`) with app rollback enabled.
+
+## Build & flash
+
+Containerized ESP-IDF v5.4 via `just robocar-unified::*`. XIAO uses native USB-Serial-JTAG — `just` auto-detects VID `0x303a`. If flashing fails, hold BOOT and tap RESET to enter download mode.
+
+```bash
+just robocar-unified::build
+just robocar-unified::flash-monitor
+```
+
+Do not invoke `idf.py` directly on the host — there's no local ESP-IDF install. Use `just robocar-unified::shell` for an interactive container.
+
+## sdkconfig rules
+
+See repo `.claude/rules/esp-idf-sdkconfig.md`. If you change `sdkconfig.defaults`, delete the generated `sdkconfig` and run `just robocar-unified::clean` before rebuilding — ESP-IDF preserves existing `sdkconfig` values and silently ignores new defaults otherwise.
+
+Key settings that matter:
+- `CONFIG_SPIRAM_MODE_OCT=y` — XIAO ESP32-S3 Sense has **octal** PSRAM (not quad); wrong mode = boot loop
+- `CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192` — bumped from default 3584 for WiFi + BLE + camera init
+- `CONFIG_ESP_BROWNOUT_DET=n` — disabled; motor inrush was tripping it
+- `CONFIG_MDNS_ENABLED=y` — required for Ollama discovery and `robocar.local`
+
+## Don't
+
+- Don't add direct GPIO motor control — everything goes through PCA9685 via `motor_controller.c`
+- Don't bypass the TCA9548A — devices on different channels can share addresses (e.g. PCA9685 and OLED would conflict without it)
+- Don't commit `main/credentials.h` — it's gitignored; use the `.example` as template
+- Don't hand-edit `version.txt` — release-please owns it
+- Don't change camera core pinning without re-verifying motor PWM jitter

--- a/packages/esp32-projects/robocar-unified/README.md
+++ b/packages/esp32-projects/robocar-unified/README.md
@@ -1,0 +1,57 @@
+# robocar-unified
+
+Single-board robocar firmware consolidating the dual-ESP32 design (`robocar-main` + `robocar-camera`) onto a **XIAO ESP32-S3 Sense**. Camera capture, AI inference, motor control, and peripherals all run on one module with core-affinity isolation.
+
+## Hardware
+
+| Component | Role | Connection |
+|-----------|------|-----------|
+| XIAO ESP32-S3 Sense | MCU + camera (OV2640) + 8MB PSRAM | USB-C (native USB-Serial-JTAG) |
+| TCA9548A | I2C multiplexer | GPIO5 (SDA), GPIO6 (SCL) |
+| PCA9685 | 16-ch PWM driver (LEDs, servos, motor control) | TCA9548A ch0 |
+| SSD1306 OLED | 128x64 status display | TCA9548A ch1 |
+| TB6612FNG | Dual motor driver | GPIO1 (STBY) + PCA9685 ch8-13 |
+| 2x RGB LEDs | Status indicators | PCA9685 ch0-5 |
+| 2x SG90 servos | Pan/tilt | PCA9685 ch6-7 |
+| Piezo buzzer | Audio feedback | GPIO2 |
+
+See [WIRING.md](WIRING.md) for full connection details.
+
+## Architecture
+
+- **Core 0**: motor control, peripheral I/O, serial commands
+- **Core 1**: camera capture, AI analysis, WiFi / MQTT / OTA
+
+AI backend is selected at compile time via sdkconfig (`CONFIG_AI_BACKEND_OLLAMA` by default; Claude and Gemini backends also available).
+
+## Build & flash
+
+This project builds in a container — no local ESP-IDF install required.
+
+```bash
+# From repo root
+just robocar-unified::build
+PORT=/dev/cu.usbmodem* just robocar-unified::flash
+just robocar-unified::monitor
+# or: just robocar-unified::flash-monitor
+```
+
+The XIAO ESP32-S3 uses native USB-Serial-JTAG — no external USB-serial adapter needed. Port auto-detection looks for VID `0x303a`.
+
+## WiFi provisioning
+
+No credentials are compiled in. First boot advertises an Improv WiFi BLE service — use a browser-based provisioner (Chrome on desktop/Android) to send WiFi credentials, which are stored in NVS. For local builds with hardcoded credentials, copy `main/credentials.h.example` to `main/credentials.h`.
+
+After connection, the device is reachable as `robocar.local` via mDNS.
+
+## OTA updates
+
+OTA is enabled (`CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`) and configured to pull releases from `laurigates/mcu-tinkering-lab` GitHub. `version.txt` is the single source of truth (managed by release-please).
+
+## Key files
+
+- `main/main.c` — FreeRTOS task setup and command dispatch
+- `main/pin_config.h` — all GPIO / PCA9685 channel assignments
+- `main/ai_backend.c` — AI backend abstraction (Claude / Ollama / Gemini)
+- `sdkconfig.defaults` — PSRAM, camera core pinning, OTA, mDNS config
+- `partitions.csv` — OTA-capable partition table for 8MB flash

--- a/packages/esp32-projects/robocar-unified/WIRING.md
+++ b/packages/esp32-projects/robocar-unified/WIRING.md
@@ -1,0 +1,109 @@
+# Wiring — robocar-unified (XIAO ESP32-S3 Sense)
+
+Single-board wiring for the consolidated robocar. All pin assignments are authoritative in [`main/pin_config.h`](main/pin_config.h); this document mirrors them for human reference.
+
+**All components must share a common ground (GND).**
+
+## GPIO assignments (XIAO ESP32-S3 Sense)
+
+The XIAO exposes only 11 GPIOs on its headers. Camera pins are internal to the Sense module and do not conflict with header pins.
+
+| XIAO Pin | GPIO | Function | Notes |
+|----------|------|----------|-------|
+| D0 | GPIO1 | TB6612FNG STBY | HIGH = motors enabled |
+| D1 | GPIO2 | Piezo buzzer | LEDC PWM |
+| D2 | GPIO3 | *spare* | future: ultrasonic trigger |
+| D3 | GPIO4 | *spare* | future: ultrasonic echo |
+| D4 | GPIO5 | **I2C SDA** | to TCA9548A |
+| D5 | GPIO6 | **I2C SCL** | to TCA9548A |
+| D6 | GPIO43 | USB Serial TX | debug console |
+| D7 | GPIO44 | USB Serial RX | debug console |
+| D8–D10 | GPIO7–9 | *spare* | future: SPI |
+
+I2C runs at **400 kHz**.
+
+## I2C topology (TCA9548A multiplexer @ 0x70)
+
+```mermaid
+graph LR
+    ESP32[XIAO ESP32-S3<br/>GPIO5/6] -->|I2C 400kHz| TCA[TCA9548A<br/>0x70]
+    TCA -->|ch0| PCA[PCA9685<br/>0x40 @ 200Hz]
+    TCA -->|ch1| OLED[SSD1306 OLED<br/>0x3C, 128x64]
+    TCA -.->|ch2-7| Future[reserved:<br/>IMU / ToF / sensors]
+```
+
+## PCA9685 channel map (0x40, 200 Hz)
+
+| Ch | Signal | Device |
+|----|--------|--------|
+| 0 | Left LED R | RGB LED (left) |
+| 1 | Left LED G | |
+| 2 | Left LED B | |
+| 3 | Right LED R | RGB LED (right) |
+| 4 | Right LED G | |
+| 5 | Right LED B | |
+| 6 | Pan PWM | SG90 servo |
+| 7 | Tilt PWM | SG90 servo |
+| 8 | Motor R IN1 | TB6612FNG (digital: 0 / 4096) |
+| 9 | Motor R IN2 | TB6612FNG (digital) |
+| 10 | Motor R PWM | TB6612FNG (PWM 0-4095) |
+| 11 | Motor L IN1 | TB6612FNG (digital) |
+| 12 | Motor L IN2 | TB6612FNG (digital) |
+| 13 | Motor L PWM | TB6612FNG (PWM 0-4095) |
+| 14-15 | *reserved* | |
+
+200 Hz is a compromise between servo timing (ideal 50 Hz) and motor PWM smoothness — works well for SG90s and TB6612FNG.
+
+## Power
+
+```mermaid
+graph TD
+    Bat[2x 18650 battery pack] --> Boost[XL6009 boost → 5V]
+    Boost -->|5V| XIAO[XIAO ESP32-S3 Sense<br/>5V pin]
+    Boost -->|5V| MD[TB6612FNG<br/>VM + VCC]
+    Boost -->|5V| PCA[PCA9685<br/>V+ + VCC]
+    Boost -->|5V| Servos[SG90 servos]
+    MD --> ML[Left motor]
+    MD --> MR[Right motor]
+    PCA --> LED_L[Left RGB LED<br/>common-anode]
+    PCA --> LED_R[Right RGB LED<br/>common-anode]
+    PCA --> Servos
+    XIAO -->|GPIO2| Piezo[Piezo buzzer]
+    XIAO -->|GPIO1| MD
+    classDef gnd fill:#ccc,stroke:#333
+```
+
+**Common ground required across all components.**
+
+## Full connection diagram
+
+```mermaid
+graph TD
+    subgraph Board[XIAO ESP32-S3 Sense]
+        ESP[ESP32-S3<br/>+ OV2640 camera<br/>+ 8MB PSRAM]
+    end
+
+    ESP -- GPIO5 SDA --> TCA[TCA9548A 0x70]
+    ESP -- GPIO6 SCL --> TCA
+    ESP -- GPIO1 STBY --> TB[TB6612FNG]
+    ESP -- GPIO2 --> BUZ[Piezo]
+
+    TCA -- ch0 --> PCA[PCA9685 0x40]
+    TCA -- ch1 --> OLED[SSD1306 0x3C]
+
+    PCA -- ch0-5 --> LEDS[2x RGB LEDs]
+    PCA -- ch6-7 --> SRV[Pan/Tilt SG90]
+    PCA -- ch8-13 --> TB
+    TB --> M1[Left motor]
+    TB --> M2[Right motor]
+```
+
+## Flashing
+
+XIAO ESP32-S3 has native USB-Serial-JTAG (VID `0x303a`). Plug in USB-C and flash:
+
+```bash
+PORT=/dev/cu.usbmodem* just robocar-unified::flash
+```
+
+If the board won't enter download mode: hold **BOOT**, tap **RESET**, release BOOT. See [README.md](README.md) for full flash / monitor commands.


### PR DESCRIPTION
## Summary
- Adds the three missing docs for `packages/esp32-projects/robocar-unified` (project-health: 7/10 → 10/10).
- README: hardware table, containerized build/flash, Improv WiFi, OTA
- CLAUDE: core-affinity + TCA9548A + PCA9685 rationale, AI backend selection, sdkconfig gotchas, "don't" list
- WIRING: GPIO table, I2C topology, PCA9685 channel map, Mermaid power + connection diagrams

Content is sourced directly from `main/pin_config.h`, `CMakeLists.txt`, `justfile`, and `sdkconfig.defaults` so it stays in sync with the firmware.

## Test plan
- [ ] Render all three files on GitHub and confirm Mermaid diagrams display
- [ ] Verify pin table in WIRING.md matches `main/pin_config.h`
- [ ] Sanity-check `just robocar-unified::build` / `flash` invocations noted in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)