### PR TITLE
refactor(justfiles): consolidate duplication via shared imports

### DIFF
--- a/packages/esp32-projects/audiobook-player/justfile
+++ b/packages/esp32-projects/audiobook-player/justfile
@@ -93,4 +93,5 @@ pins:
     @echo "Status LED:   GPIO25 (built-in blue LED)"
 
 # Quick dev cycle: upload then watch logs
-dev: upload logs
+[group: "device"]
+develop: upload logs

--- a/packages/esp32-projects/esp32-cam-webserver/justfile
+++ b/packages/esp32-projects/esp32-cam-webserver/justfile
@@ -4,6 +4,7 @@
 set positional-arguments
 
 import '../../../tools/esp32-idf.just'
+import '../../../tools/esp32-credentials.just'
 
 project_dir := "packages/esp32-projects/esp32-cam-webserver"
 port := env("PORT", _detected_serial)
@@ -18,15 +19,7 @@ default:
 
 # Create credentials file from template
 [group: "setup"]
-credentials:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -f main/credentials.h ]; then
-        cp main/credentials.h.example main/credentials.h
-        echo "Created main/credentials.h — edit it with your WiFi credentials"
-    else
-        echo "Credentials file exists"
-    fi
+credentials: (_credentials "edit it with your WiFi credentials")
 
 # Build the firmware (requires credentials)
 [group: "build"]

--- a/packages/esp32-projects/esp32-wifitest/justfile
+++ b/packages/esp32-projects/esp32-wifitest/justfile
@@ -6,7 +6,6 @@ set positional-arguments
 import '../../../tools/esp32-idf.just'
 
 project_dir := "packages/esp32-projects/esp32-wifitest"
-tools_dir := justfile_directory() / "../../.." / "tools"
 port := env("PORT", _detected_s3)
 baud := env("BAUD", "460800")
 target := "esp32s3"

--- a/packages/esp32-projects/esp32-wireguard-ha-example/justfile
+++ b/packages/esp32-projects/esp32-wireguard-ha-example/justfile
@@ -94,4 +94,5 @@ info:
     @echo "See README.md for detailed setup instructions"
 
 # Quick dev cycle: upload then watch logs
-dev: upload logs
+[group: "device"]
+develop: upload logs

--- a/packages/esp32-projects/esp32s3-gemini-vision/justfile
+++ b/packages/esp32-projects/esp32s3-gemini-vision/justfile
@@ -3,7 +3,8 @@
 
 set positional-arguments
 
-import '../../../tools/esp32.just'
+import '../../../tools/esp32-idf.just'
+import '../../../tools/esp32-credentials.just'
 
 project_dir := "packages/esp32-projects/esp32s3-gemini-vision"
 port := env("PORT", _detected_s3)
@@ -18,55 +19,27 @@ default:
 
 # Copy credentials template on first build
 [group: "setup"]
-credentials:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -f main/credentials.h ]; then
-        cp main/credentials.h.example main/credentials.h
-        echo "Created main/credentials.h — edit WIFI_SSID, WIFI_PASSWORD, GEMINI_API_KEY"
-    fi
+credentials: (_credentials "edit WIFI_SSID, WIFI_PASSWORD, GEMINI_API_KEY")
 
 ##########
 # Build (containerized)
 ##########
 
-# Build the firmware
+# Build firmware (containerized)
 [group: "build"]
-build: credentials
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "Building esp32s3-gemini-vision..."
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        bash -c "idf.py set-target {{target}} && idf.py build"
+build: credentials _idf-build
 
-# Clean build artifacts
+# Clean build artifacts (containerized)
 [group: "build"]
-clean:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        idf.py fullclean
-    echo "Clean complete"
+clean: _idf-clean
 
-# Open sdkconfig menu
+# Open sdkconfig menu (containerized)
 [group: "build"]
-menuconfig:
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        idf.py menuconfig
+menuconfig: _idf-menuconfig
 
 # Interactive shell in ESP-IDF container
 [group: "build"]
-shell:
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        /bin/bash
+shell: _idf-shell
 
 ##########
 # Flash & Monitor (native — XIAO uses USB-Serial-JTAG)

--- a/packages/esp32-projects/it-troubleshooter/justfile
+++ b/packages/esp32-projects/it-troubleshooter/justfile
@@ -3,10 +3,11 @@
 
 set positional-arguments
 
-import '../../../tools/esp32.just'
+import '../../../tools/esp32-idf.just'
+import '../../../tools/esp32-credentials.just'
 
-project_dir := justfile_directory()
-tools_dir := justfile_directory() / "../../.." / "tools"
+project_dir := "packages/esp32-projects/it-troubleshooter"
+target := "esp32s3"
 port := env("PORT", _detected_s3)
 baud := env("BAUD", "460800")
 
