### PR TITLE
chore(docs): schedule NotebookLM knowledge-base maintenance

### DIFF
--- a/.github/workflows/notebook-doc-reminder.yml
+++ b/.github/workflows/notebook-doc-reminder.yml
@@ -1,0 +1,98 @@
+name: NotebookLM Doc Reminder
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/decisions/**'
+      - 'docs/requirements/**'
+      - 'docs/flasher/**'
+      - 'packages/components/**'
+      - 'CLAUDE.md'
+      - '.claude/rules/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute affected notebooks
+        id: map
+        run: |
+          # Collect changed files from the PR
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          echo "changed files:"
+          echo "${FILES//$'\n'/$'\n  '}" | sed '1s/^/  /'
+
+          declare -A HITS
+          while IFS= read -r f; do
+            case "$f" in
+              docs/decisions/ADR-003-*|docs/decisions/ADR-008-*|docs/decisions/ADR-016-*|docs/requirements/PRD-002-*)
+                HITS["a755b5cd — AI vision backends for embedded"]=1 ;;
+              docs/decisions/ADR-004-*|docs/decisions/ADR-012-*|docs/decisions/ADR-015-*|packages/components/ota-github/*|docs/flasher/*)
+                HITS["c6868def — OTA updates & browser-based flashing"]=1 ;;
+              docs/decisions/ADR-010-*|packages/components/improv-wifi/*|.claude/rules/mdns-hostname.md)
+                HITS["ada2b18e — WiFi provisioning, mDNS & MQTT"]=1 ;;
+              docs/decisions/ADR-006-*|docs/decisions/ADR-009-*|docs/requirements/PRD-005-*|packages/input-gaming/*)
+                HITS["e91ebe8d — USB gadget & HID on ESP32-S3"]=1 ;;
+              docs/decisions/ADR-011-*|docs/requirements/PRD-008-*|packages/audio/*)
+                HITS["8cbdd8bb — I2S audio & synthesis on ESP32"]=1 ;;
+              docs/decisions/ADR-007-*|packages/components/i2c-protocol/*)
+                HITS["5601a768 — ESP32 peripherals (I2C, UART, I2S, GPIO)"]=1 ;;
+              docs/requirements/PRD-006-*|packages/games/nfc-scavenger-hunt/*)
+                HITS["4831062f — ChameleonUltra RFID/NFC"]=1 ;;
+              CLAUDE.md|.claude/rules/*)
+                HITS["ae5b0f8b — Claude Code workflow & plugins"]=1 ;;
+            esac
+          done <<< "$FILES"
+
+          if [[ ${#HITS[@]} -eq 0 ]]; then
+            echo "no_hits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no_hits=false" >> "$GITHUB_OUTPUT"
+            {
+              echo 'list<<EOF'
+              for key in "${!HITS[@]}"; do
+                echo "- $key"
+              done
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post or update PR comment
+        if: steps.map.outputs.no_hits != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          MARKER='<!-- notebook-reminder -->'
+          BODY=$(cat <<EOF
+          $MARKER
+          **NotebookLM reminder** — this PR touches docs/components linked to curated notebooks:
+
+          ${{ steps.map.outputs.list }}
+
+          Consider adding primary references from this change to the matching
+          notebook(s) in the same PR (or before closing the next monthly
+          refresh issue). See \`docs/reference/notebook-mapping.md\`.
+          EOF
+          )
+
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+
+          if [[ -n "$EXISTING" ]]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING" \
+              --method PATCH -f "body=$BODY" >/dev/null
+            echo "updated existing comment $EXISTING"
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$BODY"
+            echo "posted new comment"
+          fi

--- a/.github/workflows/notebook-refresh-reminder.yml
+++ b/.github/workflows/notebook-refresh-reminder.yml
@@ -1,0 +1,135 @@
+name: NotebookLM Refresh Reminder
+
+on:
+  schedule:
+    # 1st of each month at 06:17 UTC (off-the-hour to avoid fleet alignment)
+    - cron: '17 6 1 * *'
+  workflow_dispatch:
+    inputs:
+      force_quarterly:
+        description: 'Include quarterly tasks (mind-map, study-guide) even off-quarter'
+        required: false
+        default: 'false'
+        type: boolean
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  open-refresh-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine cycle
+        id: cycle
+        run: |
+          MONTH=$(date -u +%-m)
+          YEAR=$(date -u +%Y)
+          echo "month_name=$(date -u +%B)" >> "$GITHUB_OUTPUT"
+          echo "year=$YEAR" >> "$GITHUB_OUTPUT"
+          if [[ "$MONTH" == "1" || "$MONTH" == "4" || "$MONTH" == "7" || "$MONTH" == "10" ]]; then
+            echo "is_quarterly=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ inputs.force_quarterly }}" == "true" ]]; then
+            echo "is_quarterly=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_quarterly=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip if an open refresh issue already exists for this month
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE_PREFIX="NotebookLM refresh: ${{ steps.cycle.outputs.month_name }} ${{ steps.cycle.outputs.year }}"
+          COUNT=$(gh issue list --repo "${{ github.repository }}" \
+            --label notebooks --state open --search "$TITLE_PREFIX in:title" \
+            --json number --jq 'length')
+          if [[ "$COUNT" -gt 0 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Ensure `notebooks` label exists
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create notebooks \
+            --color 5319E7 \
+            --description "NotebookLM knowledge base maintenance" \
+            --repo "${{ github.repository }}" || true
+
+      - name: Build issue body
+        if: steps.check.outputs.skip != 'true'
+        id: body
+        run: |
+          {
+            echo 'body<<EOF'
+            cat <<'TEMPLATE'
+          Scheduled monthly refresh of the curated NotebookLM knowledge base.
+          See `docs/reference/notebook-mapping.md` for the full mapping.
+
+          **How to run:** `notebooklm login` (once) then `just notebooks-refresh`
+          from your local machine. The CLI is not available in CI because auth
+          lives on your machine.
+
+          ## Active notebooks — monthly checklist
+
+          Regenerate a briefing-doc report on each, skim it, and add/remove
+          sources where the answer drifted.
+
+          - [ ] AI vision backends for embedded — `a755b5cd`
+          - [ ] OTA updates & browser-based flashing — `c6868def`
+          - [ ] WiFi provisioning, mDNS & MQTT — `ada2b18e`
+          - [ ] USB gadget & HID on ESP32-S3 — `e91ebe8d`
+          - [ ] I2S audio & synthesis on ESP32 — `8cbdd8bb`
+          - [ ] ESP32-S3 hardware families — `3bb67ba2`
+          - [ ] Sensors & modules used in this lab — `c2d44a8c`
+          - [ ] ESP32 peripherals: I2C, UART, I2S, GPIO — `5601a768`
+          - [ ] ESP-IDF v5.4+ core reference — `f5af16f1`
+          - [ ] ChameleonUltra RFID/NFC — `4831062f`
+          - [ ] Claude Code workflow & plugins — `ae5b0f8b`
+
+          ## New docs since last refresh
+
+          Check whether any ADRs / PRDs merged since last refresh have been
+          seeded into the matching notebook:
+
+          ```
+          git log --since="1 month ago" --name-only --pretty=format: \
+            -- docs/decisions docs/requirements | sort -u
+          ```
+
+          TEMPLATE
+            if [[ "${{ steps.cycle.outputs.is_quarterly }}" == "true" ]]; then
+              cat <<'QUARTERLY'
+          ## Quarterly tasks
+
+          - [ ] Regenerate mind-map on each active notebook (`notebooklm generate mind-map --notebook <id>` + `download mind-map`)
+          - [ ] Regenerate study-guide report on the five new domain notebooks
+          - [ ] Audit source counts; trim any notebook above ~30 down toward target
+
+          QUARTERLY
+            fi
+            cat <<'FOOTER'
+          ## Done?
+
+          Close this issue when the checklist is complete. The next reminder
+          will open automatically on the 1st of next month.
+          FOOTER
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Open issue
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "NotebookLM refresh: ${{ steps.cycle.outputs.month_name }} ${{ steps.cycle.outputs.year }}" \
+            --label notebooks \
+            --body "${{ steps.body.outputs.body }}"

--- a/docs/reference/notebook-mapping.md
+++ b/docs/reference/notebook-mapping.md
@@ -1,0 +1,53 @@
+# NotebookLM Notebook Mapping
+
+Canonical mapping of repo concerns to curated NotebookLM notebooks. This
+file is the source of truth for:
+
+- The scheduled monthly refresh reminder (`.github/workflows/notebook-refresh-reminder.yml`)
+- The PR-triggered ADR/PRD reminder (`.github/workflows/notebook-doc-reminder.yml`)
+- The `just notebooks-refresh` recipe
+
+When you add a new ADR or PRD, update the matching notebook's sources in
+the same PR (or within the next monthly refresh cycle).
+
+## Active notebooks
+
+| Notebook | ID | Primary repo touchpoints |
+|---|---|---|
+| AI vision backends for embedded (Claude / Ollama / Gemini) | `a755b5cd-22ec-4b5a-844e-ba7c1a258957` | ADR-003, ADR-008, ADR-016; PRD-002; `packages/robocar/camera/`, `packages/camera-vision/` |
+| OTA updates & browser-based flashing | `c6868def-e128-4367-b70d-0efeb289d052` | ADR-004, ADR-012, ADR-015; `packages/components/ota-github/`, `docs/flasher/` |
+| WiFi provisioning, mDNS & MQTT | `ada2b18e-6172-4fea-8176-36db2031e404` | ADR-010; `.claude/rules/mdns-hostname.md`; `packages/components/improv-wifi/` |
+| USB gadget & HID on ESP32-S3 | `e91ebe8d-4b93-4321-9d7e-b97aa34956aa` | ADR-006, ADR-009; PRD-005; `packages/input-gaming/` |
+| I2S audio & synthesis on ESP32 | `8cbdd8bb-e88e-4a26-a94f-d0126e68a09e` | ADR-011; PRD-008; `packages/audio/`, `packages/camera-vision/cam-i2s-audio/` |
+| ESP32-S3 hardware families (XIAO Sense, Heltec, ESP32-CAM) | `3bb67ba2-58b4-4485-a306-6ab49ec38160` | `packages/robocar/main/`, `packages/robocar/unified/`, ESP32-CAM projects |
+| Sensors & modules used in this lab | `c2d44a8c-cba1-436f-9c5c-0fe98f672909` | Module references used anywhere in `packages/` |
+| ESP32 peripherals: I2C, UART, I2S, GPIO | `5601a768-acdb-4aeb-a2f0-455b3e493b1b` | ADR-007; `packages/components/i2c-protocol/` |
+| ESP-IDF v5.4+ core reference (FreeRTOS, flashing, sdkconfig) | `f5af16f1-d307-4cc6-b7ab-39b7dbff0381` | `.claude/rules/esp-idf-sdkconfig.md`, `.claude/rules/containerized-builds.md` |
+| ChameleonUltra: Advanced RFID and NFC Card Emulation Platform | `4831062f-84ab-4f67-89c0-61345941e3ea` | PRD-006; `packages/games/nfc-scavenger-hunt/` |
+| Claude Code workflow & plugins | `ae5b0f8b-91fa-4e9e-9871-ee85d8ce24f9` | `CLAUDE.md`, `.claude/` |
+| The Modern Soldering Equipment and Techniques Guide | `4e584364-0c55-408b-a7db-a69c177af71c` | (Lab hardware, independent of packages) |
+
+## Path → notebook routing (for the PR reminder)
+
+| Path pattern | Notebooks to consider updating |
+|---|---|
+| `docs/decisions/ADR-003-*`, `docs/decisions/ADR-008-*`, `docs/decisions/ADR-016-*`, `docs/requirements/PRD-002-*` | AI vision backends |
+| `docs/decisions/ADR-004-*`, `docs/decisions/ADR-012-*`, `docs/decisions/ADR-015-*`, `packages/components/ota-github/**`, `docs/flasher/**` | OTA & web flasher |
+| `docs/decisions/ADR-010-*`, `packages/components/improv-wifi/**`, `.claude/rules/mdns-hostname.md` | WiFi / mDNS / MQTT |
+| `docs/decisions/ADR-006-*`, `docs/decisions/ADR-009-*`, `docs/requirements/PRD-005-*`, `packages/input-gaming/**` | USB / HID |
+| `docs/decisions/ADR-011-*`, `docs/requirements/PRD-008-*`, `packages/audio/**` | I2S audio |
+| `docs/decisions/ADR-007-*`, `packages/components/i2c-protocol/**` | ESP32 peripherals |
+| `docs/requirements/PRD-006-*`, `packages/games/nfc-scavenger-hunt/**` | ChameleonUltra RFID/NFC |
+| `CLAUDE.md`, `.claude/**` | Claude Code workflow |
+
+## Maintenance cadence
+
+- **Monthly**: regenerate the briefing-doc on each active notebook; note which answers changed materially; add primary references for any new ADR/PRD that landed.
+- **Quarterly**: regenerate the mind-map and study-guide artifacts.
+- **Per-PR**: when a PR touches `docs/decisions/` or `docs/requirements/`, update the matching notebook's sources.
+
+## Conventions
+
+- **Source cap**: ~30 per notebook. When adding, consider dropping a stale one.
+- **No duplicates**: dedup by `(title, url)` — `notebooklm source list --notebook <id> --json` + manual pass.
+- **Local-only auth**: `notebooklm` CLI needs `notebooklm login` on the machine running the refresh. It cannot run in CI.

--- a/justfile
+++ b/justfile
@@ -347,6 +347,19 @@ docker-clean:
 docker-logs:
     docker compose logs -f
 
+##########
+# NotebookLM knowledge base
+##########
+
+# Audit curated NotebookLM notebooks: source counts + recent ADR/PRD changes
+[group: "notebooks"]
+notebooks-status:
+    tools/notebooks-status.sh
+
+##########
+# Git
+##########
+
 # Check for credential files in the git staging area
 [group: "git"]
 git-check-credentials:

--- a/tools/notebooks-status.sh
+++ b/tools/notebooks-status.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Local NotebookLM refresh helper. Reads the active notebook IDs from
+# docs/reference/notebook-mapping.md and reports source counts + recently
+# merged ADR/PRD files that may need to be seeded.
+#
+# Prereq: notebooklm login (one-time, OAuth stored at ~/.notebooklm)
+
+set -euo pipefail
+
+MAPPING="${MAPPING:-docs/reference/notebook-mapping.md}"
+SINCE="${SINCE:-1 month ago}"
+
+if ! command -v notebooklm >/dev/null 2>&1; then
+  echo "notebooklm CLI not found. Install with: pip install notebooklm-py" >&2
+  exit 1
+fi
+
+if ! notebooklm status >/dev/null 2>&1; then
+  echo "notebooklm is not authenticated. Run: notebooklm login" >&2
+  exit 1
+fi
+
+printf '%s\n' "== Active notebooks (source counts) =="
+# Extract backtick-wrapped UUIDs from the mapping doc's table
+grep -oE '`[0-9a-f]{8}-[0-9a-f-]+`' "$MAPPING" \
+  | tr -d '`' \
+  | sort -u \
+  | while read -r nid; do
+      title=$(notebooklm list --json | python3 -c "
+import json, sys
+nid = sys.argv[1]
+for nb in json.load(sys.stdin)['notebooks']:
+    if nb['id'] == nid:
+        print(nb['title']); break
+" "$nid")
+      count=$(notebooklm source list --notebook "$nid" --json \
+        | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('sources', [])))")
+      printf '  %-8s  %3s sources  — %s\n' "${nid:0:8}" "$count" "${title:-<unknown>}"
+    done
+
+printf '\n%s\n' "== ADR/PRD files changed since $SINCE =="
+git log --since="$SINCE" --name-only --pretty=format: \
+  -- docs/decisions docs/requirements \
+  | sort -u | grep -v '^$' | sed 's/^/  /' || true
+
+printf '\n%s\n' "== Next steps =="
+cat <<'EOF'
+  For each notebook that looks stale or drifted:
+    notebooklm use <id>
+    notebooklm generate report --format briefing-doc
+    notebooklm download report tmp/<id>-briefing.md
+
+  To add sources from a new ADR/PRD:
+    notebooklm source add --notebook <id> docs/decisions/ADR-NNN-....md
+
+  Full mapping: docs/reference/notebook-mapping.md
+EOF


### PR DESCRIPTION
## Summary

- Curates a focused set of NotebookLM notebooks aligned with this repo's domains (AI vision backends, OTA/web flasher, WiFi/mDNS/MQTT, USB/HID, I2S audio, ESP32-S3 hardware, sensors, ESP32 peripherals, ESP-IDF, RFID/NFC, Claude Code).
- Wires up the maintenance routines so they stay alive instead of drifting: a scheduled monthly issue opener, a PR-triggered reminder, a canonical mapping doc, and a local audit recipe.

## What's new

- **`.github/workflows/notebook-refresh-reminder.yml`** — scheduled (1st of month at 06:17 UTC). Opens an issue with a per-notebook checklist; adds mind-map + study-guide tasks in quarter-start months. Idempotent (skips if this month's issue is already open). Manual trigger via `workflow_dispatch` with `force_quarterly` input.
- **`.github/workflows/notebook-doc-reminder.yml`** — PR-triggered when a PR touches `docs/decisions/`, `docs/requirements/`, `packages/components/`, `CLAUDE.md`, or `.claude/rules/`. Posts a sticky comment (idempotent via `<!-- notebook-reminder -->` marker) naming which notebook(s) to update.
- **`docs/reference/notebook-mapping.md`** — single source of truth for notebook IDs, repo touchpoints, path routing, and cadence.
- **`tools/notebooks-status.sh` + `just notebooks-status`** — local audit: source counts per notebook + ADR/PRD changes since last month. (The refresh itself runs locally because `notebooklm` CLI auth is local-only.)

## Test plan

- [x] `actionlint` clean on both new workflows
- [x] `just notebooks-status` runs locally and reports the expected counts
- [ ] After merge, trigger `notebook-refresh-reminder` manually via `workflow_dispatch` to verify it opens an issue
- [ ] Follow-up PR touching e.g. `docs/decisions/ADR-003-*` to verify the PR-reminder comment appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)