### PR TITLE
ci: install uv in Code Quality job for ty pre-commit hook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
       - name: Install pre-commit
         run: pip install pre-commit
 


### PR DESCRIPTION
## Summary
- Adds `astral-sh/setup-uv@v4` to the Code Quality Checks job in `test.yml` so `uvx` is on PATH for the `ty type check` pre-commit hook (previously failed with exit 127: `uvx: command not found`).

## Context
Part of fixing the systemic CI failures across `laurigates/mcu-tinkering-lab` and siblings. The other half — flipping default `GITHUB_TOKEN` permissions to `write` so reusable-workflow callers stop hitting `startup_failure` — was applied via `gh api` on `laurigates/{claude-plugins,.github,gitops}` (no repo changes needed).

## Test plan
- [ ] `Test Suite / Code Quality Checks` runs pre-commit end-to-end
- [ ] `ty type check (robocar-simulation)` hook reports `Passed` (or real ty diagnostics) rather than exit 127
- [ ] `Test Summary` no longer fails