### PR TITLE
fix(esp32-cam-webserver): converge WiFi STA to canonical config

### DIFF
--- a/packages/esp32-projects/esp32-cam-webserver/dependencies.lock
+++ b/packages/esp32-projects/esp32-cam-webserver/dependencies.lock
@@ -23,13 +23,24 @@ dependencies:
       registry_url: https://components.espressif.com
       type: service
     version: 1.3.1
+  espressif/mdns:
+    component_hash: 1ebe3bd675bb9d1c58f52bc0b609b32f74e572b01c328f9e61282040c775495c
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.11.0
   idf:
     source:
       type: idf
     version: 5.4.0
 direct_dependencies:
 - espressif/esp32-camera
+- espressif/mdns
 - idf
-manifest_hash: a69fb037468ece0a29f43df98688fc90c3561f7f5b364ae2632d57c9d22683f4
+manifest_hash: 66a044fbc2566de621009f3fbb6c6662ad2e62d3d3ee49cc4eec5d69ea486f73
 target: esp32
 version: 2.0.0

--- a/packages/esp32-projects/esp32-cam-webserver/main/CMakeLists.txt
+++ b/packages/esp32-projects/esp32-cam-webserver/main/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(SRCS "main.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "esp32-camera" "esp_wifi" "esp_http_server" "nvs_flash" "esp_timer")
+                    REQUIRES "esp32-camera" "esp_wifi" "nvs_flash" "esp_netif" "esp_event"
+                             "esp_http_server" "esp_timer")

--- a/packages/esp32-projects/esp32-cam-webserver/main/idf_component.yml
+++ b/packages/esp32-projects/esp32-cam-webserver/main/idf_component.yml
@@ -1,7 +1,9 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  ## Required IDF version (ESP-IDF 6.0)
+  ## Required IDF version (matches monorepo ESP-IDF 5.4 container)
   idf:
-    version: '>=6.0.0'
-  # ESP32 Camera component (latest compatible with ESP-IDF 6.0)
+    version: '>=5.1'
+  # ESP32 Camera component
   espressif/esp32-camera: '^2.0.0'
+  # mDNS component — provides mdns.h (esp32-cam.local hostname)
+  espressif/mdns: '^1.8.0'

--- a/packages/esp32-projects/esp32-cam-webserver/main/main.c
+++ b/packages/esp32-projects/esp32-cam-webserver/main/main.c
@@ -98,14 +98,22 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
     if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
         esp_wifi_connect();
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        wifi_event_sta_disconnected_t *disconnected = (wifi_event_sta_disconnected_t *)event_data;
+        ESP_LOGW(TAG, "WiFi disconnected. Reason: %d (%s)", disconnected->reason,
+                 disconnected->reason == WIFI_REASON_NO_AP_FOUND         ? "AP not found"
+                 : disconnected->reason == WIFI_REASON_AUTH_FAIL         ? "Auth failed"
+                 : disconnected->reason == WIFI_REASON_ASSOC_FAIL        ? "Assoc failed"
+                 : disconnected->reason == WIFI_REASON_HANDSHAKE_TIMEOUT ? "Handshake timeout"
+                                                                         : "Other");
+
         if (s_retry_num < WIFI_MAXIMUM_RETRY) {
             esp_wifi_connect();
             s_retry_num++;
-            ESP_LOGI(TAG, "Retry to connect to the AP");
+            ESP_LOGI(TAG, "Retry %d/%d to connect to the AP", s_retry_num, WIFI_MAXIMUM_RETRY);
         } else {
             xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+            ESP_LOGE(TAG, "Failed to connect to AP after %d retries", WIFI_MAXIMUM_RETRY);
         }
-        ESP_LOGI(TAG, "Connect to the AP fail");
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
         ESP_LOGI(TAG, "Got IP:" IPSTR, IP2STR(&event->ip_info.ip));
@@ -127,6 +135,14 @@ void wifi_init_sta(void)
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
 
+    // Set country code for regulatory compliance (Finland — allows channels 1-13)
+    wifi_country_t country = {
+        .cc = "FI", .schan = 1, .nchan = 13, .policy = WIFI_COUNTRY_POLICY_AUTO};
+    ESP_ERROR_CHECK(esp_wifi_set_country(&country));
+
+    // Disable power save — server-class device needs steady connectivity
+    ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
+
     esp_event_handler_instance_t instance_any_id;
     esp_event_handler_instance_t instance_got_ip;
     ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID,
