### PR TITLE
chore: pin format-check clang-format to 18.1.8 and format gemini-vision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install clang-format
-        run: sudo apt-get update && sudo apt-get install -y clang-format
+        # Pin to 18.1.8 to match the pre-commit hook (mirrors-clang-format v18.1.8).
+        # Ubuntu 24.04's apt clang-format is 18.1.3, which disagrees with 18.1.8 on
+        # brace-wrapping in macro initializers, causing the Format Check and
+        # Code Quality (pre-commit) jobs to contradict each other.
+        run: pipx install clang-format==18.1.8
 
       - name: Check C/C++ formatting
         run: |

--- a/packages/esp32-projects/esp32s3-gemini-vision/main/gemini_client.c
+++ b/packages/esp32-projects/esp32s3-gemini-vision/main/gemini_client.c
@@ -23,7 +23,7 @@
 static const char *TAG = "gemini";
 
 #define GEMINI_MODEL "gemini-robotics-er-1.5-preview"
-#define GEMINI_URL                                                                             \
+#define GEMINI_URL \
     "https://generativelanguage.googleapis.com/v1beta/models/" GEMINI_MODEL ":generateContent"
 
 #define GEMINI_RESPONSE_BUF_SIZE (16 * 1024)

--- a/packages/esp32-projects/esp32s3-gemini-vision/main/main.c
+++ b/packages/esp32-projects/esp32s3-gemini-vision/main/main.c
@@ -197,7 +197,7 @@ static void detection_store_update(const char *json, uint32_t latency_ms)
 }
 
 // ---------------------------------------------------- Gemini worker task ----
-static QueueHandle_t s_trigger_queue;     // messages: uint8_t (ignored; presence is the signal)
+static QueueHandle_t s_trigger_queue;  // messages: uint8_t (ignored; presence is the signal)
 static volatile bool s_inference_busy = false;
 static volatile uint32_t s_auto_interval_s = 0;  // 0 = disabled
 
@@ -273,8 +273,7 @@ extern const uint8_t index_html_end[] asm("_binary_index_html_end");
 static esp_err_t root_handler(httpd_req_t *req)
 {
     httpd_resp_set_type(req, "text/html; charset=utf-8");
-    return httpd_resp_send(req, (const char *)index_html_start,
-                           index_html_end - index_html_start);
+    return httpd_resp_send(req, (const char *)index_html_start, index_html_end - index_html_start);
 }
 
 static const char *STREAM_CT = "multipart/x-mixed-replace;boundary=frame";
@@ -331,10 +330,10 @@ static esp_err_t metadata_handler(httpd_req_t *req)
     }
     if (xSemaphoreTake(s_detection_mutex, portMAX_DELAY) == pdTRUE) {
         int n = snprintf(out, DETECTION_BUF_SIZE + 256,
-                         "{\"timestamp_ms\":%lld,\"latency_ms\":%u,\"busy\":%s,\"auto_interval_s\":%u,\"objects\":%s}",
+                         "{\"timestamp_ms\":%lld,\"latency_ms\":%u,\"busy\":%s,\"auto_interval_s\":"
+                         "%u,\"objects\":%s}",
                          (long long)(s_detection_timestamp_us / 1000),
-                         (unsigned)s_detection_latency_ms,
-                         s_inference_busy ? "true" : "false",
+                         (unsigned)s_detection_latency_ms, s_inference_busy ? "true" : "false",
                          (unsigned)s_auto_interval_s, s_detection_json);
         xSemaphoreGive(s_detection_mutex);
         httpd_resp_set_type(req, "application/json");
@@ -353,8 +352,10 @@ static esp_err_t config_handler(httpd_req_t *req)
         char val[16];
         if (httpd_query_key_value(query, "interval", val, sizeof(val)) == ESP_OK) {
             int v = atoi(val);
-            if (v < 0) v = 0;
-            if (v > 300) v = 300;
+            if (v < 0)
+                v = 0;
+            if (v > 300)
+                v = 300;
             s_auto_interval_s = v;
             ESP_LOGI(TAG, "auto_interval_s = %d", v);
         }
@@ -394,8 +395,7 @@ static void http_start(void)
     scfg.stack_size = 8192;
     httpd_handle_t stream = NULL;
     ESP_ERROR_CHECK(httpd_start(&stream, &scfg));
-    httpd_uri_t stream_uri = {
-        .uri = "/stream", .method = HTTP_GET, .handler = stream_handler};
+    httpd_uri_t stream_uri = {.uri = "/stream", .method = HTTP_GET, .handler = stream_handler};
     httpd_register_uri_handler(stream, &stream_uri);
 
     ESP_LOGI(TAG, "HTTP: api on :80, stream on :81");


### PR DESCRIPTION
## Summary

Two changes that together unblock the `Format Check` + `Code Quality Checks` job pair on every PR touching C code.

## Changes

1. **Pin CI `Format Check` to clang-format 18.1.8** (`.github/workflows/test.yml`)

   Install via `pipx install clang-format==18.1.8` instead of `apt-get install clang-format`. The apt package on Ubuntu 24.04 is 18.1.3, which disagrees with the pre-commit hook's pinned 18.1.8 on brace-wrapping in macro initializers (e.g. `LEFT_LED_CONFIG`, `SERVO_SYSTEM_CONFIG`, `OLED_DISPLAY_CONFIG` in `robocar-main/main/system_config.h`).

   With the old setup, a file can simultaneously fail `Format Check` (18.1.3 wants the expanded brace form) and be modified by the pre-commit hook (18.1.8 wants the compact form). That's mutually impossible to satisfy — blocking all downstream PRs.

2. **Apply clang-format to `esp32s3-gemini-vision/main/{gemini_client.c, main.c}`**

   These were merged via #206 / #211 without being clang-formatted. Every downstream PR that touches C code inherits these failures.

## Why this is blocking

Open PRs inheriting these failures: #212, #213, #214, #215.

## Test plan

- [x] `clang-format --dry-run --Werror --style=file` (18.1.8) passes for the touched files locally
- [x] `pre-commit run clang-format --files ...` passes for the touched files
- [ ] CI `Format Check` passes
- [ ] CI `Code Quality Checks` (pre-commit) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)