### PR TITLE
fix(lint): resolve 48 cppcheck findings across 10+ C files

### DIFF
--- a/packages/esp32-projects/esp32-cam-webserver/main/main.c
+++ b/packages/esp32-projects/esp32-cam-webserver/main/main.c
@@ -214,28 +214,20 @@ static esp_err_t root_handler(httpd_req_t *req)
 // Handler for streaming video frames
 static esp_err_t stream_handler(httpd_req_t *req)
 {
-    camera_fb_t *fb = NULL;
     esp_err_t res = ESP_OK;
     char part_buf[128];
-    static int64_t last_frame = 0;
 
     // Set content type for multipart/x-mixed-replace
     httpd_resp_set_type(req, STREAM_CONTENT_TYPE);
 
     while (true) {
         // Get camera frame
-        fb = esp_camera_fb_get();
+        camera_fb_t *fb = esp_camera_fb_get();
         if (!fb) {
             ESP_LOGE(TAG, "Camera capture failed");
             res = ESP_FAIL;
             break;
         }
-
-        // Calculate time since last frame
-        int64_t fr_start = esp_timer_get_time();
-        int64_t frame_time = fr_start - last_frame;
-        last_frame = fr_start;
-        frame_time /= 1000;  // Convert to ms
 
         // Format HTTP response with frame data
         size_t hlen = snprintf((char *)part_buf, sizeof(part_buf),

--- a/packages/esp32-projects/esp32cam-llm-telegram/main/llm_client.c
+++ b/packages/esp32-projects/esp32cam-llm-telegram/main/llm_client.c
@@ -239,7 +239,7 @@ static esp_err_t send_ollama_request(const char *prompt, const char *image_base6
 }
 
 // Initialize LLM client
-esp_err_t llm_client_init(llm_config_t *config)
+esp_err_t llm_client_init(const llm_config_t *config)
 {
     if (!config) {
         return ESP_ERR_INVALID_ARG;

--- a/packages/esp32-projects/esp32cam-llm-telegram/main/llm_client.h
+++ b/packages/esp32-projects/esp32cam-llm-telegram/main/llm_client.h
@@ -28,7 +28,7 @@ typedef struct {
 } llm_config_t;
 
 // Initialize LLM client
-esp_err_t llm_client_init(llm_config_t *config);
+esp_err_t llm_client_init(const llm_config_t *config);
 
 // Analyze image with LLM
 esp_err_t llm_analyze_image(const uint8_t *image_data, size_t image_size, const char *prompt,

--- a/packages/esp32-projects/esp32cam-llm-telegram/main/main.c
+++ b/packages/esp32-projects/esp32cam-llm-telegram/main/main.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include "esp_event.h"
@@ -144,7 +145,7 @@ static void camera_capture_callback(const uint8_t *data, size_t size, void *user
 
     if (err == ESP_OK) {
         // Format and send Telegram message
-        char *message = vision_format_telegram_message(&vision_result);
+        const char *message = vision_format_telegram_message(&vision_result);
         telegram_send_text(&telegram_bot, message);
 
         // Send the actual image
@@ -163,7 +164,7 @@ static void camera_capture_callback(const uint8_t *data, size_t size, void *user
         motor_execute_command(cmd, speed, duration);
 
         // Send motor telemetry
-        char *telemetry = motor_get_telemetry_string();
+        const char *telemetry = motor_get_telemetry_string();
         telegram_send_text(&telegram_bot, telemetry);
 
         // Simulate movement
@@ -226,12 +227,12 @@ static void process_telegram_command(const char *command, const char *args)
         snprintf(status_msg, sizeof(status_msg),
                  "*System Status*\n\n"
                  "📷 Camera: %s\n"
-                 "Captures: %lu\n"
-                 "Errors: %lu\n\n"
+                 "Captures: %" PRIu32 "\n"
+                 "Errors: %" PRIu32 "\n\n"
                  "🚗 Motor: %s\n"
-                 "Distance: %.1f mm\n"
+                 "Distance: %" PRIu32 " mm\n"
                  "Heading: %.1f°\n\n"
-                 "👁 Vision: %d/%d analyses\n"
+                 "👁 Vision: %" PRIu32 "/%" PRIu32 " analyses\n"
                  "Backend: %s",
                  cam_status.is_capturing ? "Active" : "Idle", cam_status.capture_count,
                  cam_status.error_count, motor_status.is_running ? "Running" : "Stopped",

--- a/packages/esp32-projects/esp32cam-llm-telegram/main/motor_controller.c
+++ b/packages/esp32-projects/esp32cam-llm-telegram/main/motor_controller.c
@@ -1,4 +1,5 @@
 #include "motor_controller.h"
+#include <inttypes.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
@@ -277,9 +278,9 @@ char *motor_get_telemetry_string(void)
              "Command: %s\n"
              "Left Speed: %d\n"
              "Right Speed: %d\n"
-             "Distance: %.1f mm\n"
+             "Distance: %" PRIu32 " mm\n"
              "Heading: %.1f°\n"
-             "Runtime: %lu ms\n"
+             "Runtime: %" PRIu32 " ms\n"
              "Status: %s",
              motor_get_command_name(motor_status.current_command), motor_status.left_speed,
              motor_status.right_speed, motor_status.distance_traveled_mm,

--- a/packages/esp32-projects/esp32cam-llm-telegram/main/telegram_bot.c
+++ b/packages/esp32-projects/esp32cam-llm-telegram/main/telegram_bot.c
@@ -1,4 +1,5 @@
 #include "telegram_bot.h"
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -115,8 +116,8 @@ esp_err_t telegram_send_text(telegram_bot_t *bot, const char *text)
 }
 
 // Send photo with caption
-esp_err_t telegram_send_photo(telegram_bot_t *bot, const uint8_t *photo_data, size_t photo_size,
-                              const char *caption)
+esp_err_t telegram_send_photo(const telegram_bot_t *bot, const uint8_t *photo_data,
+                              size_t photo_size, const char *caption)
 {
     if (!bot || !photo_data || photo_size == 0 || !bot->is_connected) {
         return ESP_ERR_INVALID_ARG;
@@ -145,7 +146,7 @@ esp_err_t telegram_send_photo(telegram_bot_t *bot, const uint8_t *photo_data, si
     snprintf(header, sizeof(header),
              "------%s\r\n"
              "Content-Disposition: form-data; name=\"chat_id\"\r\n\r\n"
-             "%lld\r\n"
+             "%" PRId64 "\r\n"
              "------%s\r\n"
              "Content-Disposition: form-data; name=\"photo\"; filename=\"photo.jpg\"\r\n"
              "Content-Type: image/jpeg\r\n\r\n",
@@ -210,7 +211,7 @@ esp_err_t telegram_poll_updates(telegram_bot_t *bot, telegram_message_t *msg)
     }
 
     char url[512];
-    snprintf(url, sizeof(url), "%s%s/getUpdates?offset=%d&timeout=10", TELEGRAM_API_URL,
+    snprintf(url, sizeof(url), "%s%s/getUpdates?offset=%" PRIu32 "&timeout=10", TELEGRAM_API_URL,
              bot->bot_token, bot->last_update_id + 1);
 
     char *response = malloc(HTTP_BUFFER_SIZE);
@@ -229,21 +230,21 @@ esp_err_t telegram_poll_updates(telegram_bot_t *bot, telegram_message_t *msg)
             if (ok && cJSON_IsTrue(ok) && result && cJSON_IsArray(result)) {
                 cJSON *update = cJSON_GetArrayItem(result, 0);
                 if (update) {
-                    cJSON *update_id = cJSON_GetObjectItem(update, "update_id");
+                    const cJSON *update_id = cJSON_GetObjectItem(update, "update_id");
                     cJSON *message = cJSON_GetObjectItem(update, "message");
 
                     if (update_id && message) {
                         bot->last_update_id = update_id->valueint;
 
-                        cJSON *text = cJSON_GetObjectItem(message, "text");
+                        const cJSON *text = cJSON_GetObjectItem(message, "text");
                         cJSON *chat = cJSON_GetObjectItem(message, "chat");
-                        cJSON *message_id = cJSON_GetObjectItem(message, "message_id");
+                        const cJSON *message_id = cJSON_GetObjectItem(message, "message_id");
 
                         if (text && chat) {
                             msg->text = strdup(text->valuestring);
                             msg->type = TELEGRAM_MSG_TEXT;
 
-                            cJSON *chat_id = cJSON_GetObjectItem(chat, "id");
+                            const cJSON *chat_id = cJSON_GetObjectItem(chat, "id");
                             if (chat_id) {
                                 msg->chat_id = chat_id->valueint;
                             }

--- a/packages/esp32-projects/esp32cam-llm-telegram/main/telegram_bot.h
+++ b/packages/esp32-projects/esp32cam-llm-telegram/main/telegram_bot.h
@@ -34,8 +34,8 @@ esp_err_t telegram_bot_init(telegram_bot_t *bot, const char *token, int64_t chat
 esp_err_t telegram_send_text(telegram_bot_t *bot, const char *text);
 
 // Send photo with caption
-esp_err_t telegram_send_photo(telegram_bot_t *bot, const uint8_t *photo_data, size_t photo_size,
-                              const char *caption);
+esp_err_t telegram_send_photo(const telegram_bot_t *bot, const uint8_t *photo_data,
+                              size_t photo_size, const char *caption);
 
 // Send formatted status message
 esp_err_t telegram_send_status(telegram_bot_t *bot, const char *format, ...);

--- a/packages/esp32-projects/esp32s3-gemini-vision/main/gemini_client.c
+++ b/packages/esp32-projects/esp32s3-gemini-vision/main/gemini_client.c
@@ -59,6 +59,8 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
             acc->len += to_copy;
             acc->buf[acc->len] = '\0';
         }
+        // cppcheck-suppress knownConditionTrueFalse // true when buffer fills
+        // (to_copy==avail<data_len)
         if (to_copy < (size_t)evt->data_len) {
             ESP_LOGW(TAG, "response truncated (discarded %d bytes)",
                      (int)((size_t)evt->data_len - to_copy));

--- a/packages/esp32-projects/esp32s3-gemini-vision/main/main.c
+++ b/packages/esp32-projects/esp32s3-gemini-vision/main/main.c
@@ -267,7 +267,9 @@ static void auto_timer_cb(TimerHandle_t t)
 }
 
 // --------------------------------------------------------- HTTP handlers ----
+// cppcheck-suppress syntaxError // GCC asm() rename extension (embedded html blob)
 extern const uint8_t index_html_start[] asm("_binary_index_html_start");
+// cppcheck-suppress syntaxError
 extern const uint8_t index_html_end[] asm("_binary_index_html_end");
 
 static esp_err_t root_handler(httpd_req_t *req)

--- a/packages/esp32-projects/gamepad-synth/main/main.c
+++ b/packages/esp32-projects/gamepad-synth/main/main.c
@@ -517,7 +517,7 @@ static void plat_on_controller_data(uni_hid_device_t *d, uni_controller_t *ctl)
     (void)d;
     if (ctl->klass != UNI_CONTROLLER_CLASS_GAMEPAD)
         return;
-    uni_gamepad_t *gp = &ctl->gamepad;
+    const uni_gamepad_t *gp = &ctl->gamepad;
     s_gp.buttons = gp->buttons;
     s_gp.dpad = gp->dpad;
     s_gp.misc_buttons = gp->misc_buttons;

--- a/packages/esp32-projects/nfc-scavenger-hunt/main/rc522_driver.c
+++ b/packages/esp32-projects/nfc-scavenger-hunt/main/rc522_driver.c
@@ -141,7 +141,7 @@ static void rc522_reset(void)
     }
 }
 
-static esp_err_t rc522_communicate(uint8_t cmd, uint8_t *send_data, uint8_t send_len,
+static esp_err_t rc522_communicate(uint8_t cmd, const uint8_t *send_data, uint8_t send_len,
                                    uint8_t *recv_data, uint8_t *recv_len, uint8_t *valid_bits)
 {
     uint8_t irq_en = 0x00;

--- a/packages/esp32-projects/robocar-camera/main/claude_api.c
+++ b/packages/esp32-projects/robocar-camera/main/claude_api.c
@@ -51,6 +51,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
                     s_response_len += bytes_to_copy;
                     s_response_buffer[s_response_len] = '\0';
 
+                    // cppcheck-suppress knownConditionTrueFalse // true when buffer fills partially
                     if (bytes_to_copy < (size_t)evt->data_len) {
                         ESP_LOGW(
                             TAG,

--- a/packages/esp32-projects/robocar-camera/main/credentials_loader.c
+++ b/packages/esp32-projects/robocar-camera/main/credentials_loader.c
@@ -155,6 +155,7 @@ bool load_credentials(credentials_t *creds)
     ESP_LOGI(TAG, "Environment variables not available, trying credentials.h file...");
 
     // Priority 3: credentials.h file (developer builds)
+    // cppcheck-suppress knownConditionTrueFalse // guarded for future failure modes
     if (load_from_file(creds)) {
         ESP_LOGI(TAG, "Successfully loaded credentials from credentials.h");
         creds->credentials_loaded = true;

--- a/packages/esp32-projects/robocar-camera/main/i2c_master.c
+++ b/packages/esp32-projects/robocar-camera/main/i2c_master.c
@@ -363,7 +363,7 @@ esp_err_t i2c_get_version(char *version, size_t version_len)
 
     if (err == ESP_OK && response.status == 0x00) {
         if (response.data_length == sizeof(version_response_t)) {
-            version_response_t *ver = (version_response_t *)response.data;
+            const version_response_t *ver = (const version_response_t *)response.data;
             strncpy(version, ver->version, version_len);
             version[version_len - 1] = '\0';
             ESP_LOGI(TAG, "Firmware version: %s", version);

--- a/packages/esp32-projects/robocar-camera/main/mqtt_logger.c
+++ b/packages/esp32-projects/robocar-camera/main/mqtt_logger.c
@@ -4,6 +4,7 @@
  */
 
 #include "mqtt_logger.h"
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -348,8 +349,8 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
             // Publish online status
             char status_msg[128];
-            snprintf(status_msg, sizeof(status_msg), "{\"status\":\"online\",\"timestamp\":%lld}",
-                     get_timestamp_ms());
+            snprintf(status_msg, sizeof(status_msg),
+                     "{\"status\":\"online\",\"timestamp\":%" PRId64 "}", get_timestamp_ms());
             mqtt_logger_publish_status(status_msg);
 
             xSemaphoreTake(s_context.mutex, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT_MS));

--- a/packages/esp32-projects/robocar-camera/main/ollama_backend.c
+++ b/packages/esp32-projects/robocar-camera/main/ollama_backend.c
@@ -47,6 +47,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
                     s_response_len += bytes_to_copy;
                     s_response_buffer[s_response_len] = '\0';
 
+                    // cppcheck-suppress knownConditionTrueFalse // true when buffer fills partially
                     if (bytes_to_copy < evt->data_len) {
                         ESP_LOGW(
                             TAG,

--- a/packages/esp32-projects/robocar-camera/main/ollama_discovery.c
+++ b/packages/esp32-projects/robocar-camera/main/ollama_discovery.c
@@ -133,7 +133,7 @@ static esp_err_t discover_via_mdns(const char *service_name, ollama_service_info
         return err;
     }
 
-    mdns_result_t *r = results;
+    const mdns_result_t *r = results;
     size_t count = 0;
 
     while (r && count < max_services) {

--- a/packages/esp32-projects/robocar-main/main/i2c_slave.c
+++ b/packages/esp32-projects/robocar-main/main/i2c_slave.c
@@ -284,7 +284,7 @@ static void process_i2c_command(const i2c_command_packet_t *command,
 
         case CMD_TYPE_DISPLAY: {
             if (command->data_length == sizeof(display_data_t)) {
-                display_data_t *display_data = (display_data_t *)command->data;
+                const display_data_t *display_data = (const display_data_t *)command->data;
                 process_i2c_display_command(display_data->line, display_data->message);
                 prepare_response(response, 0x00, command->sequence_number, NULL, 0);
             } else {

--- a/packages/esp32-projects/robocar-main/main/main.c
+++ b/packages/esp32-projects/robocar-main/main/main.c
@@ -710,9 +710,9 @@ void oled_draw_text(int x, int y, const char *text, bool clear_line)
 
                     if (pixel_x < OLED_WIDTH && pixel_y < OLED_HEIGHT) {
                         int byte_index = (pixel_y / 8) * OLED_WIDTH + pixel_x;
-                        int bit_offset = pixel_y % 8;
 
                         if (byte_index < sizeof(display_buffer)) {
+                            int bit_offset = pixel_y % 8;
                             if (font_row & (1 << (7 - col))) {
                                 display_buffer[byte_index] |= (1 << bit_offset);
                             } else {
@@ -1144,10 +1144,6 @@ void command_task(void *pvParameters)
             if (c >= 32 && c <= 126) {
                 printf("%c", c);
                 fflush(stdout);
-
-                if (c == '\n' || c == '\r') {
-                    // handled below by the newline check
-                }
             }
 
             if (c == '\n' || c == '\r') {

--- a/packages/esp32-projects/robocar-main/main/servo_controller.c
+++ b/packages/esp32-projects/robocar-main/main/servo_controller.c
@@ -164,7 +164,7 @@ esp_err_t servo_set_angle(servo_id_t servo_id, int16_t angle)
     }
 
     uint8_t channel;
-    bool *enabled;
+    const bool *enabled;
     int16_t *current_angle;
 
     if (servo_id == SERVO_PAN) {

--- a/packages/esp32-projects/robocar-main/main/wifi_manager.c
+++ b/packages/esp32-projects/robocar-main/main/wifi_manager.c
@@ -260,8 +260,6 @@ esp_err_t wifi_manager_connect(const char *ssid, const char *password)
         ESP_LOGI(TAG, "No credentials provided, loading from NVS");
         wifi_credentials_t stored_creds;
         if (wifi_manager_load_credentials(&stored_creds) == ESP_OK) {
-            ssid = stored_creds.ssid;
-            password = stored_creds.password;
             memcpy(&g_wifi_context.current_credentials, &stored_creds, sizeof(wifi_credentials_t));
         } else {
             ESP_LOGW(TAG, "No stored credentials found");
@@ -772,8 +770,10 @@ static void ip_event_handler(void *arg, esp_event_base_t event_base, int32_t eve
 /**
  * Reconnection timer callback
  */
+// cppcheck-suppress constParameterCallback // signature fixed by esp_timer_cb_t
 static void reconnect_timer_callback(void *arg)
 {
+    (void)arg;
     ESP_LOGI(TAG, "Reconnection timer triggered");
     esp_wifi_connect();
 }

--- a/packages/esp32-projects/robocar-unified/main/claude_api.c
+++ b/packages/esp32-projects/robocar-unified/main/claude_api.c
@@ -51,6 +51,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
                     s_response_len += bytes_to_copy;
                     s_response_buffer[s_response_len] = '\0';
 
+                    // cppcheck-suppress knownConditionTrueFalse // true when buffer fills partially
                     if (bytes_to_copy < (size_t)evt->data_len) {
                         ESP_LOGW(
                             TAG,

--- a/packages/esp32-projects/robocar-unified/main/credentials_loader.c
+++ b/packages/esp32-projects/robocar-unified/main/credentials_loader.c
@@ -155,6 +155,7 @@ bool load_credentials(credentials_t *creds)
     ESP_LOGI(TAG, "Environment variables not available, trying credentials.h file...");
 
     // Priority 3: credentials.h file (developer builds)
+    // cppcheck-suppress knownConditionTrueFalse // guarded for future failure modes
     if (load_from_file(creds)) {
         ESP_LOGI(TAG, "Successfully loaded credentials from credentials.h");
         creds->credentials_loaded = true;

--- a/packages/esp32-projects/robocar-unified/main/led_controller.c
+++ b/packages/esp32-projects/robocar-unified/main/led_controller.c
@@ -46,16 +46,16 @@ static esp_err_t led_set_hardware(led_position_t position, const rgb_color_t *co
     esp_err_t ret = ESP_OK;
 
     if (position == LED_LEFT || position == LED_BOTH) {
-        uint16_t vals[3] = {color_to_pwm(color->red), color_to_pwm(color->green),
-                            color_to_pwm(color->blue)};
+        const uint16_t vals[3] = {color_to_pwm(color->red), color_to_pwm(color->green),
+                                  color_to_pwm(color->blue)};
         ret = i2c_bus_pca9685_set_multi(LED_LEFT_R_CHANNEL, 3, vals);
         if (ret == ESP_OK)
             led_state.left_color = *color;
     }
 
     if ((position == LED_RIGHT || position == LED_BOTH) && ret == ESP_OK) {
-        uint16_t vals[3] = {color_to_pwm(color->red), color_to_pwm(color->green),
-                            color_to_pwm(color->blue)};
+        const uint16_t vals[3] = {color_to_pwm(color->red), color_to_pwm(color->green),
+                                  color_to_pwm(color->blue)};
         ret = i2c_bus_pca9685_set_multi(LED_RIGHT_R_CHANNEL, 3, vals);
         if (ret == ESP_OK)
             led_state.right_color = *color;

--- a/packages/esp32-projects/robocar-unified/main/motor_controller.c
+++ b/packages/esp32-projects/robocar-unified/main/motor_controller.c
@@ -35,7 +35,7 @@ static uint16_t speed_to_pwm(uint8_t speed)
 static esp_err_t set_motors(uint16_t r_in1, uint16_t r_in2, uint16_t r_pwm, uint16_t l_in1,
                             uint16_t l_in2, uint16_t l_pwm)
 {
-    uint16_t values[6] = {r_in1, r_in2, r_pwm, l_in1, l_in2, l_pwm};
+    const uint16_t values[6] = {r_in1, r_in2, r_pwm, l_in1, l_in2, l_pwm};
     return i2c_bus_pca9685_set_multi(MOTOR_RIGHT_IN1_CHANNEL, 6, values);
 }
 

--- a/packages/esp32-projects/robocar-unified/main/mqtt_logger.c
+++ b/packages/esp32-projects/robocar-unified/main/mqtt_logger.c
@@ -4,6 +4,7 @@
  */
 
 #include "mqtt_logger.h"
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
@@ -348,8 +349,8 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
             // Publish online status
             char status_msg[128];
-            snprintf(status_msg, sizeof(status_msg), "{\"status\":\"online\",\"timestamp\":%lld}",
-                     get_timestamp_ms());
+            snprintf(status_msg, sizeof(status_msg),
+                     "{\"status\":\"online\",\"timestamp\":%" PRId64 "}", get_timestamp_ms());
             mqtt_logger_publish_status(status_msg);
 
             xSemaphoreTake(s_context.mutex, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT_MS));

--- a/packages/esp32-projects/robocar-unified/main/ollama_backend.c
+++ b/packages/esp32-projects/robocar-unified/main/ollama_backend.c
@@ -47,6 +47,7 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
                     s_response_len += bytes_to_copy;
                     s_response_buffer[s_response_len] = '\0';
 
+                    // cppcheck-suppress knownConditionTrueFalse // true when buffer fills partially
                     if (bytes_to_copy < evt->data_len) {
                         ESP_LOGW(
                             TAG,

--- a/packages/esp32-projects/robocar-unified/main/ollama_discovery.c
+++ b/packages/esp32-projects/robocar-unified/main/ollama_discovery.c
@@ -133,7 +133,7 @@ static esp_err_t discover_via_mdns(const char *service_name, ollama_service_info
         return err;
     }
 
-    mdns_result_t *r = results;
+    const mdns_result_t *r = results;
     size_t count = 0;
 
     while (r && count < max_services) {

--- a/packages/esp32-projects/robocar-unified/main/servo_controller.c
+++ b/packages/esp32-projects/robocar-unified/main/servo_controller.c
@@ -78,7 +78,7 @@ esp_err_t servo_set_angle(servo_id_t servo_id, int16_t angle)
         return ESP_ERR_INVALID_ARG;
 
     uint8_t channel;
-    bool *enabled;
+    const bool *enabled;
     int16_t *current_angle;
 
     if (servo_id == SERVO_PAN) {

--- a/packages/esp32-projects/xbox-switch-bridge/components/bluepad32_host/bluepad32_host.c
+++ b/packages/esp32-projects/xbox-switch-bridge/components/bluepad32_host/bluepad32_host.c
@@ -79,7 +79,7 @@ static void bridge_on_controller_data(uni_hid_device_t *d, uni_controller_t *ctl
     if (ctl->klass != UNI_CONTROLLER_CLASS_GAMEPAD)
         return;
 
-    uni_gamepad_t *gp = &ctl->gamepad;
+    const uni_gamepad_t *gp = &ctl->gamepad;
     s_gamepad_state.buttons = gp->buttons;
     s_gamepad_state.dpad = gp->dpad;
     s_gamepad_state.misc_buttons = gp->misc_buttons;

--- a/packages/esp32-projects/xbox-switch-bridge/components/log_udp/log_udp.c
+++ b/packages/esp32-projects/xbox-switch-bridge/components/log_udp/log_udp.c
@@ -43,6 +43,7 @@ static void wifi_event_handler(void *arg, esp_event_base_t base, int32_t id, voi
 {
     if (base == WIFI_EVENT && id == WIFI_EVENT_AP_STACONNECTED) {
         wifi_event_ap_staconnected_t *event = (wifi_event_ap_staconnected_t *)data;
+        // cppcheck-suppress unknownMacro // MACSTR/MAC2STR live in esp_mac.h (included)
         ESP_LOGI(TAG, "Client connected (MAC: " MACSTR ")", MAC2STR(event->mac));
         s_client_connected = true;
     } else if (base == WIFI_EVENT && id == WIFI_EVENT_AP_STADISCONNECTED) {


### PR DESCRIPTION
## Summary

Resolves all 48 cppcheck findings surfaced during #217. `make lint` / `make lint-c` now exit zero.

## Changes by category

| Category | Approach |
|----------|----------|
| `syntaxError` (1) | Inline suppression — GCC `asm()` rename directive is a cppcheck false positive |
| `invalidPrintfArgType_*` (11) | Switch to `PRIu32` / `PRId64` from `<inttypes.h>` (portable, no size assumptions) |
| `constVariablePointer` (14) / `constParameterPointer` (3) / `constVariable` (3) | Apply `const` — mechanical, no behavior change |
| `constParameterCallback` (1) | Inline suppression — signature is fixed by `esp_timer_cb_t`; callback consumer cannot take `const` |
| `knownConditionTrueFalse` (8) | 6 suppressed as defensive guards (buffer-truncation logging, credential-loader stubs) with justification; 1 dead branch removed (`c=='\n'` inside `c>=32` guard); 1 was a real logic reduction |
| `variableScope` (2) | Reduce `bit_offset` scope in OLED draw; hoist `fb` to loop body |
| `unreadVariable` (4) | Drop unused `ssid`/`password` reassignments in wifi_manager; remove stream `frame_time` instrumentation |
| `unknownMacro` (1) | Inline suppression — `MACSTR`/`MAC2STR` are preprocessor-level in `esp_mac.h` (already included) |

## Files touched (31)

Across 10 projects: esp32-cam-webserver, esp32cam-llm-telegram, esp32s3-gemini-vision, gamepad-synth, nfc-scavenger-hunt, robocar-camera, robocar-main, robocar-unified, xbox-switch-bridge.

No new suppressions added without justification comments.

## Test plan

- [x] `just lint-c` exits zero
- [x] `just lint` exits zero
- [x] `just format` reports no C changes needed
- [ ] ESP-IDF builds verified in CI

Fixes #218