@@ -23,29 +24,17 @@ default:
 
 # Create credentials.h from example template (required before first build)
 [group: "setup"]
-setup:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ -f main/credentials.h ]; then
-        echo "main/credentials.h already exists — no changes made"
-    else
-        cp main/credentials.h.example main/credentials.h
-        echo "Created main/credentials.h — edit with your WiFi SSID, password, and API key"
-    fi
+setup: (_credentials "edit with your WiFi SSID, password, and API key")
 
 ##########
 # Build
 ##########
 
-# Build firmware in Docker container
+# Build firmware (containerized)
 [group: "build"]
-build:
-    docker compose -f {{compose_file}} run --rm \
-        -w /workspace/packages/esp32-projects/it-troubleshooter \
-        esp-idf \
-        bash -c "idf.py set-target esp32s3 && idf.py build"
+build: _idf-build
 
-# Clean build artifacts
+# Clean build artifacts, sdkconfig, and managed_components
 [group: "build"]
 [confirm("Remove build/, sdkconfig, and managed_components?")]
 clean:
@@ -63,7 +52,7 @@ detect-port:
 # Flash firmware to device
 [group: "device"]
 flash: require-port
-    cd {{project_dir}}/build && esptool --chip esp32s3 -p {{port}} -b {{baud}} \
+    cd build && esptool --chip esp32s3 -p {{port}} -b {{baud}} \
         --before default-reset --after hard-reset \
         write-flash @flash_args
 
@@ -89,13 +78,13 @@ monitor: require-port
 # Config
 ##########
 
-# Run menuconfig in Docker
+# Run menuconfig (containerized)
 [group: "config"]
-menuconfig:
-    docker compose -f {{compose_file}} run --rm \
-        -w /workspace/packages/esp32-projects/it-troubleshooter \
-        esp-idf \
-        idf.py menuconfig
+menuconfig: _idf-menuconfig
+
+# Interactive shell in ESP-IDF container
+[group: "config"]
+shell: _idf-shell
 
 ##########
 # Info

--- a/packages/esp32-projects/robocar-camera/justfile
+++ b/packages/esp32-projects/robocar-camera/justfile
@@ -4,6 +4,7 @@
 set positional-arguments
 
 import '../../../tools/esp32-idf.just'
+import '../../../tools/esp32-credentials.just'
 
 project_dir := "packages/esp32-projects/robocar-camera"
 port := env("PORT", _detected_serial)
@@ -18,15 +19,7 @@ default:
 
 # Create credentials file from template
 [group: "setup"]
-credentials:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -f main/credentials.h ]; then
-        cp main/credentials.h.example main/credentials.h
-        echo "Created main/credentials.h — edit it with your WiFi and API credentials"
-    else
-        echo "Credentials file exists"
-    fi
+credentials: _credentials
 
 # Build the firmware (requires credentials)
 [group: "build"]

--- a/packages/esp32-projects/robocar-unified/justfile
+++ b/packages/esp32-projects/robocar-unified/justfile
@@ -3,7 +3,7 @@
 
 set positional-arguments
 
-import '../../../tools/esp32.just'
+import '../../../tools/esp32-idf.just'
 
 project_dir := "packages/esp32-projects/robocar-unified"
 port := env("PORT", _detected_s3)
@@ -16,43 +16,21 @@ default:
 # Build (containerized)
 ##########
 
-# Build the firmware
+# Build firmware (containerized)
 [group: "build"]
-build:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    echo "Building robocar-unified..."
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        bash -c "idf.py set-target {{target}} && idf.py build"
+build: _idf-build
 
-# Clean build files
+# Clean build artifacts (containerized)
 [group: "build"]
-clean:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        idf.py fullclean
-    echo "Clean complete"
+clean: _idf-clean
 
-# Open configuration menu
+# Open configuration menu (containerized)
 [group: "build"]
-menuconfig:
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        idf.py menuconfig
+menuconfig: _idf-menuconfig
 
 # Interactive shell in ESP-IDF container
 [group: "build"]
-shell:
-    {{container_cmd}} compose -f {{compose_file}} run --rm \
-        -w /workspace/{{project_dir}} \
-        esp-idf \
-        /bin/bash
+shell: _idf-shell
 
 ##########
 # Flash & Monitor (native — XIAO ESP32-S3 uses native USB-Serial-JTAG)

--- a/packages/esp32-projects/switch-usb-proxy/justfile
+++ b/packages/esp32-projects/switch-usb-proxy/justfile
@@ -6,7 +6,6 @@ set positional-arguments
 import '../../../tools/esp32-idf.just'
 
 project_dir := "packages/esp32-projects/switch-usb-proxy"
-tools_dir := justfile_directory() / "../../.." / "tools"
 port := env("PORT", _detected_s3)
 baud := env("BAUD", "460800")
 target := "esp32s3"

