### PR TITLE
test(robocar-unified): host-test harness + hook scoping fixes

### DIFF
--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,25 +1,50 @@
 #!/usr/bin/env bash
-# PostToolUse:Edit hook — run `make lint` and `make format` only when the edited
-# file is a C/C++ or Python source. Prevents unrelated lint runs on every
-# justfile, Markdown, or config edit.
+# PostToolUse:Edit hook — lint and format only the edited file.
+#
+# Previous versions ran `just lint format` which walks the full tree and
+# reformats unrelated C files (flattening HID descriptor tables etc.). This
+# scopes the work to the single edited path so the author's intent elsewhere
+# in the tree is preserved.
 #
 # Reads the Claude Code hook payload on stdin and extracts
-# `.tool_input.file_path` via jq. Files outside the relevant extensions
-# produce exit 0 immediately so no lint chore runs.
+# `.tool_input.file_path` via jq. Non-C/Python paths exit 0 immediately.
 set -euo pipefail
 
-# Extract the edited file path from the hook payload
-# If jq fails or the payload has no file_path, skip silently
 file_path="$(jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
 
-if [[ -z "$file_path" ]]; then
+if [[ -z "$file_path" || ! -f "$file_path" ]]; then
     exit 0
 fi
 
+# Skip files in vendored/generated trees even if they are C/Python.
 case "$file_path" in
