### PR TITLE
fix(ci): use GitHub API for PR reminder file list + tighten README titles

### DIFF
--- a/.github/workflows/notebook-doc-reminder.yml
+++ b/.github/workflows/notebook-doc-reminder.yml
@@ -27,14 +27,18 @@ jobs:
   remind:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
       - name: Compute affected notebooks
         id: map
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
-          # Collect changed files from the PR
-          git fetch origin "${{ github.base_ref }}" --depth=1
-          FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          # Collect changed files from the PR via the API (robust against
+          # shallow clones and force-pushes).
+          FILES=$(gh api --paginate \
+            "repos/$REPO/pulls/$PR_NUMBER/files" \
+            --jq '.[].filename')
           echo "changed files:"
           echo "${FILES//$'\n'/$'\n  '}" | sed '1s/^/  /'
 

--- a/packages/audio/audiobook-player/README.md
+++ b/packages/audio/audiobook-player/README.md
@@ -1,4 +1,4 @@
-# Audiobook Player
+# RFID Audiobook Player
 
 An RFID-based audiobook player that integrates with Home Assistant. Scan picture cards with RFID tags to play different audiobooks, with physical play/pause buttons.
 

--- a/packages/robocar/simulation/README.md
+++ b/packages/robocar/simulation/README.md
@@ -1,4 +1,4 @@
-# ESP32 Robot Car Simulation
+# Robocar Physics Simulation
 
 A comprehensive simulation environment for the ESP32-based robot car with physics modeling using Pymunk. This simulation provides accurate physics modeling, 2D visualization (matplotlib), and seamless communication with the actual ESP32 hardware.
 


### PR DESCRIPTION
## Summary

Originally a smoke test for the `notebook-doc-reminder.yml` routing after #234; the run surfaced a pre-existing bug where `git diff --name-only \"origin/main...HEAD\"` failed on the default shallow clone (`fatal: origin/main...HEAD: no merge base`). Fix included.

## Changes

- **`notebook-doc-reminder.yml`**: swap the shallow-clone `git diff` for `gh api repos/$REPO/pulls/$PR_NUMBER/files`. Removes the need for a checkout step in this job entirely; also handles force-pushes correctly.
- **`packages/robocar/simulation/README.md`**: `# ESP32 Robot Car Simulation` → `# Robocar Physics Simulation` (drop the redundant `ESP32` prefix, matches the `packages/<domain>/<name>` convention).
- **`packages/audio/audiobook-player/README.md`**: `# Audiobook Player` → `# RFID Audiobook Player` (more specific).

## Verification

The fix is already validated on this very PR: the second workflow run (after the fix landed on the branch — same-repo PRs use the HEAD branch's workflow file) posted a correct reminder comment naming both expected notebooks:

- `28c00388 — Python simulation & robotics math`
- `2cb7153a — ESPHome platform & components`

See the bot comment above.

## Test plan

- [x] `actionlint` passes.
- [x] Reminder bot runs successfully and names both expected notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)