--- a/packages/esp32-projects/xbox-switch-bridge/justfile
+++ b/packages/esp32-projects/xbox-switch-bridge/justfile
@@ -6,7 +6,6 @@ set positional-arguments
 import '../../../tools/esp32.just'
 
 project_dir := "packages/esp32-projects/xbox-switch-bridge"
-tools_dir := justfile_directory() / "../../.." / "tools"
 port := env("PORT", _detected_s3)
 baud := env("BAUD", "460800")
 target := "esp32s3"

--- a/tools/esp32-credentials.just
+++ b/tools/esp32-credentials.just
@@ -1,0 +1,33 @@
+# Shared credentials.h bootstrap helper
+# Import this from project justfiles that have a main/credentials.h.example:
+#   import '../../../tools/esp32-credentials.just'
+#
+# Provides:
+#   _credentials hint="..." (private) — copy main/credentials.h.example to
+#                                        main/credentials.h if missing
+#
+# Usage in a project justfile:
+#
+#   # Use default hint
+#   [group: "setup"]
+#   credentials: _credentials
+#
+#   # Override hint
+#   [group: "setup"]
+#   credentials: (_credentials "edit WIFI_SSID, WIFI_PASSWORD, GEMINI_API_KEY")
+#
+#   # Or chain into build
+#   [group: "build"]
+#   build: credentials _idf-build
+
+# Copy main/credentials.h.example to main/credentials.h if missing
+[private]
+_credentials hint="edit it with your WiFi and API credentials":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -f main/credentials.h ]; then
+        echo "main/credentials.h already exists — no changes made"
+    else
+        cp main/credentials.h.example main/credentials.h
+        echo "Created main/credentials.h — {{hint}}"
+    fi

--- a/tools/esp32.just
+++ b/tools/esp32.just
@@ -4,6 +4,7 @@
 # Provides:
 #   container_cmd    — docker or podman
 #   compose_file     — path to shared docker-compose.yml
+#   tools_dir        — absolute path to the monorepo tools/ directory
 #   _detected_serial — auto-detected USB-serial adapter port (CH340/CP2102/FTDI)
 #   _detected_s3     — auto-detected ESP32-S3 USB-Serial-JTAG port
 #   _monitor_baud    — serial monitor baud rate (default 115200, override in project)
@@ -15,6 +16,9 @@ container_cmd := env("CONTAINER_CMD", "docker")
 
 # Shared docker-compose.yml (relative to each project at packages/esp32-projects/<name>/)
 compose_file := "../../../docker-compose.yml"
+
+# Absolute path to monorepo tools/ directory (for helper scripts)
+tools_dir := justfile_directory() / "../../.." / "tools"
 
 # Auto-detect USB-serial adapter (CH340/CP2102/FTDI)
 _detected_serial := `ls /dev/cu.usbserial-* 2>/dev/null | head -1 || true`


### PR DESCRIPTION
## Summary

Audit of 19 justfiles (run via a 4-specialist team) surfaced consolidation opportunities. Net **−71 lines** across 11 justfiles + 1 new shared helper.

### Changes

- **Migrate 3 projects to `esp32-idf.just`** — `robocar-unified`, `it-troubleshooter`, `esp32s3-gemini-vision` previously imported `esp32.just` and reimplemented `_idf-build` / `_idf-clean` / `_idf-menuconfig` / `_idf-shell` inline. Now delegate to the shared helpers.
- **New `tools/esp32-credentials.just`** — private `_credentials` helper with optional hint parameter. Collapses the `credentials.h.example → credentials.h` bootstrap in 4 projects to a single dependency.
- **Export `tools_dir` from `tools/esp32.just`** — removes 4 local redefinitions of `justfile_directory() / "../../.." / "tools"`.
- **Rename `dev:` → `develop:`** in `audiobook-player` and `esp32-wireguard-ha-example` for verb-first convention compliance; added missing `[group: "device"]`.
- **Bonus**: fixed an `it-troubleshooter` flash regression introduced while standardizing `project_dir` to a relative path (simplified `cd {{project_dir}}/build` → `cd build`).

### Why

`.claude/rules/containerized-builds.md` explicitly forbids inline container commands when shared helpers exist. The three migrated projects were the last offenders. Credentials bootstrap and `tools_dir` redefinition were the top cross-cutting duplications the audit team identified.

## Test plan

- [x] `just --list` parses cleanly in all 10 modified projects
- [x] `tools_dir` resolves correctly in all 4 projects that previously defined it
- [x] No functional changes to flash, monitor, build offsets, or credential logic
- [ ] CI: ESP32 build matrix passes
- [ ] CI: pre-commit hooks pass

## Follow-up

- #218 — pre-existing cppcheck failures in C source (surfaced by this refactor's lint runs but not caused by it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)