-    *.c|*.h|*.cpp|*.hpp|*.py)
-        cd "$CLAUDE_PROJECT_DIR"
-        exec make lint format
+    */managed_components/*|*/components/esp-idf-lib/*|*/external/*|*/build/*|*/.esphome/*|*/.venv/*)
+        exit 0
+        ;;
+esac
+
+case "$file_path" in
+    *.c|*.h|*.cpp|*.hpp)
+        if command -v clang-format >/dev/null 2>&1; then
+            clang-format -i --style=file "$file_path"
+        fi
+        if command -v cppcheck >/dev/null 2>&1; then
+            cppcheck \
+                --enable=warning,style,performance,portability \
+                --suppress=missingIncludeSystem \
+                --suppress=unmatchedSuppression \
+                --suppress=unusedStructMember \
+                --inline-suppr \
+                --quiet \
+                --template=gcc \
+                "$file_path" || true
+        fi
+        ;;
+    *.py)
+        if command -v ruff >/dev/null 2>&1; then
+            ruff format "$file_path" >/dev/null || true
+            ruff check --fix "$file_path" || true
+        fi
         ;;
     *)
         exit 0

--- a/packages/esp32-projects/it-troubleshooter/components/usb_composite/usb_composite.c
+++ b/packages/esp32-projects/it-troubleshooter/components/usb_composite/usb_composite.c
@@ -64,7 +64,10 @@ static const char *s_string_desc[] = {
     [3] = "000001",
 };
 
-/* HID boot keyboard report descriptor */
+/* HID boot keyboard report descriptor.
+ * The paired-byte layout below encodes meaning (each line is one HID item);
+ * do not reflow. */
+/* clang-format off */
 static const uint8_t s_hid_report_desc[] = {
     0x05, 0x01, /* Usage Page (Generic Desktop) */
     0x09, 0x06, /* Usage (Keyboard) */
@@ -99,17 +102,18 @@ static const uint8_t s_hid_report_desc[] = {
     0x91, 0x01, /*   Output (Constant) */
 
     /* Key codes (6 bytes) */
-    0x95, 0x06,       /*   Report Count (6) */
-    0x75, 0x08,       /*   Report Size (8) */
-    0x15, 0x00,       /*   Logical Minimum (0) */
+    0x95, 0x06, /*   Report Count (6) */
+    0x75, 0x08, /*   Report Size (8) */
+    0x15, 0x00, /*   Logical Minimum (0) */
     0x26, 0xFF, 0x00, /* Logical Maximum (255) */
-    0x05, 0x07,       /*   Usage Page (Key Codes) */
-    0x19, 0x00,       /*   Usage Minimum (0) */
+    0x05, 0x07, /*   Usage Page (Key Codes) */
+    0x19, 0x00, /*   Usage Minimum (0) */
     0x2A, 0xFF, 0x00, /* Usage Maximum (255) */
-    0x81, 0x00,       /*   Input (Data, Array) */
+    0x81, 0x00, /*   Input (Data, Array) */
 
     0xC0, /* End Collection */
 };
+/* clang-format on */
 
 /* ─── Configuration Descriptor ─────────────────────────────────────────────── */
 

--- a/packages/esp32-projects/robocar-simulation/src/stub_planner.py
+++ b/packages/esp32-projects/robocar-simulation/src/stub_planner.py
@@ -28,11 +28,11 @@ Usage::
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 
-class GoalKind(str, Enum):
+class GoalKind(StrEnum):
     """Mirrors goal_kind_t in goal_state.h."""
 
     NONE = "none"

--- a/packages/esp32-projects/robocar-simulation/src/stub_planner.py
+++ b/packages/esp32-projects/robocar-simulation/src/stub_planner.py
@@ -1,0 +1,126 @@
+"""
+Stub planner for hierarchical-AI-controller sim/dev runs.
+
+The real planner on the robot (robocar-unified/main/planner_task.c) calls
+Gemini Robotics-ER 1.6 at ~1 Hz and writes structured goals into a shared
+goal state that the 30 Hz reactive executor drains. For sim regression runs
+and offline development we do not want to pay that API cost nor hit Gemini
+rate limits — this module emits a deterministic round-robin sequence of the
+same goal shapes so the executor can be exercised end-to-end.
+
+The goal shapes here mirror the C ``goal_t`` union in
+``packages/esp32-projects/robocar-unified/main/goal_state.h``:
+
+  drive:   {heading_deg, distance_cm, speed_pct}
+  track:   {ymin, xmin, ymax, xmax, max_speed_pct}   # Gemini ER 1.6 0..1000 units
+  rotate:  {angle_deg}
+  stop:    {}
+
+Usage::
+
+    planner = StubPlanner(period_s=1.0)
+    while sim.running:
+        goal = planner.next_goal(now=sim.clock())
+        executor.consume(goal)
+        sim.step()
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class GoalKind(str, Enum):
+    """Mirrors goal_kind_t in goal_state.h."""
+
+    NONE = "none"
+    STOP = "stop"
+    DRIVE = "drive"
+    TRACK = "track"
+    ROTATE = "rotate"
+
+
+@dataclass(frozen=True)
+class Goal:
+    """Shape-compatible with the C ``goal_t`` union.
+
+    ``params`` is a plain dict so the sim's executor port can pattern-match on
+    ``kind`` and look up the fields it expects without depending on this
+    module's classes.
+    """
+
+    kind: GoalKind
+    params: dict[str, Any]
+
+
+DEFAULT_SEQUENCE: tuple[Goal, ...] = (
+    Goal(
+        kind=GoalKind.DRIVE,
+        params={"heading_deg": 0, "distance_cm": 100, "speed_pct": 60},
+    ),
+    Goal(
+        kind=GoalKind.ROTATE,
+        params={"angle_deg": 90},
+    ),
+    Goal(
+        kind=GoalKind.TRACK,
+        params={
+            "ymin": 400,
+            "xmin": 400,
+            "ymax": 600,
+            "xmax": 600,
+            "max_speed_pct": 50,
+        },
+    ),
+    Goal(kind=GoalKind.STOP, params={}),
+)
+
+
+class StubPlanner:
+    """Deterministic cyclic planner emitting one goal per ``period_s``.
+
+    The planner advances on a monotonic "now" value the caller supplies (seconds
+    since epoch-of-choice). Calling :meth:`next_goal` multiple times inside one
+    period returns the same goal — matching the MCU contract where the executor
+    polls faster than the planner updates.
+    """
+
+    def __init__(
+        self,
+        period_s: float = 1.0,
+        sequence: tuple[Goal, ...] = DEFAULT_SEQUENCE,
+    ):
+        if period_s <= 0:
+            raise ValueError("period_s must be positive")
+        if not sequence:
+            raise ValueError("sequence must contain at least one goal")
+        self._period_s = float(period_s)
+        self._sequence = sequence
+        self._start: float | None = None
+
+    @property
+    def period_s(self) -> float:
+        return self._period_s
+
+    @property
+    def sequence(self) -> tuple[Goal, ...]:
+        return self._sequence
+
+    def reset(self) -> None:
+        """Forget the anchor time — next :meth:`next_goal` reopens the sequence."""
+        self._start = None
+
+    def next_goal(self, now: float) -> Goal:
+        """Return the goal the real planner *would* have published by ``now``.
+
+        ``now`` is seconds in any monotonic frame; the first call anchors the
+        sequence, and index ``(now - start) // period_s`` (modulo sequence
+        length) selects the goal.
+        """
+        if self._start is None:
+            self._start = now
+        elapsed = max(0.0, now - self._start)
+        idx = int(elapsed // self._period_s) % len(self._sequence)
+        return self._sequence[idx]

--- a/packages/esp32-projects/robocar-simulation/tests/test_stub_planner.py
+++ b/packages/esp32-projects/robocar-simulation/tests/test_stub_planner.py
@@ -1,0 +1,118 @@
+"""Tests for ``stub_planner`` — the deterministic goal emitter.
+
+Exercises the contract documented in ``src/stub_planner.py``:
+
+* goals are emitted in the declared order
+* the same goal is returned for repeated calls inside one period (like the
+  MCU executor polling faster than the 1 Hz planner)
+* the sequence wraps cyclically after the last entry
+* ``reset()`` re-anchors the sequence to the next ``next_goal`` call
+* invalid constructor args raise ``ValueError``
+"""
+
+import pytest
+
+from stub_planner import DEFAULT_SEQUENCE, Goal, GoalKind, StubPlanner
+
+
+def test_default_sequence_order():
+    planner = StubPlanner(period_s=1.0)
+
+    # Tick at t=0, 1, 2, 3 — one per period, one per sequence entry
+    kinds = [planner.next_goal(now=float(i)).kind for i in range(len(DEFAULT_SEQUENCE))]
+    expected = [g.kind for g in DEFAULT_SEQUENCE]
+    assert kinds == expected
+    assert kinds == [GoalKind.DRIVE, GoalKind.ROTATE, GoalKind.TRACK, GoalKind.STOP]
+
+
+def test_drive_goal_shape_matches_mcu_contract():
+    """Field names must match the C goal_t.drive struct in goal_state.h."""
+    planner = StubPlanner(period_s=1.0)
+    goal = planner.next_goal(now=0.0)
+    assert goal.kind == GoalKind.DRIVE
+    assert set(goal.params.keys()) == {"heading_deg", "distance_cm", "speed_pct"}
+
+
+def test_track_goal_shape_matches_mcu_contract():
+    """Field names must match the C goal_t.track struct in goal_state.h."""
+    planner = StubPlanner(period_s=1.0)
+    planner.next_goal(now=0.0)
+    planner.next_goal(now=1.0)
+    track = planner.next_goal(now=2.0)
+    assert track.kind == GoalKind.TRACK
+    assert set(track.params.keys()) == {"ymin", "xmin", "ymax", "xmax", "max_speed_pct"}
+
+
+def test_rotate_goal_shape_matches_mcu_contract():
+    planner = StubPlanner(period_s=1.0)
+    planner.next_goal(now=0.0)
+    rotate = planner.next_goal(now=1.0)
+    assert rotate.kind == GoalKind.ROTATE
+    assert set(rotate.params.keys()) == {"angle_deg"}
+
+
+def test_stable_within_period():
+    """Executor polls 30× per second; planner updates 1× per second. The same
+    goal must be returned for all polls inside one period."""
+    planner = StubPlanner(period_s=1.0)
+    first = planner.next_goal(now=0.0)
+    for dt in (0.01, 0.1, 0.5, 0.99):
+        assert planner.next_goal(now=dt) == first
+
+
+def test_advances_on_period_boundary():
+    planner = StubPlanner(period_s=1.0)
+    g0 = planner.next_goal(now=0.0)
+    g1 = planner.next_goal(now=1.0)
+    assert g0 != g1
+    assert g0.kind == DEFAULT_SEQUENCE[0].kind
+    assert g1.kind == DEFAULT_SEQUENCE[1].kind
+
+
+def test_sequence_wraps_cyclically():
+    planner = StubPlanner(period_s=1.0)
+    n = len(DEFAULT_SEQUENCE)
+    first_loop = [planner.next_goal(now=float(i)).kind for i in range(n)]
+    second_loop = [planner.next_goal(now=float(n + i)).kind for i in range(n)]
+    assert first_loop == second_loop
+
+
+def test_reset_reanchors_sequence():
+    planner = StubPlanner(period_s=1.0)
+    planner.next_goal(now=10.0)
+    planner.next_goal(now=11.0)  # would land on index 1
+    planner.reset()
+    # After reset, the first call anchors at its own "now" → index 0
+    after = planner.next_goal(now=50.0)
+    assert after.kind == DEFAULT_SEQUENCE[0].kind
+
+
+def test_custom_sequence():
+    custom = (
+        Goal(kind=GoalKind.STOP, params={}),
+        Goal(kind=GoalKind.DRIVE, params={"heading_deg": 0, "distance_cm": 10, "speed_pct": 30}),
+    )
+    planner = StubPlanner(period_s=0.5, sequence=custom)
+    assert planner.next_goal(now=0.0).kind == GoalKind.STOP
+    assert planner.next_goal(now=0.5).kind == GoalKind.DRIVE
+    assert planner.next_goal(now=1.0).kind == GoalKind.STOP  # wrap
+
+
+def test_custom_period():
+    planner = StubPlanner(period_s=2.0)
+    assert planner.next_goal(now=0.0).kind == DEFAULT_SEQUENCE[0].kind
+    # at t=1.0, still inside first period
+    assert planner.next_goal(now=1.0).kind == DEFAULT_SEQUENCE[0].kind
+    assert planner.next_goal(now=2.0).kind == DEFAULT_SEQUENCE[1].kind
+
+
+def test_invalid_period_rejected():
+    with pytest.raises(ValueError):
+        StubPlanner(period_s=0.0)
+    with pytest.raises(ValueError):
+        StubPlanner(period_s=-0.1)
+
+
+def test_empty_sequence_rejected():
+    with pytest.raises(ValueError):
+        StubPlanner(period_s=1.0, sequence=())

--- a/packages/esp32-projects/robocar-unified/main/CMakeLists.txt
+++ b/packages/esp32-projects/robocar-unified/main/CMakeLists.txt
@@ -9,6 +9,7 @@ idf_component_register(
         "camera.c"
         "base64.c"
         "gemini_backend.c"
+        "gemini_parse.c"
         "goal_state.c"
         "ultrasonic.c"
         "reactive_controller.c"

--- a/packages/esp32-projects/robocar-unified/main/gemini_backend.c
+++ b/packages/esp32-projects/robocar-unified/main/gemini_backend.c
@@ -26,6 +26,7 @@
 #include "esp_http_client.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "gemini_parse.h"
 #include "goal_state.h"
 
 static const char *TAG = "gemini_backend";
@@ -298,133 +299,9 @@ static char *build_request_json(const char *b64_image)
 }
 
 /* -------------------------------------------------------------------------- */
-/* Response parsing                                                             */
+/* Response parsing delegated to gemini_parse.c so it can be unit-tested on   */
+/* the host without pulling in esp_http_client / WiFi / mbedtls.              */
 /* -------------------------------------------------------------------------- */
-
-/**
- * Navigate candidates[0].content.parts[0].functionCall from the raw API
- * response and populate *out_goal.
- *
- * Gemini function-call response shape:
- * {
- *   "candidates": [{
- *     "content": {
- *       "parts": [{
- *         "functionCall": {
- *           "name": "drive",
- *           "args": { "heading_deg": 0, "distance_cm": 50, "speed_pct": 60 }
- *         }
- *       }]
- *     }
- *   }]
- * }
- */
-static esp_err_t parse_function_call(const char *json_text, goal_t *out_goal)
-{
-    out_goal->kind = GOAL_KIND_STOP; /* safe default */
-
-    cJSON *root = cJSON_Parse(json_text);
-    if (!root) {
-        ESP_LOGE(TAG, "failed to parse API response JSON");
-        return ESP_FAIL;
-    }
-
-    esp_err_t result = ESP_FAIL;
-
-    cJSON *candidates = cJSON_GetObjectItem(root, "candidates");
-    cJSON *cand0 = candidates ? cJSON_GetArrayItem(candidates, 0) : NULL;
-    cJSON *cand_content = cand0 ? cJSON_GetObjectItem(cand0, "content") : NULL;
-    cJSON *cand_parts = cand_content ? cJSON_GetObjectItem(cand_content, "parts") : NULL;
-    cJSON *part0 = cand_parts ? cJSON_GetArrayItem(cand_parts, 0) : NULL;
-    cJSON *fn_call = part0 ? cJSON_GetObjectItem(part0, "functionCall") : NULL;
-
-    if (!fn_call) {
-        ESP_LOGE(TAG, "no functionCall in response — candidates[0].content.parts[0].functionCall "
-                      "missing");
-        /* Log finish reason if present for diagnostics */
-        cJSON *finish_reason = cand0 ? cJSON_GetObjectItem(cand0, "finishReason") : NULL;
-        if (cJSON_IsString(finish_reason)) {
-            ESP_LOGE(TAG, "finishReason: %s", finish_reason->valuestring);
-        }
-        goto done;
-    }
-
-    cJSON *name_item = cJSON_GetObjectItem(fn_call, "name");
-    cJSON *args = cJSON_GetObjectItem(fn_call, "args");
-
-    if (!cJSON_IsString(name_item)) {
-        ESP_LOGE(TAG, "functionCall.name missing or not a string");
-        goto done;
-    }
-
-    const char *name = name_item->valuestring;
-    ESP_LOGI(TAG, "model called function: %s", name);
-
-    if (strcmp(name, "stop") == 0) {
-        out_goal->kind = GOAL_KIND_STOP;
-        result = ESP_OK;
-
-    } else if (strcmp(name, "drive") == 0) {
-        cJSON *h = args ? cJSON_GetObjectItem(args, "heading_deg") : NULL;
-        cJSON *d = args ? cJSON_GetObjectItem(args, "distance_cm") : NULL;
-        cJSON *s = args ? cJSON_GetObjectItem(args, "speed_pct") : NULL;
-        if (!cJSON_IsNumber(h) || !cJSON_IsNumber(d) || !cJSON_IsNumber(s)) {
-            ESP_LOGE(TAG, "drive: missing or invalid args");
-            goto done;
-        }
-        out_goal->kind = GOAL_KIND_DRIVE;
-        out_goal->params.drive.heading_deg = (int16_t)h->valueint;
-        out_goal->params.drive.distance_cm = (uint16_t)d->valueint;
-        out_goal->params.drive.speed_pct = (uint8_t)s->valueint;
-        result = ESP_OK;
-
-    } else if (strcmp(name, "track") == 0) {
-        cJSON *box = args ? cJSON_GetObjectItem(args, "box_2d") : NULL;
-        cJSON *ms = args ? cJSON_GetObjectItem(args, "max_speed_pct") : NULL;
-        if (!cJSON_IsArray(box) || cJSON_GetArraySize(box) != 4 || !cJSON_IsNumber(ms)) {
-            ESP_LOGE(TAG, "track: invalid box_2d (need 4-element array) or missing max_speed_pct");
-            goto done;
-        }
-        out_goal->kind = GOAL_KIND_TRACK;
-        /* ER 1.6 box_2d order: [ymin, xmin, ymax, xmax] */
-        out_goal->params.track.ymin = (uint16_t)cJSON_GetArrayItem(box, 0)->valueint;
-        out_goal->params.track.xmin = (uint16_t)cJSON_GetArrayItem(box, 1)->valueint;
-        out_goal->params.track.ymax = (uint16_t)cJSON_GetArrayItem(box, 2)->valueint;
-        out_goal->params.track.xmax = (uint16_t)cJSON_GetArrayItem(box, 3)->valueint;
-        out_goal->params.track.max_speed_pct = (uint8_t)ms->valueint;
-        result = ESP_OK;
-
-    } else if (strcmp(name, "rotate") == 0) {
-        cJSON *a = args ? cJSON_GetObjectItem(args, "angle_deg") : NULL;
-        if (!cJSON_IsNumber(a)) {
-            ESP_LOGE(TAG, "rotate: missing angle_deg");
-            goto done;
-        }
-        out_goal->kind = GOAL_KIND_ROTATE;
-        out_goal->params.rotate.angle_deg = (int16_t)a->valueint;
-        result = ESP_OK;
-
-    } else {
-        ESP_LOGW(TAG, "unrecognised function name: %s — defaulting to stop", name);
-        out_goal->kind = GOAL_KIND_STOP;
-        result = ESP_OK; /* not a fatal error; safe default applied */
-    }
-
-    /* Log usage metadata for cost observability */
-    cJSON *usage = cJSON_GetObjectItem(root, "usageMetadata");
-    if (usage) {
-        cJSON *pt = cJSON_GetObjectItem(usage, "promptTokenCount");
-        cJSON *ot = cJSON_GetObjectItem(usage, "candidatesTokenCount");
-        cJSON *tt = cJSON_GetObjectItem(usage, "totalTokenCount");
-        ESP_LOGI(TAG, "tokens: prompt=%d output=%d total=%d",
-                 cJSON_IsNumber(pt) ? pt->valueint : -1, cJSON_IsNumber(ot) ? ot->valueint : -1,
-                 cJSON_IsNumber(tt) ? tt->valueint : -1);
-    }
-
-done:
-    cJSON_Delete(root);
-    return result;
-}
 
 /* -------------------------------------------------------------------------- */
 /* Public API                                                                   */
@@ -549,7 +426,7 @@ esp_err_t gemini_backend_plan(const uint8_t *jpeg, size_t jpeg_len, goal_t *out_
     }
 
     /* ---- Parse function call from response ---- */
-    err = parse_function_call(acc.buf, out_goal);
+    err = gemini_parse_function_call(acc.buf, out_goal);
     if (err != ESP_OK) {
         /* parse_function_call already set out_goal->kind = GOAL_KIND_STOP */
         ESP_LOGW(TAG, "falling back to STOP due to parse failure");

--- a/packages/esp32-projects/robocar-unified/main/gemini_parse.c
+++ b/packages/esp32-projects/robocar-unified/main/gemini_parse.c
@@ -1,0 +1,154 @@
+/**
+ * @file gemini_parse.c
+ * @brief Parser for Gemini Robotics-ER 1.6 function-call responses.
+ *
+ * Extracted from gemini_backend.c for host-based unit testing. See
+ * gemini_parse.h for the public contract.
+ *
+ * Response shape this file accepts::
+ *
+ *   {
+ *     "candidates": [{
+ *       "content": {
+ *         "parts": [{
+ *           "functionCall": {
+ *             "name": "drive",
+ *             "args": { "heading_deg": 0, "distance_cm": 50, "speed_pct": 60 }
+ *           }
+ *         }]
+ *       },
+ *       "finishReason": "STOP"
+ *     }],
+ *     "usageMetadata": { "promptTokenCount": 123, ... }
+ *   }
+ *
+ * Box coordinates for ``track`` follow ER 1.6: ``[ymin, xmin, ymax, xmax]``,
+ * integers normalised 0..1000.
+ */
+
+#include "gemini_parse.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "cJSON.h"
+#include "esp_log.h"
+
+/* On the host-test build ESP_LOGx macros are no-ops, leaving TAG and the
+ * usageMetadata locals unused. Suppress with a compiler attribute rather
+ * than an #ifdef — keeps the source identical across targets. */
+#if defined(__GNUC__) || defined(__clang__)
+#define GP_MAYBE_UNUSED __attribute__((unused))
+#else
+#define GP_MAYBE_UNUSED
+#endif
+
+static const char *TAG GP_MAYBE_UNUSED = "gemini_parse";
+
+esp_err_t gemini_parse_function_call(const char *json_text, goal_t *out_goal)
+{
+    if (json_text == NULL || out_goal == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    out_goal->kind = GOAL_KIND_STOP; /* safe default */
+
+    cJSON *root = cJSON_Parse(json_text);
+    if (!root) {
+        ESP_LOGE(TAG, "failed to parse API response JSON");
+        return ESP_FAIL;
+    }
+
+    esp_err_t result = ESP_FAIL;
+
+    cJSON *candidates = cJSON_GetObjectItem(root, "candidates");
+    cJSON *cand0 = candidates ? cJSON_GetArrayItem(candidates, 0) : NULL;
+    cJSON *cand_content = cand0 ? cJSON_GetObjectItem(cand0, "content") : NULL;
+    cJSON *cand_parts = cand_content ? cJSON_GetObjectItem(cand_content, "parts") : NULL;
+    cJSON *part0 = cand_parts ? cJSON_GetArrayItem(cand_parts, 0) : NULL;
+    cJSON *fn_call = part0 ? cJSON_GetObjectItem(part0, "functionCall") : NULL;
+
+    if (!fn_call) {
+        ESP_LOGE(TAG, "no functionCall in response — candidates[0].content.parts[0].functionCall "
+                      "missing");
+        cJSON *finish_reason = cand0 ? cJSON_GetObjectItem(cand0, "finishReason") : NULL;
+        if (cJSON_IsString(finish_reason)) {
+            ESP_LOGE(TAG, "finishReason: %s", finish_reason->valuestring);
+        }
+        goto done;
+    }
+
+    cJSON *name_item = cJSON_GetObjectItem(fn_call, "name");
+    cJSON *args = cJSON_GetObjectItem(fn_call, "args");
+
+    if (!cJSON_IsString(name_item)) {
+        ESP_LOGE(TAG, "functionCall.name missing or not a string");
+        goto done;
+    }
+
+    const char *name = name_item->valuestring;
+    ESP_LOGI(TAG, "model called function: %s", name);
+
+    if (strcmp(name, "stop") == 0) {
+        out_goal->kind = GOAL_KIND_STOP;
+        result = ESP_OK;
+
+    } else if (strcmp(name, "drive") == 0) {
+        cJSON *h = args ? cJSON_GetObjectItem(args, "heading_deg") : NULL;
+        cJSON *d = args ? cJSON_GetObjectItem(args, "distance_cm") : NULL;
+        cJSON *s = args ? cJSON_GetObjectItem(args, "speed_pct") : NULL;
+        if (!cJSON_IsNumber(h) || !cJSON_IsNumber(d) || !cJSON_IsNumber(s)) {
+            ESP_LOGE(TAG, "drive: missing or invalid args");
+            goto done;
+        }
+        out_goal->kind = GOAL_KIND_DRIVE;
+        out_goal->params.drive.heading_deg = (int16_t)h->valueint;
+        out_goal->params.drive.distance_cm = (uint16_t)d->valueint;
+        out_goal->params.drive.speed_pct = (uint8_t)s->valueint;
+        result = ESP_OK;
+
+    } else if (strcmp(name, "track") == 0) {
+        cJSON *box = args ? cJSON_GetObjectItem(args, "box_2d") : NULL;
+        cJSON *ms = args ? cJSON_GetObjectItem(args, "max_speed_pct") : NULL;
+        if (!cJSON_IsArray(box) || cJSON_GetArraySize(box) != 4 || !cJSON_IsNumber(ms)) {
+            ESP_LOGE(TAG, "track: invalid box_2d (need 4-element array) or missing max_speed_pct");
+            goto done;
+        }
+        out_goal->kind = GOAL_KIND_TRACK;
+        out_goal->params.track.ymin = (uint16_t)cJSON_GetArrayItem(box, 0)->valueint;
+        out_goal->params.track.xmin = (uint16_t)cJSON_GetArrayItem(box, 1)->valueint;
+        out_goal->params.track.ymax = (uint16_t)cJSON_GetArrayItem(box, 2)->valueint;
+        out_goal->params.track.xmax = (uint16_t)cJSON_GetArrayItem(box, 3)->valueint;
+        out_goal->params.track.max_speed_pct = (uint8_t)ms->valueint;
+        result = ESP_OK;
+
+    } else if (strcmp(name, "rotate") == 0) {
+        cJSON *a = args ? cJSON_GetObjectItem(args, "angle_deg") : NULL;
+        if (!cJSON_IsNumber(a)) {
+            ESP_LOGE(TAG, "rotate: missing angle_deg");
+            goto done;
+        }
+        out_goal->kind = GOAL_KIND_ROTATE;
+        out_goal->params.rotate.angle_deg = (int16_t)a->valueint;
+        result = ESP_OK;
+
+    } else {
+        ESP_LOGW(TAG, "unrecognised function name: %s — defaulting to stop", name);
+        out_goal->kind = GOAL_KIND_STOP;
+        result = ESP_OK;
+    }
+
+    cJSON *usage = cJSON_GetObjectItem(root, "usageMetadata");
+    if (usage) {
+        cJSON *pt GP_MAYBE_UNUSED = cJSON_GetObjectItem(usage, "promptTokenCount");
+        cJSON *ot GP_MAYBE_UNUSED = cJSON_GetObjectItem(usage, "candidatesTokenCount");
+        cJSON *tt GP_MAYBE_UNUSED = cJSON_GetObjectItem(usage, "totalTokenCount");
+        ESP_LOGI(TAG, "tokens: prompt=%d output=%d total=%d",
+                 cJSON_IsNumber(pt) ? pt->valueint : -1, cJSON_IsNumber(ot) ? ot->valueint : -1,
+                 cJSON_IsNumber(tt) ? tt->valueint : -1);
+    }
+
+done:
+    cJSON_Delete(root);
+    return result;
+}

--- a/packages/esp32-projects/robocar-unified/main/gemini_parse.h
+++ b/packages/esp32-projects/robocar-unified/main/gemini_parse.h
@@ -1,0 +1,37 @@
+/**
+ * @file gemini_parse.h
+ * @brief Parse Gemini Robotics-ER 1.6 function-call responses into goal_t.
+ *
+ * Extracted from gemini_backend.c so the parser can be unit-tested on the
+ * host without dragging in esp_http_client, WiFi, etc. Fail-safe contract:
+ * on any error the parser sets ``out_goal->kind = GOAL_KIND_STOP`` before
+ * returning ``ESP_FAIL`` so callers never operate on an uninitialised goal.
+ */
+
+#ifndef GEMINI_PARSE_H
+#define GEMINI_PARSE_H
+
+#include "esp_err.h"
+#include "goal_state.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Navigate candidates[0].content.parts[0].functionCall from the raw
+ *        Gemini API response body and populate *out_goal.
+ *
+ * @param json_text  NUL-terminated response body. Must not be NULL.
+ * @param out_goal   Destination goal. Must not be NULL. On failure its
+ *                   ``kind`` is forced to ``GOAL_KIND_STOP``.
+ * @return ESP_OK on success, ESP_FAIL on any parse/structure error,
+ *         ESP_ERR_INVALID_ARG if either pointer is NULL.
+ */
+esp_err_t gemini_parse_function_call(const char *json_text, goal_t *out_goal);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GEMINI_PARSE_H */

--- a/packages/esp32-projects/robocar-unified/main/reactive_controller.c
+++ b/packages/esp32-projects/robocar-unified/main/reactive_controller.c
@@ -403,6 +403,7 @@ esp_err_t reactive_controller_get_telemetry(reactive_telemetry_t *out)
 
 #include <math.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "goal_state.h"

--- a/packages/esp32-projects/robocar-unified/main/ultrasonic.c
+++ b/packages/esp32-projects/robocar-unified/main/ultrasonic.c
@@ -312,6 +312,7 @@ esp_err_t ultrasonic_deinit(void)
  * ========================================================================= */
 #else /* ULTRASONIC_HOST_TEST */
 
+#include <stddef.h>
 #include <stdint.h>
 
 static uint16_t s_injected_distance = ULTRASONIC_DIST_ERROR;

--- a/packages/esp32-projects/robocar-unified/test/CMakeLists.txt
+++ b/packages/esp32-projects/robocar-unified/test/CMakeLists.txt
@@ -20,7 +20,13 @@ add_compile_definitions(
 set(MAIN_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../main")
 
 # Include directories
+# test/include comes first so its esp_err.h / esp_log.h shims shadow any
+# ESP-IDF header that leaks in via motor_controller.h (which unconditionally
+# includes "esp_err.h") or gemini_parse.c (which uses ESP_LOG* macros). The
+# companion host-test guards in goal_state.h / ultrasonic.h /
+# reactive_controller.h handle their own typedef under #else.
 include_directories(
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
     "${MAIN_SRC_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}"
 )
@@ -28,14 +34,80 @@ include_directories(
 # Shared on-host link requirements
 find_package(Threads REQUIRED)
 
+# cJSON — required by gemini_parse.c. Prefer the installed library via
+# pkg-config; fall back to Homebrew's prefix on macOS.
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(CJSON libcjson)
+endif()
+
+if(NOT CJSON_FOUND)
+    # Homebrew on Apple Silicon
+    set(_CJSON_HINTS "/opt/homebrew/opt/cjson" "/opt/homebrew" "/usr/local/opt/cjson" "/usr/local")
+    find_path(CJSON_INCLUDE_DIR cjson/cJSON.h HINTS ${_CJSON_HINTS} PATH_SUFFIXES include)
+    find_library(CJSON_LIB cjson HINTS ${_CJSON_HINTS} PATH_SUFFIXES lib)
+    if(CJSON_INCLUDE_DIR AND CJSON_LIB)
+        set(CJSON_INCLUDE_DIRS "${CJSON_INCLUDE_DIR}/cjson")
+        set(CJSON_LIBRARIES "${CJSON_LIB}")
+        set(CJSON_FOUND TRUE)
+    endif()
+endif()
+
 enable_testing()
 
-# goal_state host tests (Phase 4, Gate G3) — the only test suite landed in the
-# first Phase 4 pass. test_reactive_controller.c / test_ultrasonic_stub.c are
-# tracked as Phase 5 follow-ups.
+# -----------------------------------------------------------------------------
+# goal_state host tests (Phase 4, gate G3)
+# -----------------------------------------------------------------------------
 add_executable(test_goal_state
     "${MAIN_SRC_DIR}/goal_state.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/test_goal_state.c"
 )
 target_link_libraries(test_goal_state PRIVATE Threads::Threads m)
 add_test(NAME goal_state COMMAND test_goal_state)
+
+# -----------------------------------------------------------------------------
+# ultrasonic stub regression (Phase 5, issue #226)
+# -----------------------------------------------------------------------------
+add_executable(test_ultrasonic_stub
+    "${MAIN_SRC_DIR}/ultrasonic.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_ultrasonic_stub.c"
+)
+target_link_libraries(test_ultrasonic_stub PRIVATE Threads::Threads m)
+add_test(NAME ultrasonic_stub COMMAND test_ultrasonic_stub)
+
+# -----------------------------------------------------------------------------
+# reactive_controller decision logic (Phase 5, gate G2, issue #226)
+# -----------------------------------------------------------------------------
+add_executable(test_reactive_controller
+    "${MAIN_SRC_DIR}/goal_state.c"
+    "${MAIN_SRC_DIR}/ultrasonic.c"
+    "${MAIN_SRC_DIR}/reactive_controller.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/motor_controller_stub.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_reactive_controller.c"
+)
+target_link_libraries(test_reactive_controller PRIVATE Threads::Threads m)
+add_test(NAME reactive_controller COMMAND test_reactive_controller)
+
+# -----------------------------------------------------------------------------
+# gemini parse (Phase 5, gate G1, issue #228)
+#
+# Only built when cJSON is available. Skipped (with a message) otherwise so
+# the other host-test suites still build in environments without cJSON.
+# -----------------------------------------------------------------------------
+if(CJSON_FOUND)
+    add_executable(test_gemini_parse
+        "${MAIN_SRC_DIR}/gemini_parse.c"
+        "${CMAKE_CURRENT_SOURCE_DIR}/test_gemini_parse.c"
+    )
+    target_include_directories(test_gemini_parse PRIVATE ${CJSON_INCLUDE_DIRS})
+    # pkg-config returns a plain -lcjson without a library path. Pass the
+    # library search dirs explicitly so the linker finds libcjson.*.
+    target_link_directories(test_gemini_parse PRIVATE ${CJSON_LIBRARY_DIRS})
+    target_link_libraries(test_gemini_parse PRIVATE ${CJSON_LIBRARIES} Threads::Threads m)
+    target_compile_definitions(test_gemini_parse PRIVATE
+        "FIXTURE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/fixtures\""
+    )
+    add_test(NAME gemini_parse COMMAND test_gemini_parse)
+else()
+    message(STATUS "cJSON not found — skipping test_gemini_parse. Install via `brew install cjson` or `apt install libcjson-dev`.")
+endif()

--- a/packages/esp32-projects/robocar-unified/test/fixtures/README.md
+++ b/packages/esp32-projects/robocar-unified/test/fixtures/README.md
@@ -1,0 +1,89 @@
+# Gemini ER 1.6 response fixtures
+
+These JSON files are captured from live
+`generativelanguage.googleapis.com/v1beta/models/gemini-robotics-er-1.6:generateContent`
+calls and used by `test_gemini_parse.c` to lock down the shape assumptions of
+`gemini_parse_function_call()`.
+
+## Current status
+
+The committed files are **synthetic** fixtures that match the schema documented
+in `gemini_parse.c`. They prove the parser reads the expected path, but they
+do not guarantee the live API still emits the same shape. Closing PRP gate
+**G1** requires replacing each file with a recording from a real API call —
+see **Capturing a real fixture** below.
+
+| File | Scenario | Synthetic | Captured |
+|------|----------|:---:|:---:|
+| `er_1_6_drive.json`   | straight-line drive    | ✅ | ☐ |
+| `er_1_6_track.json`   | track a bounding box   | ✅ | ☐ |
+| `er_1_6_rotate.json`  | rotate in place        | ✅ | ☐ |
+| `er_1_6_stop.json`    | stop                    | ✅ | ☐ |
+| `er_1_6_corrupt.json` | malformed response → fail-safe contract | n/a | n/a |
+
+## Capturing a real fixture
+
+You need a `GEMINI_API_KEY` with access to Robotics-ER.
+
+```bash
+# 1. Grab a representative JPEG (any scene works; a cup on a table is classic).
+curl -L -o /tmp/scene.jpg https://picsum.photos/seed/robot/640/480
+
+# 2. Base64 the image.
+B64=$(base64 -i /tmp/scene.jpg | tr -d '\n')
+
+# 3. Build the request body — match the shape in gemini_backend.c's
+#    build_request_json() so you exercise the same function declarations
+#    and toolConfig the firmware sends. The stub below embeds the minimum.
+cat > /tmp/req.json <<EOF
+{
+  "contents": [{
+    "role": "user",
+    "parts": [
+      {"inlineData": {"mimeType": "image/jpeg", "data": "${B64}"}},
+      {"text": "Choose one action: drive, track, rotate, or stop."}
+    ]
+  }],
+  "tools": [{
+    "functionDeclarations": [
+      {"name": "drive",  "description": "Drive on heading.",
+       "parameters": {"type": "OBJECT", "properties": {
+         "heading_deg": {"type": "INTEGER"},
+         "distance_cm": {"type": "INTEGER"},
+         "speed_pct":   {"type": "INTEGER"}},
+         "required": ["heading_deg","distance_cm","speed_pct"]}},
+      {"name": "track",  "description": "Visually servo toward bbox.",
+       "parameters": {"type": "OBJECT", "properties": {
+         "box_2d":        {"type": "ARRAY", "items": {"type": "INTEGER"}},
+         "max_speed_pct": {"type": "INTEGER"}},
+         "required": ["box_2d","max_speed_pct"]}},
+      {"name": "rotate", "description": "Rotate in place.",
+       "parameters": {"type": "OBJECT", "properties": {
+         "angle_deg": {"type": "INTEGER"}},
+         "required": ["angle_deg"]}},
+      {"name": "stop",   "description": "Halt.",
+       "parameters": {"type": "OBJECT", "properties": {}, "required": []}}
+    ]
+  }],
+  "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+  "generationConfig": {"thinkingConfig": {"thinkingBudget": 0}}
+}
+EOF
+
+# 4. Call the API, save the raw response.
+curl -s \
+  -H "Content-Type: application/json" \
+  -H "x-goog-api-key: ${GEMINI_API_KEY}" \
+  -X POST \
+  -d @/tmp/req.json \
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-robotics-er-1.6:generateContent' \
+  | jq . > er_1_6_<scenario>.json
+
+# 5. Run the host tests — they should still pass against the live capture.
+cd .. && cmake --build build && ctest --test-dir build --output-on-failure
+```
+
+Replace the synthetic fixtures one scenario at a time; run the parse tests
+after each swap to catch schema drift. If a field rename breaks parsing,
+update `gemini_parse.c` to match what the live API emits and document the
+change in `ADR-016`.

--- a/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_corrupt.json
+++ b/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_corrupt.json
@@ -1,0 +1,15 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": "I am not going to call a function today."
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ]
+}

--- a/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_drive.json
+++ b/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_drive.json
@@ -1,0 +1,27 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "functionCall": {
+              "name": "drive",
+              "args": {
+                "heading_deg": 0,
+                "distance_cm": 100,
+                "speed_pct": 60
+              }
+            }
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 1425,
+    "candidatesTokenCount": 23,
+    "totalTokenCount": 1448
+  }
+}

--- a/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_rotate.json
+++ b/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_rotate.json
@@ -1,0 +1,25 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "functionCall": {
+              "name": "rotate",
+              "args": {
+                "angle_deg": -45
+              }
+            }
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 1425,
+    "candidatesTokenCount": 18,
+    "totalTokenCount": 1443
+  }
+}

--- a/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_stop.json
+++ b/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_stop.json
@@ -1,0 +1,23 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "functionCall": {
+              "name": "stop",
+              "args": {}
+            }
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 1425,
+    "candidatesTokenCount": 15,
+    "totalTokenCount": 1440
+  }
+}

--- a/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_track.json
+++ b/packages/esp32-projects/robocar-unified/test/fixtures/er_1_6_track.json
@@ -1,0 +1,26 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "functionCall": {
+              "name": "track",
+              "args": {
+                "box_2d": [380, 410, 620, 590],
+                "max_speed_pct": 55
+              }
+            }
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 1425,
+    "candidatesTokenCount": 28,
+    "totalTokenCount": 1453
+  }
+}

--- a/packages/esp32-projects/robocar-unified/test/include/esp_err.h
+++ b/packages/esp32-projects/robocar-unified/test/include/esp_err.h
@@ -1,0 +1,26 @@
+/**
+ * @file esp_err.h — host-test shim.
+ *
+ * motor_controller.h (and a few other target headers) unconditionally include
+ * "esp_err.h" from ESP-IDF. This file is only visible on the test include
+ * path; it provides just enough of the real API to let those headers and
+ * their implementations compile on the host.
+ *
+ * Companion host-test guards (GOAL_STATE_HOST_TEST, ULTRASONIC_HOST_TEST,
+ * REACTIVE_CONTROLLER_HOST_TEST) also typedef esp_err_t under their `#else`
+ * branches. Use a single include-guard macro here so both entry points remain
+ * compatible: whichever file is first wins, and the other is a no-op.
+ */
+
+#ifndef ROBOCAR_UNIFIED_HOST_TEST_ESP_ERR_H
+#define ROBOCAR_UNIFIED_HOST_TEST_ESP_ERR_H
+
+typedef int esp_err_t;
+
+#define ESP_OK 0
+#define ESP_FAIL (-1)
+#define ESP_ERR_INVALID_ARG (-2)
+#define ESP_ERR_INVALID_STATE (-3)
+#define ESP_ERR_NOT_FOUND (-4)
+
+#endif /* ROBOCAR_UNIFIED_HOST_TEST_ESP_ERR_H */

--- a/packages/esp32-projects/robocar-unified/test/include/esp_log.h
+++ b/packages/esp32-projects/robocar-unified/test/include/esp_log.h
@@ -1,0 +1,18 @@
+/**
+ * @file esp_log.h — host-test shim.
+ *
+ * ESP-IDF's logging macros are no-ops in the host-test build. Keeping them
+ * silent avoids polluting test output, and matches the way test_goal_state.c
+ * stays quiet during its fuzz run.
+ */
+
+#ifndef ROBOCAR_UNIFIED_HOST_TEST_ESP_LOG_H
+#define ROBOCAR_UNIFIED_HOST_TEST_ESP_LOG_H
+
+#define ESP_LOGE(tag, fmt, ...) ((void)0)
+#define ESP_LOGW(tag, fmt, ...) ((void)0)
+#define ESP_LOGI(tag, fmt, ...) ((void)0)
+#define ESP_LOGD(tag, fmt, ...) ((void)0)
+#define ESP_LOGV(tag, fmt, ...) ((void)0)
+
+#endif /* ROBOCAR_UNIFIED_HOST_TEST_ESP_LOG_H */

--- a/packages/esp32-projects/robocar-unified/test/test_gemini_parse.c
+++ b/packages/esp32-projects/robocar-unified/test/test_gemini_parse.c
@@ -1,0 +1,252 @@
+/**
+ * @file test_gemini_parse.c
+ * @brief Host-based unit tests for gemini_parse_function_call().
+ *
+ * Loads JSON fixtures from test/fixtures/ (see fixtures/README.md for the
+ * capture protocol) and asserts each parses into the expected goal_t plus
+ * the fail-safe contract for corrupt/empty responses.
+ *
+ * The FIXTURE_DIR macro is injected from CMake so the binary can locate its
+ * fixtures regardless of the working directory ctest uses.
+ */
+
+#include "gemini_parse.h"
+#include "goal_state.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef FIXTURE_DIR
+#error "FIXTURE_DIR must be defined by the build system"
+#endif
+
+/* =========================================================================
+ * Test harness
+ * ========================================================================= */
+
+static int test_count = 0;
+static int test_pass = 0;
+
+static void test_assert(int cond, const char *file, int line, const char *expr)
+{
+    if (!cond) {
+        printf("FAIL: %s:%d assertion failed: %s\n", file, line, expr);
+        assert(cond);
+    }
+}
+
+#define ASSERT(cond) test_assert((cond), __FILE__, __LINE__, #cond)
+
+static void test_run(const char *name, void (*fn)(void))
+{
+    test_count++;
+    printf("[%d] Running: %s...\n", test_count, name);
+    fflush(stdout);
+    fn();
+    test_pass++;
+    printf("     PASS\n");
+}
+
+/* =========================================================================
+ * Fixture loader
+ * ========================================================================= */
+
+static char *load_fixture(const char *filename)
+{
+    char path[1024];
+    int n = snprintf(path, sizeof(path), "%s/%s", FIXTURE_DIR, filename);
+    if (n < 0 || (size_t)n >= sizeof(path)) {
+        printf("fixture path too long: %s/%s\n", FIXTURE_DIR, filename);
+        return NULL;
+    }
+
+    FILE *fp = fopen(path, "rb");
+    if (!fp) {
+        printf("failed to open fixture: %s\n", path);
+        return NULL;
+    }
+
+    fseek(fp, 0, SEEK_END);
+    long size = ftell(fp);
+    fseek(fp, 0, SEEK_SET);
+    if (size <= 0) {
+        fclose(fp);
+        return NULL;
+    }
+
+    char *buf = malloc((size_t)size + 1);
+    if (!buf) {
+        fclose(fp);
+        return NULL;
+    }
+
+    size_t read_n = fread(buf, 1, (size_t)size, fp);
+    fclose(fp);
+    buf[read_n] = '\0';
+    return buf;
+}
+
+/* =========================================================================
+ * Tests
+ * ========================================================================= */
+
+static void test_parse_drive(void)
+{
+    char *json = load_fixture("er_1_6_drive.json");
+    ASSERT(json != NULL);
+
+    goal_t goal = {0};
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_OK);
+    ASSERT(goal.kind == GOAL_KIND_DRIVE);
+    ASSERT(goal.params.drive.heading_deg == 0);
+    ASSERT(goal.params.drive.distance_cm == 100);
+    ASSERT(goal.params.drive.speed_pct == 60);
+
+    free(json);
+}
+
+static void test_parse_track(void)
+{
+    char *json = load_fixture("er_1_6_track.json");
+    ASSERT(json != NULL);
+
+    goal_t goal = {0};
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_OK);
+    ASSERT(goal.kind == GOAL_KIND_TRACK);
+    /* Fixture box_2d: [380, 410, 620, 590] → [ymin, xmin, ymax, xmax] */
+    ASSERT(goal.params.track.ymin == 380);
+    ASSERT(goal.params.track.xmin == 410);
+    ASSERT(goal.params.track.ymax == 620);
+    ASSERT(goal.params.track.xmax == 590);
+    ASSERT(goal.params.track.max_speed_pct == 55);
+
+    free(json);
+}
+
+static void test_parse_rotate(void)
+{
+    char *json = load_fixture("er_1_6_rotate.json");
+    ASSERT(json != NULL);
+
+    goal_t goal = {0};
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_OK);
+    ASSERT(goal.kind == GOAL_KIND_ROTATE);
+    ASSERT(goal.params.rotate.angle_deg == -45);
+
+    free(json);
+}
+
+static void test_parse_stop(void)
+{
+    char *json = load_fixture("er_1_6_stop.json");
+    ASSERT(json != NULL);
+
+    goal_t goal;
+    goal.kind = GOAL_KIND_DRIVE; /* poison — parser must overwrite */
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_OK);
+    ASSERT(goal.kind == GOAL_KIND_STOP);
+
+    free(json);
+}
+
+/* Corrupt response (no functionCall) → ESP_FAIL, kind forced to STOP. */
+static void test_parse_corrupt_falls_back_to_stop(void)
+{
+    char *json = load_fixture("er_1_6_corrupt.json");
+    ASSERT(json != NULL);
+
+    goal_t goal;
+    goal.kind = GOAL_KIND_DRIVE;
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_FAIL);
+    ASSERT(goal.kind == GOAL_KIND_STOP);
+
+    free(json);
+}
+
+/* Completely invalid JSON → ESP_FAIL, fail-safe STOP. */
+static void test_parse_invalid_json(void)
+{
+    const char *garbage = "this is not json at all };{[";
+    goal_t goal;
+    goal.kind = GOAL_KIND_DRIVE;
+    esp_err_t ret = gemini_parse_function_call(garbage, &goal);
+    ASSERT(ret == ESP_FAIL);
+    ASSERT(goal.kind == GOAL_KIND_STOP);
+}
+
+/* NULL pointer guard. */
+static void test_parse_null_args(void)
+{
+    goal_t goal;
+    ASSERT(gemini_parse_function_call(NULL, &goal) == ESP_ERR_INVALID_ARG);
+    ASSERT(gemini_parse_function_call("{}", NULL) == ESP_ERR_INVALID_ARG);
+}
+
+/* Drive with missing speed_pct → fail-safe STOP. */
+static void test_parse_drive_missing_field(void)
+{
+    const char *json = "{\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{"
+                       "\"name\":\"drive\",\"args\":{\"heading_deg\":0,\"distance_cm\":50}}}]}}]}";
+    goal_t goal;
+    goal.kind = GOAL_KIND_DRIVE;
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_FAIL);
+    ASSERT(goal.kind == GOAL_KIND_STOP);
+}
+
+/* Track with wrong-sized box_2d → fail-safe STOP. */
+static void test_parse_track_wrong_box_length(void)
+{
+    const char *json =
+        "{\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{"
+        "\"name\":\"track\",\"args\":{\"box_2d\":[1,2,3],\"max_speed_pct\":50}}}]}}]}";
+    goal_t goal;
+    goal.kind = GOAL_KIND_DRIVE;
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_FAIL);
+    ASSERT(goal.kind == GOAL_KIND_STOP);
+}
+
+/* Unknown function name → ESP_OK with STOP goal (per parser contract). */
+static void test_parse_unknown_function_defaults_to_stop(void)
+{
+    const char *json = "{\"candidates\":[{\"content\":{\"parts\":[{\"functionCall\":{"
+                       "\"name\":\"launch_missiles\",\"args\":{}}}]}}]}";
+    goal_t goal;
+    goal.kind = GOAL_KIND_DRIVE;
+    esp_err_t ret = gemini_parse_function_call(json, &goal);
+    ASSERT(ret == ESP_OK);
+    ASSERT(goal.kind == GOAL_KIND_STOP);
+}
+
+/* =========================================================================
+ * Main
+ * ========================================================================= */
+
+int main(void)
+{
+    printf("=== gemini_parse host tests ===\n\n");
+
+    test_run("parse_drive", test_parse_drive);
+    test_run("parse_track", test_parse_track);
+    test_run("parse_rotate", test_parse_rotate);
+    test_run("parse_stop", test_parse_stop);
+    test_run("parse_corrupt_falls_back_to_stop", test_parse_corrupt_falls_back_to_stop);
+    test_run("parse_invalid_json", test_parse_invalid_json);
+    test_run("parse_null_args", test_parse_null_args);
+    test_run("parse_drive_missing_field", test_parse_drive_missing_field);
+    test_run("parse_track_wrong_box_length", test_parse_track_wrong_box_length);
+    test_run("parse_unknown_function_defaults_to_stop",
+             test_parse_unknown_function_defaults_to_stop);
+
+    printf("\n=== Results ===\n");
+    printf("Passed: %d / %d\n", test_pass, test_count);
+    return (test_pass == test_count) ? 0 : 1;
+}

--- a/packages/esp32-projects/robocar-unified/test/test_reactive_controller.c
+++ b/packages/esp32-projects/robocar-unified/test/test_reactive_controller.c
@@ -1,0 +1,330 @@
+/**
+ * @file test_reactive_controller.c
+ * @brief Host-based unit tests for reactive_controller decision logic.
+ *
+ * Exercises the one-tick executor via reactive_controller_tick_for_test(),
+ * which reactive_controller.c exposes under REACTIVE_CONTROLLER_HOST_TEST=1.
+ * Motor commands are captured by motor_controller_stub.c; distance readings
+ * are injected via ultrasonic_test_set_distance(); goals are written via
+ * goal_state_write(). Each test primes the smoothing filter with three
+ * "clear" readings before probing behaviour so the running mean stabilises.
+ */
+
+#include "goal_state.h"
+#include "motor_controller.h"
+#include "reactive_controller.h"
+#include "ultrasonic.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* From motor_controller_stub.c */
+void motor_stub_reset(void);
+void motor_stub_get_last_state(uint8_t *left_speed, uint8_t *right_speed, uint8_t *left_direction,
+                               uint8_t *right_direction);
+
+/* From reactive_controller.c (host-test build) */
+void reactive_controller_tick_for_test(void);
+
+/* =========================================================================
+ * Test harness
+ * ========================================================================= */
+
+static int test_count = 0;
+static int test_pass = 0;
+
+static void test_assert(int cond, const char *file, int line, const char *expr)
+{
+    if (!cond) {
+        printf("FAIL: %s:%d assertion failed: %s\n", file, line, expr);
+        assert(cond);
+    }
+}
+
+#define ASSERT(cond) test_assert((cond), __FILE__, __LINE__, #cond)
+
+static void test_run(const char *name, void (*fn)(void))
+{
+    test_count++;
+    printf("[%d] Running: %s...\n", test_count, name);
+    fflush(stdout);
+    fn();
+    test_pass++;
+    printf("     PASS\n");
+}
+
+/* =========================================================================
+ * Fixtures
+ * ========================================================================= */
+
+/**
+ * Reset all module state so each test starts from a known baseline.
+ *
+ * Note: the smoothing buffer inside reactive_controller.c is *process-local*
+ * static state. The only way to clear it is to call
+ * reactive_controller_init() which memsets it. So we call init here.
+ */
+static void setup(void)
+{
+    goal_state_init();
+    goal_state_force_stop(); /* clear any prior goal */
+    motor_stub_reset();
+    ultrasonic_test_set_distance(100); /* "clear" default */
+    reactive_controller_init();        /* clears smoothing buffer */
+}
+
+/** Prime the 3-sample running-mean distance filter at @p cm. */
+static void prime_distance(uint16_t cm)
+{
+    ultrasonic_test_set_distance(cm);
+    for (int i = 0; i < 3; i++) {
+        reactive_controller_tick_for_test();
+    }
+}
+
+static void get_motor_state(uint8_t *l_speed, uint8_t *r_speed, uint8_t *l_dir, uint8_t *r_dir)
+{
+    motor_stub_get_last_state(l_speed, r_speed, l_dir, r_dir);
+}
+
+/* =========================================================================
+ * Tests
+ * ========================================================================= */
+
+/* Reflex latch: smoothed distance < 15 cm → motor_stop regardless of goal. */
+static void test_reflex_latch_overrides_drive(void)
+{
+    setup();
+
+    goal_t drive = {
+        .kind = GOAL_KIND_DRIVE,
+        .params.drive = {.heading_deg = 0, .distance_cm = 200, .speed_pct = 80},
+    };
+    ASSERT(goal_state_write(&drive, 1500) == ESP_OK);
+
+    prime_distance(10); /* 10 cm — well below the 15 cm threshold */
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+    ASSERT(ls == 0);
+    ASSERT(rs == 0);
+}
+
+/* Reflex release: distance back above threshold → goal takes effect. */
+static void test_reflex_release(void)
+{
+    setup();
+
+    goal_t drive = {
+        .kind = GOAL_KIND_DRIVE,
+        .params.drive = {.heading_deg = 0, .distance_cm = 200, .speed_pct = 80},
+    };
+    ASSERT(goal_state_write(&drive, 1500) == ESP_OK);
+
+    /* Block, then clear. 3 ticks at 30 cm fully flushes the 3-sample buffer. */
+    prime_distance(10);
+    prime_distance(30);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+    ASSERT(ls > 0);
+    ASSERT(rs > 0);
+    ASSERT(ld == 1);
+    ASSERT(rd == 1);
+}
+
+/* GOAL_KIND_TRACK centered box → both wheels within 5%. */
+static void test_track_centered(void)
+{
+    setup();
+
+    goal_t track = {
+        .kind = GOAL_KIND_TRACK,
+        .params.track = {.ymin = 400, .xmin = 400, .ymax = 600, .xmax = 600, .max_speed_pct = 60},
+    };
+    ASSERT(goal_state_write(&track, 1500) == ESP_OK);
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+
+    /* Centre of (400..600) = 500 → error 0 → left == right. */
+    ASSERT(ls == rs);
+    ASSERT(ld == 1);
+    ASSERT(rd == 1);
+
+    /* Within 5 % of expected 60 % of 255 = 153 */
+    int32_t diff = (int32_t)ls - 153;
+    if (diff < 0)
+        diff = -diff;
+    ASSERT(diff < 10);
+}
+
+/* GOAL_KIND_TRACK right-biased box → right wheel slower. */
+static void test_track_right_biased(void)
+{
+    setup();
+
+    goal_t track = {
+        .kind = GOAL_KIND_TRACK,
+        .params.track = {.ymin = 400, .xmin = 700, .ymax = 600, .xmax = 900, .max_speed_pct = 60},
+    };
+    ASSERT(goal_state_write(&track, 1500) == ESP_OK);
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+
+    /* Centre = 800 → error +300 → left faster, right slower. */
+    ASSERT(ls > rs);
+    ASSERT(ld == 1);
+    ASSERT(rd == 1);
+}
+
+/* GOAL_KIND_DRIVE heading=0 → both wheels forward at commanded speed. */
+static void test_drive_straight(void)
+{
+    setup();
+
+    goal_t drive = {
+        .kind = GOAL_KIND_DRIVE,
+        .params.drive = {.heading_deg = 0, .distance_cm = 100, .speed_pct = 50},
+    };
+    ASSERT(goal_state_write(&drive, 1500) == ESP_OK);
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+
+    /* 50 % of 255 = 127 */
+    ASSERT(ls == rs);
+    ASSERT(ls >= 126 && ls <= 128);
+    ASSERT(ld == 1);
+    ASSERT(rd == 1);
+}
+
+/* GOAL_KIND_DRIVE heading=+45 → right wheel slower than left. */
+static void test_drive_turn_right(void)
+{
+    setup();
+
+    goal_t drive = {
+        .kind = GOAL_KIND_DRIVE,
+        .params.drive = {.heading_deg = 45, .distance_cm = 100, .speed_pct = 80},
+    };
+    ASSERT(goal_state_write(&drive, 1500) == ESP_OK);
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+
+    /* Positive heading → right wheel slowed by bias */
+    ASSERT(ls > rs);
+    ASSERT(ld == 1);
+    ASSERT(rd == 1);
+}
+
+/* GOAL_KIND_ROTATE angle=+30 → CW (right back, left forward). */
+static void test_rotate_cw(void)
+{
+    setup();
+
+    goal_t rot = {
+        .kind = GOAL_KIND_ROTATE,
+        .params.rotate = {.angle_deg = 30},
+    };
+    ASSERT(goal_state_write(&rot, 1500) == ESP_OK);
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+
+    /* motor_rotate_cw stub: left=1 (fwd), right=0 (back) */
+    ASSERT(ld == 1);
+    ASSERT(rd == 0);
+    ASSERT(ls > 0);
+    ASSERT(rs > 0);
+}
+
+/* GOAL_KIND_ROTATE angle=-30 → CCW (left back, right forward). */
+static void test_rotate_ccw(void)
+{
+    setup();
+
+    goal_t rot = {
+        .kind = GOAL_KIND_ROTATE,
+        .params.rotate = {.angle_deg = -30},
+    };
+    ASSERT(goal_state_write(&rot, 1500) == ESP_OK);
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+
+    /* motor_rotate_ccw stub: left=0 (back), right=1 (fwd) */
+    ASSERT(ld == 0);
+    ASSERT(rd == 1);
+}
+
+/* Stale goal (TTL expired) → motor_stop. */
+static int64_t g_test_time_us;
+static int64_t test_clock(void)
+{
+    return g_test_time_us;
+}
+
+static void test_stale_goal_stops(void)
+{
+    setup();
+
+    g_test_time_us = 0;
+    goal_state_set_clock_override(test_clock);
+
+    goal_t drive = {
+        .kind = GOAL_KIND_DRIVE,
+        .params.drive = {.heading_deg = 0, .distance_cm = 100, .speed_pct = 80},
+    };
+    ASSERT(goal_state_write(&drive, 1000) == ESP_OK);
+
+    /* Advance past TTL */
+    g_test_time_us = 2000 * 1000LL;
+
+    prime_distance(100);
+
+    uint8_t ls, rs, ld, rd;
+    get_motor_state(&ls, &rs, &ld, &rd);
+    ASSERT(ls == 0);
+    ASSERT(rs == 0);
+
+    goal_state_set_clock_override(NULL);
+}
+
+/* =========================================================================
+ * Main
+ * ========================================================================= */
+
+int main(void)
+{
+    printf("=== reactive_controller host tests ===\n\n");
+
+    test_run("reflex_latch_overrides_drive", test_reflex_latch_overrides_drive);
+    test_run("reflex_release", test_reflex_release);
+    test_run("track_centered", test_track_centered);
+    test_run("track_right_biased", test_track_right_biased);
+    test_run("drive_straight", test_drive_straight);
+    test_run("drive_turn_right", test_drive_turn_right);
+    test_run("rotate_cw", test_rotate_cw);
+    test_run("rotate_ccw", test_rotate_ccw);
+    test_run("stale_goal_stops", test_stale_goal_stops);
+
+    printf("\n=== Results ===\n");
+    printf("Passed: %d / %d\n", test_pass, test_count);
+    return (test_pass == test_count) ? 0 : 1;
+}

--- a/packages/esp32-projects/robocar-unified/test/test_ultrasonic_stub.c
+++ b/packages/esp32-projects/robocar-unified/test/test_ultrasonic_stub.c
@@ -1,0 +1,56 @@
+/**
+ * @file test_ultrasonic_stub.c
+ * @brief Regression test for the ULTRASONIC_HOST_TEST stub.
+ *
+ * The stub is a single-variable latch: the value passed to
+ * ultrasonic_test_set_distance() is returned by the next (and every
+ * subsequent) ultrasonic_measure() call until overwritten. If this contract
+ * breaks, every reactive_controller test that depends on it silently
+ * misbehaves — hence this small guard.
+ */
+
+#include "ultrasonic.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+#define ASSERT(cond)                                               \
+    do {                                                           \
+        if (!(cond)) {                                             \
+            printf("FAIL: %s:%d %s\n", __FILE__, __LINE__, #cond); \
+            assert(cond);                                          \
+        }                                                          \
+    } while (0)
+
+int main(void)
+{
+    printf("=== ultrasonic stub host tests ===\n\n");
+
+    ASSERT(ultrasonic_init() == ESP_OK);
+
+    /* Basic set→read */
+    ultrasonic_test_set_distance(42);
+    uint16_t out = 0;
+    ASSERT(ultrasonic_measure(&out) == ESP_OK);
+    ASSERT(out == 42);
+
+    /* Overwrite */
+    ultrasonic_test_set_distance(200);
+    ASSERT(ultrasonic_measure(&out) == ESP_OK);
+    ASSERT(out == 200);
+
+    /* Latch persistence: second read returns same value */
+    ASSERT(ultrasonic_measure(&out) == ESP_OK);
+    ASSERT(out == 200);
+
+    /* ULTRASONIC_DIST_ERROR simulates a timeout → ESP_FAIL */
+    ultrasonic_test_set_distance(ULTRASONIC_DIST_ERROR);
+    ASSERT(ultrasonic_measure(&out) == ESP_FAIL);
+    ASSERT(out == ULTRASONIC_DIST_ERROR);
+
+    /* NULL arg → ESP_ERR_INVALID_ARG */
+    ASSERT(ultrasonic_measure(NULL) == ESP_ERR_INVALID_ARG);
+
+    printf("\nAll ultrasonic stub tests passed.\n");
+    return 0;
+}

--- a/packages/esp32-projects/xbox-switch-bridge/components/switch_pro_usb/switch_pro_usb.c
+++ b/packages/esp32-projects/xbox-switch-bridge/components/switch_pro_usb/switch_pro_usb.c
@@ -66,7 +66,11 @@ static uint8_t s_timer_counter = 0;
  * and structurally valid for enumeration to succeed.
  *
  * Source: https://gist.github.com/spacemeowx2/22171913a36721501e42f14f1fd81633
+ *
+ * The paired-byte layout below encodes meaning (each line is one HID item);
+ * do not reflow.
  */
+/* clang-format off */
 static const uint8_t s_hid_report_descriptor[] = {
     0x05, 0x01, /* Usage Page (Generic Desktop) */
     0x15, 0x00, /* Logical Minimum (0) */
@@ -167,6 +171,7 @@ static const uint8_t s_hid_report_descriptor[] = {
     0x91, 0x83, /*   Output (Constant, Variable, Volatile) */
     0xC0,       /* End Collection */
 };
+/* clang-format on */
 
 /**
  * USB Configuration Descriptor for HID with IN + OUT endpoints.


### PR DESCRIPTION
## Summary

Phase 5 host-test follow-ups to #222, plus a session-feedback fix for the
post-edit lint hook.

- **#230** — Scope `.claude/hooks/post-edit-lint.sh` to the edited file
  (clang-format/cppcheck/ruff on one path, not the whole tree). Protect the HID
  descriptor tables in `usb_composite.c` + `switch_pro_usb.c` with
  `/* clang-format off */` and restore the paired-byte layout.
- **#226** — `test_reactive_controller.c` (9 tests: reflex latch/release, DRIVE
  straight/turn, TRACK centered/right-biased, ROTATE CW/CCW, stale goal) and
  `test_ultrasonic_stub.c` (5 assertions). Add `esp_err.h` host-test shim; fix
  missing `stddef.h` / `stdlib.h` in ultrasonic.c / reactive_controller.c
  host-test branches.
- **#227** — `robocar-simulation/src/stub_planner.py` + tests: deterministic
  DRIVE → ROTATE → TRACK → STOP sequence at 1 Hz, shape-compatible with the
  MCU `goal_t` union. 12 pytest cases covering ordering, cadence stability,
  wrap-around, reset, and argument validation.
- **#228** — Extract `parse_function_call` into `gemini_parse.{c,h}` so it can
  be host-tested without `esp_http_client` / WiFi / TLS. Add synthetic ER 1.6
  fixtures, `fixtures/README.md` with the live-capture protocol, `esp_log.h`
  host shim, and `test_gemini_parse.c` (10 tests: fixture parsing, fail-safe
  STOP contract, NULL guards, schema drift). CMake auto-detects `libcjson` via
  pkg-config with a Homebrew fallback; the suite skips cleanly when cJSON is
  absent.

Closes #226, closes #227, closes #228, closes #230.
Refs #229 (hardware bench validation — requires physical robot).

## Test plan

- [x] `cd packages/esp32-projects/robocar-unified/test && cmake -S . -B build && cmake --build build && ctest --test-dir build --output-on-failure` — all 4 suites pass (goal_state, ultrasonic_stub, reactive_controller, gemini_parse)
- [x] `cd packages/esp32-projects/robocar-simulation && uv run pytest tests/test_stub_planner.py` — 12/12 pass
- [x] `uv run ruff check src/stub_planner.py tests/test_stub_planner.py` — clean
- [ ] CI (esp32-build.yml) still builds robocar-unified with the new `gemini_parse.c` source
- [ ] Follow-up on #229: capture real ER 1.6 fixtures with a live API key and swap them in (protocol in `test/fixtures/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)