### PR TITLE
chore(claude): scope post-edit lint hook to C/Python sources

### DIFF
--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# PostToolUse:Edit hook — run `make lint` and `make format` only when the edited
+# file is a C/C++ or Python source. Prevents unrelated lint runs on every
+# justfile, Markdown, or config edit.
+#
+# Reads the Claude Code hook payload on stdin and extracts
+# `.tool_input.file_path` via jq. Files outside the relevant extensions
+# produce exit 0 immediately so no lint chore runs.
+set -euo pipefail
+
+# Extract the edited file path from the hook payload
+# If jq fails or the payload has no file_path, skip silently
+file_path="$(jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+
+if [[ -z "$file_path" ]]; then
+    exit 0
+fi
+
+case "$file_path" in
+    *.c|*.h|*.cpp|*.hpp|*.py)
+        cd "$CLAUDE_PROJECT_DIR"
+        exec make lint format
+        ;;
+    *)
+        exit 0
+        ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/post-edit-lint.sh\"",
+            "timeout": 120
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Moves the `PostToolUse:Edit` hook from personal `.claude/settings.local.json` into the tracked `.claude/settings.json` and scopes it to file types that actually need linting.

Previously the hook ran `make lint && make format` after **every single Edit** — a justfile, Markdown, YAML, or JSON edit would trigger cppcheck on the entire C codebase. `make lint-c` currently fails with 48 pre-existing cppcheck findings (#218), so the hook reported blocking errors on every unrelated edit.

## Changes

- New script `.claude/hooks/post-edit-lint.sh` — reads the Claude Code tool payload from stdin via `jq`, inspects `.tool_input.file_path`, runs `make lint format` only when the path ends in `.c/.h/.cpp/.hpp/.py`. Otherwise exits 0 immediately.
- Register the hook in `.claude/settings.json` under `PostToolUse` with matcher `Edit|Write|MultiEdit` (so `Write` and `MultiEdit` are also covered).
- `set -euo pipefail`, `exec`s `make` so the hook returns its exit code directly.

## Why tracked, not local?

Every contributor running Claude Code on this repo benefits from the same sensible default. The old config lived in `settings.local.json` — gitignored — so it only helped the one user who set it up. Moving it into `settings.json` makes the behavior repository-wide.

## Test plan

Tested the script with three payload shapes (local testing):

- [x] `{"tool_input":{"file_path":"some/file.c"}}` → matches, runs `make lint format`
- [x] `{"tool_input":{"file_path":"some/file/justfile"}}` → exits 0
- [x] `{}` (no file_path) → exits 0

The hook only takes effect on the next Claude Code session (current session has the old hook cached). Contributors should not notice any behavior change unless they edit C or Python files, in which case they'll get the same lint/format pass as before.

## Related

- #218 — pre-existing cppcheck failures that this hook was noisily surfacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)