### PR TITLE
chore(docs): extend notebook taxonomy with boards, components, and libraries

### DIFF
--- a/.github/workflows/notebook-doc-reminder.yml
+++ b/.github/workflows/notebook-doc-reminder.yml
@@ -7,7 +7,15 @@ on:
       - 'docs/decisions/**'
       - 'docs/requirements/**'
       - 'docs/flasher/**'
+      - 'docs/reference/boards/**'
       - 'packages/components/**'
+      - 'packages/audio/**'
+      - 'packages/input-gaming/**'
+      - 'packages/networking/wireguard-ha/**'
+      - 'packages/robocar/camera/**'
+      - 'packages/robocar/main/**'
+      - 'packages/robocar/simulation/**'
+      - 'packages/robocar/unified/main/motor_controller.*'
       - 'CLAUDE.md'
       - '.claude/rules/**'
 
@@ -40,13 +48,23 @@ jobs:
               docs/decisions/ADR-010-*|packages/components/improv-wifi/*|.claude/rules/mdns-hostname.md)
                 HITS["ada2b18e — WiFi provisioning, mDNS & MQTT"]=1 ;;
               docs/decisions/ADR-006-*|docs/decisions/ADR-009-*|docs/requirements/PRD-005-*|packages/input-gaming/*)
-                HITS["e91ebe8d — USB gadget & HID on ESP32-S3"]=1 ;;
-              docs/decisions/ADR-011-*|docs/requirements/PRD-008-*|packages/audio/*)
+                HITS["e91ebe8d — USB gadget & HID on ESP32-S3"]=1 ;;&
+              docs/decisions/ADR-009-*|docs/requirements/PRD-008-*|packages/audio/gamepad-synth/*|packages/input-gaming/*)
+                HITS["f696b00a — Bluepad32 & BLE HID input"]=1 ;;
+              packages/robocar/*/main/motor_controller.*)
+                HITS["197ef318 — Motor drivers & power electronics"]=1 ;;
+              docs/requirements/PRD-007-*|packages/audio/audiobook-player/*|packages/networking/wireguard-ha/*)
+                HITS["2cb7153a — ESPHome platform & components"]=1 ;;
+              docs/decisions/ADR-011-*|packages/audio/*)
                 HITS["8cbdd8bb — I2S audio & synthesis on ESP32"]=1 ;;
               docs/decisions/ADR-007-*|packages/components/i2c-protocol/*)
                 HITS["5601a768 — ESP32 peripherals (I2C, UART, I2S, GPIO)"]=1 ;;
               docs/requirements/PRD-006-*|packages/games/nfc-scavenger-hunt/*)
                 HITS["4831062f — ChameleonUltra RFID/NFC"]=1 ;;
+              packages/robocar/camera/*|packages/robocar/main/*|docs/reference/boards/ttgo-lora32-v2.md)
+                HITS["d2d63711 — ESP32 classic boards (CAM, Heltec, TTGO)"]=1 ;;
+              docs/requirements/PRD-003-*|packages/robocar/simulation/*)
+                HITS["28c00388 — Python simulation & robotics math"]=1 ;;
               CLAUDE.md|.claude/rules/*)
                 HITS["ae5b0f8b — Claude Code workflow & plugins"]=1 ;;
             esac

--- a/.github/workflows/notebook-refresh-reminder.yml
+++ b/.github/workflows/notebook-refresh-reminder.yml
@@ -87,10 +87,15 @@ jobs:
           - [ ] USB gadget & HID on ESP32-S3 — `e91ebe8d`
           - [ ] I2S audio & synthesis on ESP32 — `8cbdd8bb`
           - [ ] ESP32-S3 hardware families — `3bb67ba2`
+          - [ ] ESP32 classic boards (CAM, Heltec, TTGO) — `d2d63711`
           - [ ] Sensors & modules used in this lab — `c2d44a8c`
+          - [ ] Motor drivers & power electronics — `197ef318`
           - [ ] ESP32 peripherals: I2C, UART, I2S, GPIO — `5601a768`
           - [ ] ESP-IDF v5.4+ core reference — `f5af16f1`
+          - [ ] ESPHome platform & components — `2cb7153a`
+          - [ ] Bluepad32 & BLE HID input — `f696b00a`
           - [ ] ChameleonUltra RFID/NFC — `4831062f`
+          - [ ] Python simulation & robotics math — `28c00388`
           - [ ] Claude Code workflow & plugins — `ae5b0f8b`
 
           ## New docs since last refresh

--- a/docs/reference/notebook-mapping.md
+++ b/docs/reference/notebook-mapping.md
@@ -12,19 +12,56 @@ the same PR (or within the next monthly refresh cycle).
 
 ## Active notebooks
 
+The taxonomy is organized along six axes: **MCU boards**, **peripheral IC
+classes**, **embedded frameworks & SDKs**, **network protocols**, **AI /
+cloud APIs**, and **dev tooling & simulation**. Notebooks grouped by
+purpose below.
+
+### MCU boards
+
+| Notebook | ID | Primary repo touchpoints |
+|---|---|---|
+| ESP32-S3 hardware families (XIAO Sense, XIAO Plus, ESP32-S3-Zero) | `3bb67ba2-58b4-4485-a306-6ab49ec38160` | ADR-013; `packages/robocar/unified/`, XIAO projects; XIAO ESP32-C6 cross-ref |
+| ESP32 classic boards (CAM, Heltec, TTGO) | `d2d63711-4843-48e7-9965-018362dad0e5` | `packages/robocar/camera/`, `packages/robocar/main/`, `docs/reference/boards/ttgo-lora32-v2.md` |
+
+### Peripheral IC classes
+
+| Notebook | ID | Primary repo touchpoints |
+|---|---|---|
+| Sensors & modules used in this lab | `c2d44a8c-cba1-436f-9c5c-0fe98f672909` | Module references used anywhere in `packages/` |
+| Motor drivers & power electronics | `197ef318-9983-4168-9a3b-d92288d832b6` | `packages/robocar/*/main/motor_controller.*`; TB6612FNG, L298N, DRV8833, TP4056, MT3608, XL6009, AMS1117, NE555 |
+| I2S audio & synthesis on ESP32 | `8cbdd8bb-e88e-4a26-a94f-d0126e68a09e` | ADR-011; PRD-008; `packages/audio/`, `packages/camera-vision/cam-i2s-audio/` |
+| USB gadget & HID on ESP32-S3 | `e91ebe8d-4b93-4321-9d7e-b97aa34956aa` | ADR-006, ADR-009; PRD-005; `packages/input-gaming/` |
+| ChameleonUltra: Advanced RFID and NFC Card Emulation Platform | `4831062f-84ab-4f67-89c0-61345941e3ea` | PRD-006; `packages/games/nfc-scavenger-hunt/` |
+
+### Embedded frameworks & SDKs
+
+| Notebook | ID | Primary repo touchpoints |
+|---|---|---|
+| ESP-IDF v5.4+ core reference (FreeRTOS, flashing, sdkconfig) | `f5af16f1-d307-4cc6-b7ab-39b7dbff0381` | `.claude/rules/esp-idf-sdkconfig.md`, `.claude/rules/containerized-builds.md` |
+| ESP32 peripherals: I2C, UART, I2S, GPIO | `5601a768-acdb-4aeb-a2f0-455b3e493b1b` | ADR-007; `packages/components/i2c-protocol/` |
+| ESPHome platform & components | `2cb7153a-c51f-43c5-9a95-25261be28aec` | PRD-007; `packages/audio/audiobook-player/`, `packages/networking/wireguard-ha/` |
+| Bluepad32 & BLE HID input | `f696b00a-1c42-44ae-92de-1bb1fef30c1d` | ADR-009; PRD-005, PRD-008; `packages/audio/gamepad-synth/`, `packages/input-gaming/xbox-switch-bridge/` |
+
+### Network protocols & integration
+
+| Notebook | ID | Primary repo touchpoints |
+|---|---|---|
+| WiFi provisioning, mDNS & MQTT | `ada2b18e-6172-4fea-8176-36db2031e404` | ADR-010; `.claude/rules/mdns-hostname.md`; `packages/components/improv-wifi/` |
+| OTA updates & browser-based flashing | `c6868def-e128-4367-b70d-0efeb289d052` | ADR-004, ADR-012, ADR-015; `packages/components/ota-github/`, `docs/flasher/` |
+
+### AI / cloud APIs
+
 | Notebook | ID | Primary repo touchpoints |
 |---|---|---|
 | AI vision backends for embedded (Claude / Ollama / Gemini) | `a755b5cd-22ec-4b5a-844e-ba7c1a258957` | ADR-003, ADR-008, ADR-016; PRD-002; `packages/robocar/camera/`, `packages/camera-vision/` |
-| OTA updates & browser-based flashing | `c6868def-e128-4367-b70d-0efeb289d052` | ADR-004, ADR-012, ADR-015; `packages/components/ota-github/`, `docs/flasher/` |
-| WiFi provisioning, mDNS & MQTT | `ada2b18e-6172-4fea-8176-36db2031e404` | ADR-010; `.claude/rules/mdns-hostname.md`; `packages/components/improv-wifi/` |
-| USB gadget & HID on ESP32-S3 | `e91ebe8d-4b93-4321-9d7e-b97aa34956aa` | ADR-006, ADR-009; PRD-005; `packages/input-gaming/` |
-| I2S audio & synthesis on ESP32 | `8cbdd8bb-e88e-4a26-a94f-d0126e68a09e` | ADR-011; PRD-008; `packages/audio/`, `packages/camera-vision/cam-i2s-audio/` |
-| ESP32-S3 hardware families (XIAO Sense, Heltec, ESP32-CAM) | `3bb67ba2-58b4-4485-a306-6ab49ec38160` | `packages/robocar/main/`, `packages/robocar/unified/`, ESP32-CAM projects |
-| Sensors & modules used in this lab | `c2d44a8c-cba1-436f-9c5c-0fe98f672909` | Module references used anywhere in `packages/` |
-| ESP32 peripherals: I2C, UART, I2S, GPIO | `5601a768-acdb-4aeb-a2f0-455b3e493b1b` | ADR-007; `packages/components/i2c-protocol/` |
-| ESP-IDF v5.4+ core reference (FreeRTOS, flashing, sdkconfig) | `f5af16f1-d307-4cc6-b7ab-39b7dbff0381` | `.claude/rules/esp-idf-sdkconfig.md`, `.claude/rules/containerized-builds.md` |
-| ChameleonUltra: Advanced RFID and NFC Card Emulation Platform | `4831062f-84ab-4f67-89c0-61345941e3ea` | PRD-006; `packages/games/nfc-scavenger-hunt/` |
+
+### Dev tooling & simulation
+
+| Notebook | ID | Primary repo touchpoints |
+|---|---|---|
 | Claude Code workflow & plugins | `ae5b0f8b-91fa-4e9e-9871-ee85d8ce24f9` | `CLAUDE.md`, `.claude/` |
+| Python simulation & robotics math | `28c00388-b713-4e0e-b7f2-591c31b60d90` | PRD-003; `packages/robocar/simulation/` |
 | The Modern Soldering Equipment and Techniques Guide | `4e584364-0c55-408b-a7db-a69c177af71c` | (Lab hardware, independent of packages) |
 
 ## Path → notebook routing (for the PR reminder)
@@ -34,10 +71,15 @@ the same PR (or within the next monthly refresh cycle).
 | `docs/decisions/ADR-003-*`, `docs/decisions/ADR-008-*`, `docs/decisions/ADR-016-*`, `docs/requirements/PRD-002-*` | AI vision backends |
 | `docs/decisions/ADR-004-*`, `docs/decisions/ADR-012-*`, `docs/decisions/ADR-015-*`, `packages/components/ota-github/**`, `docs/flasher/**` | OTA & web flasher |
 | `docs/decisions/ADR-010-*`, `packages/components/improv-wifi/**`, `.claude/rules/mdns-hostname.md` | WiFi / mDNS / MQTT |
-| `docs/decisions/ADR-006-*`, `docs/decisions/ADR-009-*`, `docs/requirements/PRD-005-*`, `packages/input-gaming/**` | USB / HID |
-| `docs/decisions/ADR-011-*`, `docs/requirements/PRD-008-*`, `packages/audio/**` | I2S audio |
+| `docs/decisions/ADR-006-*`, `docs/requirements/PRD-005-*` | USB / HID |
+| `docs/decisions/ADR-009-*`, `docs/requirements/PRD-008-*`, `packages/audio/gamepad-synth/**`, `packages/input-gaming/**` | USB / HID + Bluepad32 |
+| `docs/decisions/ADR-011-*`, `packages/audio/**` (non-gamepad) | I2S audio |
 | `docs/decisions/ADR-007-*`, `packages/components/i2c-protocol/**` | ESP32 peripherals |
 | `docs/requirements/PRD-006-*`, `packages/games/nfc-scavenger-hunt/**` | ChameleonUltra RFID/NFC |
+| `packages/robocar/camera/**`, `packages/robocar/main/**`, `docs/reference/boards/ttgo-lora32-v2.md` | ESP32 classic boards |
+| `packages/robocar/*/main/motor_controller.*` | Motor drivers & power electronics |
+| `docs/requirements/PRD-007-*`, `packages/audio/audiobook-player/**`, `packages/networking/wireguard-ha/**` | ESPHome platform & components |
+| `docs/requirements/PRD-003-*`, `packages/robocar/simulation/**` | Python simulation & robotics math |
 | `CLAUDE.md`, `.claude/**` | Claude Code workflow |
 
 ## Maintenance cadence


### PR DESCRIPTION
## Summary

- Layers a **parts-and-libraries axis** onto the curated NotebookLM taxonomy by creating 5 new notebooks and extending 3 existing ones.
- Reorganizes `docs/reference/notebook-mapping.md` into six axes: MCU boards, peripheral IC classes, embedded frameworks & SDKs, network protocols, AI / cloud APIs, and dev tooling & simulation.
- Extends the PR reminder + monthly refresh workflows with the new notebook IDs and path routing.

## New notebooks

| ID | Title | Seed count |
|---|---|---|
| `d2d63711` | ESP32 classic boards (CAM, Heltec, TTGO) | 11 |
| `197ef318` | Motor drivers & power electronics | 12 |
| `2cb7153a` | ESPHome platform & components | 11 |
| `f696b00a` | Bluepad32 & BLE HID input | 11 |
| `28c00388` | Python simulation & robotics math | 11 |

All within the ~30-source per-notebook cap.

## Extended notebooks

- `8cbdd8bb` I2S audio — MAX98357A datasheet, INMP441 datasheet
- `e91ebe8d` USB/HID — Xbox Wireless Controller + DualSense BLE protocol notes
- `3bb67ba2` ESP32-S3 hardware families — XIAO ESP32-C6 pinout cross-ref

## Workflow changes

- `notebook-doc-reminder.yml` — extended path filter and `case` routing to cover the 5 new notebooks. Uses `;;&` fallthrough so `packages/input-gaming/**` and ADR-009 hit both USB/HID and Bluepad32.
- `notebook-refresh-reminder.yml` — added the 5 new notebook IDs to the monthly checklist.

## Test plan

- [x] `actionlint` passes on both workflow files.
- [x] Case-routing smoke test (bash script) verifies:
  - `packages/audio/gamepad-synth/*` → Bluepad32 only
  - `packages/audio/audiobook-player/*` → ESPHome only
  - `packages/audio/kids-audio-toy/*` → I2S audio only
  - `packages/input-gaming/*` → USB/HID + Bluepad32
  - `packages/robocar/simulation/*` → Python sim
  - `packages/robocar/camera/*` → ESP32 classic boards
  - `packages/robocar/unified/main/motor_controller.c` → Motor drivers
  - `packages/networking/wireguard-ha/*` → ESPHome
- [x] `just notebooks-status` resolves all new IDs and reports source counts.
- [ ] After merge: `gh workflow run notebook-refresh-reminder.yml -f force_quarterly=true` to confirm the issue body includes the 5 new checklist items.
- [ ] After merge: throwaway PR touching `packages/robocar/simulation/pyproject.toml` + `packages/audio/audiobook-player/audiobook-player.yaml` to verify the PR reminder comment names the Python sim + ESPHome notebooks.

## Non-goals

- Per-part notebooks (one per IC) — would fragment the taxonomy past a maintainable ceiling.
- Per-project notebooks — ADRs/PRDs already serve that role.
- The optional 6th "Emerging MCU families" notebook (ESP32-C3 Super Mini, XIAO ESP32-C6, RP2350) is deferred until a package targets one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)