@@ -139,11 +155,10 @@ void wifi_init_sta(void)
             {
                 .ssid = WIFI_SSID,
                 .password = WIFI_PASS,
-                /* Setting a password implies station will connect to all security modes including
-                 * WEP/WPA. However these modes are deprecated and not advisable to be used. Incase
-                 * your Access point doesn't support WPA2, these mode can be enabled by commenting
-                 * below line */
-                .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+                .threshold.authmode = WIFI_AUTH_WPA_WPA2_PSK,     // mixed-mode tolerant
+                .pmf_cfg = {.capable = true, .required = false},  // 4-way handshake tolerance
+                .scan_method = WIFI_FAST_SCAN,
+                .sort_method = WIFI_CONNECT_AP_BY_SIGNAL,
             },
     };
 

--- a/packages/esp32-projects/esp32-cam-webserver/sdkconfig.defaults
+++ b/packages/esp32-projects/esp32-cam-webserver/sdkconfig.defaults
@@ -31,13 +31,21 @@ CONFIG_CAMERA_PIN_PCLK=22
 # PSRAM is required for camera applications
 CONFIG_ESP32_SPIRAM_SUPPORT=y
 
-# Wi-Fi configuration
+# Wi-Fi configuration (canonical block — see .claude/skills/wifi-sta-setup)
 CONFIG_ESP_WIFI_ENABLED=y
-CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=16
+CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=10
 CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM=32
+CONFIG_ESP_WIFI_TX_BUFFER_TYPE=1
 CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=32
+CONFIG_ESP_WIFI_AMPDU_TX_ENABLED=n
+CONFIG_ESP_WIFI_AMPDU_RX_ENABLED=n
+CONFIG_ESP_WIFI_AMSDU_TX_ENABLED=n
+CONFIG_ESP_WIFI_NVS_ENABLED=y
 
-# Reduce WiFi TX power to lower current draw during initialization
+# Brownout-justified TX power cap: AI-Thinker ESP32-CAM has documented
+# brownout-during-WiFi-association issues; brownout detector is enabled above.
+# See README.md "Power Considerations" and the 1-second power stabilization
+# delay in app_main(). Do not remove without re-verifying brownout behaviour.
 CONFIG_ESP_PHY_MAX_WIFI_TX_POWER=15
 CONFIG_ESP_PHY_MAX_TX_POWER=15
 


### PR DESCRIPTION
## Summary

Migrates the `esp32-cam-webserver` WiFi STA setup to the canonical pattern codified in PR #211 (the `wifi-sta-setup` skill). The reference implementation is `packages/esp32-projects/robocar-unified/main/wifi_manager.c`.

- Source (`main/main.c`): mixed-mode auth (`WIFI_AUTH_WPA_WPA2_PSK`), PMF tolerant, Finnish country code so channels 12/13 are scannable, fast scan + signal sort, `WIFI_PS_NONE` (server-class device), reason-code disconnect logging matching the skill's diagnosis table, clearer retry log.
- sdkconfig.defaults: canonical WiFi buffer block (AMPDU/AMSDU off, `TX_BUFFER_TYPE=1`, `NVS_ENABLED=y`). TX power cap at 15 dBm is **kept** with a comment explaining the justification — this project has `CONFIG_ESP_BROWNOUT_DET=y` AND documented power-supply dips during WiFi association, which is the only scenario where the skill allows the cap. The next skill-audit should not flag it.
- `main/CMakeLists.txt`: explicit `esp_netif` + `esp_event` in REQUIRES (canonical names all four).
- `main/idf_component.yml`: relax `idf >=6.0.0` → `>=5.1` (monorepo builds on v5.4) and add `espressif/mdns ^1.8.0` explicitly since `main.c` already uses `mdns_init()`.

Closes #210.

## Test plan

- [x] `just webserver::build` — clean build, binary is 0xf35b0 bytes (5% free in 1 MB app partition). The `espressif/mdns@1.11.0` component is pulled in via `dependencies.lock`.
- [ ] Flash to ESP32-CAM hardware (GPIO0→GND during reset).
- [ ] On success: `Got IP: <addr>`, `mDNS initialized: esp32-cam.local`, MJPEG stream reachable at `http://esp32-cam.local/`.
- [ ] On failure: log now shows `WiFi disconnected. Reason: N (<name>)` on each retry; cross-reference the diagnosis table in `.claude/skills/wifi-sta-setup/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)