### PR TITLE
fix(ci): avoid bash command substitution in monthly refresh issue body

### DIFF
--- a/.github/workflows/notebook-refresh-reminder.yml
+++ b/.github/workflows/notebook-refresh-reminder.yml
@@ -66,8 +66,8 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         id: body
         run: |
+          BODY_FILE="$RUNNER_TEMP/issue-body.md"
           {
-            echo 'body<<EOF'
             cat <<'TEMPLATE'
           Scheduled monthly refresh of the curated NotebookLM knowledge base.
           See `docs/reference/notebook-mapping.md` for the full mapping.
@@ -125,8 +125,8 @@ jobs:
           Close this issue when the checklist is complete. The next reminder
           will open automatically on the 1st of next month.
           FOOTER
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          } > "$BODY_FILE"
+          echo "path=$BODY_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Open issue
         if: steps.check.outputs.skip != 'true'
@@ -137,4 +137,4 @@ jobs:
             --repo "${{ github.repository }}" \
             --title "NotebookLM refresh: ${{ steps.cycle.outputs.month_name }} ${{ steps.cycle.outputs.year }}" \
             --label notebooks \
-            --body "${{ steps.body.outputs.body }}"
+            --body-file "${{ steps.body.outputs.path }}"


### PR DESCRIPTION
## Summary

Issue #235 (opened by the April 2026 smoke run) surfaced a pre-existing bug in `notebook-refresh-reminder.yml`: the `Open issue` step inlines the assembled body via `--body "${{ steps.body.outputs.body }}"`. GitHub Actions expands that before bash parses the command, so backtick-wrapped notebook IDs (e.g. `` `a755b5cd` ``) and inline codespans (`` `notebooklm login` ``, `` `just notebooks-refresh` ``) were interpreted by bash as command substitutions. Every backtick span resolved to an empty string — including every notebook ID in the monthly checklist.

Fix: write the assembled body to `$RUNNER_TEMP/issue-body.md` and pass it to `gh issue create` via `--body-file`, bypassing shell re-parsing.

## Test plan

- [x] `actionlint` passes.
- [ ] After merge: close #235, re-run `workflow_dispatch` with `force_quarterly=true`, verify the new issue renders every `- [ ] <title> — ` `<id>` ` ` row correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)