### PR TITLE
feat(thinkpack): Phase 3A — message fragmentation + behaviors component

### DIFF
--- a/packages/components/thinkpack-behaviors/CMakeLists.txt
+++ b/packages/components/thinkpack-behaviors/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(SRCS "command_dispatcher.c"
+                            "command_executor.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES thinkpack-protocol log esp_common
+                    PRIV_REQUIRES freertos)

--- a/packages/components/thinkpack-behaviors/command_dispatcher.c
+++ b/packages/components/thinkpack-behaviors/command_dispatcher.c
@@ -1,0 +1,126 @@
+/**
+ * @file command_dispatcher.c
+ * @brief Leader-side command packet builders for the ThinkPack behavior layer.
+ *
+ * Each helper constructs a thinkpack_command_data_t envelope, copies it into
+ * the packet's data field, then calls thinkpack_finalize() to stamp the magic
+ * bytes and checksum.  No ESP-IDF runtime calls are made — purely packet
+ * construction.
+ */
+
+#include "command_dispatcher.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Compile-time payload size assertions                                */
+/* ------------------------------------------------------------------ */
+
+_Static_assert(sizeof(cmd_led_pattern_payload_t) <= 48,
+               "cmd_led_pattern_payload_t exceeds thinkpack_command_data_t payload limit");
+_Static_assert(sizeof(cmd_set_mood_payload_t) <= 48,
+               "cmd_set_mood_payload_t exceeds thinkpack_command_data_t payload limit");
+_Static_assert(sizeof(cmd_play_melody_payload_t) <= 48,
+               "cmd_play_melody_payload_t exceeds thinkpack_command_data_t payload limit");
+_Static_assert(sizeof(cmd_buzz_payload_t) <= 48,
+               "cmd_buzz_payload_t exceeds thinkpack_command_data_t payload limit");
+_Static_assert(sizeof(cmd_play_sequence_payload_t) <= 48,
+               "cmd_play_sequence_payload_t exceeds thinkpack_command_data_t payload limit");
+_Static_assert(sizeof(cmd_display_line_payload_t) <= 48,
+               "cmd_display_line_payload_t exceeds thinkpack_command_data_t payload limit");
+
+/* ------------------------------------------------------------------ */
+/* Module tag                                                          */
+/* ------------------------------------------------------------------ */
+
+static const char *TAG __attribute__((unused)) = "cmd_build";
+
+/* ------------------------------------------------------------------ */
+/* Internal helper                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Common packet setup: zero, set header fields, embed envelope, finalize.
+ *
+ * @param p           Output packet.
+ * @param seq         Sequence number.
+ * @param src_mac     Sender 6-byte MAC.
+ * @param command_id  Application command identifier.
+ * @param payload     Pointer to command-specific payload bytes.
+ * @param payload_len Byte count of the payload (must be <= 48).
+ */
+static void build_command_packet(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                 uint8_t command_id, const void *payload, uint8_t payload_len)
+{
+    thinkpack_command_data_t env;
+    memset(&env, 0, sizeof(env));
+    env.command_id = command_id;
+    env.length = payload_len;
+    memcpy(env.payload, payload, payload_len);
+
+    memset(p, 0, sizeof(*p));
+    p->msg_type = MSG_COMMAND;
+    p->sequence_number = seq;
+    memcpy(p->src_mac, src_mac, 6);
+    p->data_length = (uint8_t)sizeof(thinkpack_command_data_t);
+    memcpy(p->data, &env, sizeof(thinkpack_command_data_t));
+    thinkpack_finalize(p);
+}
+
+/* ------------------------------------------------------------------ */
+/* Public builders                                                     */
+/* ------------------------------------------------------------------ */
+
+void command_build_led_pattern(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                               const cmd_led_pattern_payload_t *payload)
+{
+    if (!p || !payload) {
+        return;
+    }
+    build_command_packet(p, seq, src_mac, CMD_LED_PATTERN, payload, (uint8_t)sizeof(*payload));
+}
+
+void command_build_set_mood(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                            const cmd_set_mood_payload_t *payload)
+{
+    if (!p || !payload) {
+        return;
+    }
+    build_command_packet(p, seq, src_mac, CMD_SET_MOOD, payload, (uint8_t)sizeof(*payload));
+}
+
+void command_build_play_melody(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                               const cmd_play_melody_payload_t *payload)
+{
+    if (!p || !payload) {
+        return;
+    }
+    build_command_packet(p, seq, src_mac, CMD_PLAY_MELODY, payload, (uint8_t)sizeof(*payload));
+}
+
+void command_build_buzz(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                        const cmd_buzz_payload_t *payload)
+{
+    if (!p || !payload) {
+        return;
+    }
+    build_command_packet(p, seq, src_mac, CMD_BUZZ, payload, (uint8_t)sizeof(*payload));
+}
+
+void command_build_play_sequence(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                 const cmd_play_sequence_payload_t *payload)
+{
+    if (!p || !payload) {
+        return;
+    }
+    build_command_packet(p, seq, src_mac, CMD_PLAY_SEQUENCE, payload, (uint8_t)sizeof(*payload));
+}
+
+void command_build_display_line(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                const cmd_display_line_payload_t *payload)
+{
+    if (!p || !payload) {
+        return;
+    }
+    build_command_packet(p, seq, src_mac, CMD_DISPLAY_LINE, payload, (uint8_t)sizeof(*payload));
+}

--- a/packages/components/thinkpack-behaviors/command_executor.c
+++ b/packages/components/thinkpack-behaviors/command_executor.c
@@ -1,0 +1,107 @@
+/**
+ * @file command_executor.c
+ * @brief Follower-side command registry and dispatcher for the ThinkPack behavior layer.
+ *
+ * Maintains a static table of up to EXECUTOR_MAX_HANDLERS registered handlers.
+ * command_executor_dispatch() unpacks the thinkpack_command_data_t envelope from
+ * an incoming MSG_COMMAND packet and routes to the appropriate handler.
+ */
+
+#include "command_executor.h"
+
+#include <string.h>
+
+#include "esp_log.h"
+
+/* ------------------------------------------------------------------ */
+/* Module tag                                                          */
+/* ------------------------------------------------------------------ */
+
+static const char *TAG = "cmd_exec";
+
+/* ------------------------------------------------------------------ */
+/* Registry                                                            */
+/* ------------------------------------------------------------------ */
+
+#define EXECUTOR_MAX_HANDLERS 16
+
+typedef struct {
+    uint8_t command_id;
+    command_handler_t handler;
+    void *user_ctx;
+    bool active;
+} handler_entry_t;
+
+static handler_entry_t s_registry[EXECUTOR_MAX_HANDLERS];
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+esp_err_t command_executor_register(uint8_t command_id, command_handler_t handler, void *user_ctx)
+{
+    int free_slot = -1;
+
+    for (int i = 0; i < EXECUTOR_MAX_HANDLERS; i++) {
+        if (!s_registry[i].active) {
+            if (free_slot < 0) {
+                free_slot = i;
+            }
+            continue;
+        }
+        if (s_registry[i].command_id == command_id) {
+            ESP_LOGW(TAG, "command 0x%02x already registered", command_id);
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
+    if (free_slot < 0) {
+        ESP_LOGW(TAG, "handler registry full (max %d)", EXECUTOR_MAX_HANDLERS);
+        return ESP_ERR_NO_MEM;
+    }
+
+    s_registry[free_slot].command_id = command_id;
+    s_registry[free_slot].handler = handler;
+    s_registry[free_slot].user_ctx = user_ctx;
+    s_registry[free_slot].active = true;
+    ESP_LOGI(TAG, "registered handler for command 0x%02x at slot %d", command_id, free_slot);
+    return ESP_OK;
+}
+
+void command_executor_dispatch(const thinkpack_packet_t *packet)
+{
+    if (!packet) {
+        return;
+    }
+
+    if (packet->msg_type != MSG_COMMAND) {
+        ESP_LOGW(TAG, "dispatch called with non-command packet (msg_type=0x%02x)",
+                 packet->msg_type);
+        return;
+    }
+
+    if (packet->data_length < sizeof(thinkpack_command_data_t)) {
+        ESP_LOGW(TAG, "packet data_length %u too small for command envelope (%zu)",
+                 packet->data_length, sizeof(thinkpack_command_data_t));
+        return;
+    }
+
+    const thinkpack_command_data_t *cmd =
+        (const thinkpack_command_data_t *)(const void *)packet->data;
+
+    for (int i = 0; i < EXECUTOR_MAX_HANDLERS; i++) {
+        if (s_registry[i].active && s_registry[i].command_id == cmd->command_id) {
+            s_registry[i].handler(cmd->command_id, cmd->payload, cmd->length,
+                                  s_registry[i].user_ctx);
+            return;
+        }
+    }
+
+    ESP_LOGW(TAG, "no handler for command 0x%02x — ignored", cmd->command_id);
+}
+
+void command_executor_reset(void)
+{
+    memset(s_registry, 0, sizeof(s_registry));
+    ESP_LOGI(TAG, "handler registry cleared");
+}

--- a/packages/components/thinkpack-behaviors/include/command_dispatcher.h
+++ b/packages/components/thinkpack-behaviors/include/command_dispatcher.h
@@ -1,0 +1,81 @@
+/**
+ * @file command_dispatcher.h
+ * @brief Leader-side helpers: build MSG_COMMAND packets for each command type.
+ *
+ * Each helper constructs a thinkpack_packet_t carrying the appropriate
+ * thinkpack_command_data_t envelope.  The caller is responsible for
+ * transmitting the resulting packet via thinkpack_mesh_send().
+ */
+
+#ifndef COMMAND_DISPATCHER_H
+#define COMMAND_DISPATCHER_H
+
+#include "thinkpack_commands.h"
+
+/**
+ * @brief Build a MSG_COMMAND packet carrying an LED pattern directive.
+ *
+ * @param p        Output packet.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender MAC (dispatcher's MAC).
+ * @param payload  LED pattern payload.
+ */
+void command_build_led_pattern(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                               const cmd_led_pattern_payload_t *payload);
+
+/**
+ * @brief Build a MSG_COMMAND packet carrying a mood directive.
+ *
+ * @param p        Output packet.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender MAC.
+ * @param payload  Mood payload.
+ */
+void command_build_set_mood(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                            const cmd_set_mood_payload_t *payload);
+
+/**
+ * @brief Build a MSG_COMMAND packet carrying a melody directive.
+ *
+ * @param p        Output packet.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender MAC.
+ * @param payload  Melody payload.
+ */
+void command_build_play_melody(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                               const cmd_play_melody_payload_t *payload);
+
+/**
+ * @brief Build a MSG_COMMAND packet carrying a single-tone buzz directive.
+ *
+ * @param p        Output packet.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender MAC.
+ * @param payload  Buzz payload.
+ */
+void command_build_buzz(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                        const cmd_buzz_payload_t *payload);
+
+/**
+ * @brief Build a MSG_COMMAND packet carrying a note-sequence directive.
+ *
+ * @param p        Output packet.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender MAC.
+ * @param payload  Sequence payload (note_count must be <= CMD_SEQUENCE_MAX_NOTES).
+ */
+void command_build_play_sequence(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                 const cmd_play_sequence_payload_t *payload);
+
+/**
+ * @brief Build a MSG_COMMAND packet carrying an OLED display-line directive.
+ *
+ * @param p        Output packet.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender MAC.
+ * @param payload  Display-line payload.
+ */
+void command_build_display_line(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                const cmd_display_line_payload_t *payload);
+
+#endif /* COMMAND_DISPATCHER_H */

--- a/packages/components/thinkpack-behaviors/include/command_executor.h
+++ b/packages/components/thinkpack-behaviors/include/command_executor.h
@@ -1,0 +1,63 @@
+/**
+ * @file command_executor.h
+ * @brief Follower-side helpers: register handlers and dispatch incoming commands.
+ *
+ * Followers call command_executor_register() once at startup for each command
+ * they handle.  On THINKPACK_EVENT_COMMAND_RECEIVED the mesh event callback
+ * passes the packet to command_executor_dispatch(), which unpacks the envelope
+ * and invokes the appropriate registered handler.
+ */
+
+#ifndef COMMAND_EXECUTOR_H
+#define COMMAND_EXECUTOR_H
+
+#include <stdint.h>
+
+#include "esp_err.h"
+#include "thinkpack_commands.h"
+
+/**
+ * @brief Handler for a single command_id.
+ *
+ * Payload and length are extracted from the thinkpack_command_data_t envelope.
+ *
+ * @param command_id  The command identifier that triggered this handler.
+ * @param payload     Pointer to the command-specific payload bytes.
+ * @param length      Number of payload bytes.
+ * @param user_ctx    Opaque pointer supplied at registration time.
+ */
+typedef void (*command_handler_t)(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                                  void *user_ctx);
+
+/**
+ * @brief Register a handler for a command id.
+ *
+ * @param command_id  Command identifier to handle.
+ * @param handler     Callback to invoke when command_id is received.
+ * @param user_ctx    Opaque pointer forwarded to every handler invocation.
+ * @return ESP_OK on success.
+ * @return ESP_ERR_INVALID_ARG if command_id already has a registered handler.
+ * @return ESP_ERR_NO_MEM if the registry is full (max 16 entries).
+ */
+esp_err_t command_executor_register(uint8_t command_id, command_handler_t handler, void *user_ctx);
+
+/**
+ * @brief Look up the handler for a packet's command and invoke it.
+ *
+ * Unpacks the thinkpack_command_data_t from packet->data and dispatches to
+ * the registered handler (if any).  Unknown command IDs are logged and ignored.
+ * Packets with unexpected msg_type or insufficient data_length are also ignored.
+ *
+ * @param packet  Non-NULL pointer to the received packet.
+ */
+void command_executor_dispatch(const thinkpack_packet_t *packet);
+
+/**
+ * @brief Clear all registered handlers.
+ *
+ * Resets the registry to an empty state.  Useful between tests or on
+ * device re-initialisation.
+ */
+void command_executor_reset(void);
+
+#endif /* COMMAND_EXECUTOR_H */

--- a/packages/components/thinkpack-behaviors/include/thinkpack_commands.h
+++ b/packages/components/thinkpack-behaviors/include/thinkpack_commands.h
@@ -1,0 +1,104 @@
+/**
+ * @file thinkpack_commands.h
+ * @brief Command IDs and payload structures for the ThinkPack behavior layer.
+ *
+ * These types encode the application-level commands carried inside a
+ * thinkpack_command_data_t envelope (MSG_COMMAND packets).  The leader
+ * (Brainbox) builds command packets using command_dispatcher.h; followers
+ * unpack and dispatch them using command_executor.h.
+ */
+
+#ifndef THINKPACK_COMMANDS_H
+#define THINKPACK_COMMANDS_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "thinkpack_protocol.h"
+
+/* ------------------------------------------------------------------ */
+/* Command IDs                                                         */
+/* ------------------------------------------------------------------ */
+
+/** Command IDs — encoded in thinkpack_command_data_t::command_id. */
+typedef enum {
+    /* LED / visual (Glowbug) */
+    CMD_LED_PATTERN = 0x10, /**< Render a named LED animation */
+    CMD_SET_MOOD = 0x30,    /**< Set a global mood (hue, intensity) */
+
+    /* Audio (Boombox, Chatterbox, Finderbox) */
+    CMD_PLAY_MELODY = 0x20,   /**< Switch melody pattern for N beats */
+    CMD_BUZZ = 0x21,          /**< One-shot single tone */
+    CMD_PLAY_SEQUENCE = 0x22, /**< Play a sequence of notes (array in payload) */
+
+    /* Display (Brainbox) */
+    CMD_DISPLAY_LINE = 0x40, /**< Write a line of text to the OLED */
+} thinkpack_command_id_t;
+
+/* ------------------------------------------------------------------ */
+/* LED / visual payloads                                               */
+/* ------------------------------------------------------------------ */
+
+/** LED animation patterns for CMD_LED_PATTERN. */
+typedef enum {
+    LED_PATTERN_BREATHE = 0,
+    LED_PATTERN_RAINBOW = 1,
+    LED_PATTERN_SPARKLE = 2,
+    LED_PATTERN_NIGHTLIGHT = 3,
+    LED_PATTERN_SOLID = 4,
+    LED_PATTERN_FLASH = 5,
+} thinkpack_led_pattern_t;
+
+/** Payload for CMD_LED_PATTERN. */
+typedef struct __attribute__((packed)) {
+    uint8_t r;       /**< Red channel 0-255 */
+    uint8_t g;       /**< Green channel 0-255 */
+    uint8_t b;       /**< Blue channel 0-255 */
+    uint8_t pattern; /**< thinkpack_led_pattern_t */
+} cmd_led_pattern_payload_t;
+
+/** Payload for CMD_SET_MOOD. */
+typedef struct __attribute__((packed)) {
+    uint8_t hue;       /**< 0-255 */
+    uint8_t intensity; /**< 0-100 */
+} cmd_set_mood_payload_t;
+
+/* ------------------------------------------------------------------ */
+/* Audio payloads                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Payload for CMD_PLAY_MELODY. */
+typedef struct __attribute__((packed)) {
+    uint8_t pattern_id;   /**< 0=MARCH, 1=WALTZ, 2=PENTATONIC, 3=SILENCE */
+    uint8_t repeat_count; /**< Number of beats to stay in this pattern */
+} cmd_play_melody_payload_t;
+
+/** Payload for CMD_BUZZ. */
+typedef struct __attribute__((packed)) {
+    uint8_t note;          /**< thinkpack note_t equivalent index */
+    uint16_t duration_ms;  /**< Duration in milliseconds */
+    int8_t semitone_shift; /**< Signed semitone offset */
+} cmd_buzz_payload_t;
+
+/** Maximum notes per CMD_PLAY_SEQUENCE call. */
+#define CMD_SEQUENCE_MAX_NOTES 20
+
+/** Payload for CMD_PLAY_SEQUENCE. Max 20 notes per call. */
+typedef struct __attribute__((packed)) {
+    uint8_t note_count;        /**< Number of notes in notes[] (0-CMD_SEQUENCE_MAX_NOTES) */
+    uint16_t note_duration_ms; /**< Uniform duration per step in milliseconds */
+    int8_t semitone_shift;     /**< Signed semitone offset applied to all notes */
+    uint8_t notes[CMD_SEQUENCE_MAX_NOTES]; /**< Note index array */
+} cmd_play_sequence_payload_t;
+
+/* ------------------------------------------------------------------ */
+/* Display payloads                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Payload for CMD_DISPLAY_LINE. */
+typedef struct __attribute__((packed)) {
+    uint8_t line;  /**< Display row 0-7 */
+    char text[32]; /**< NUL-terminated text string */
+} cmd_display_line_payload_t;
+
+#endif /* THINKPACK_COMMANDS_H */

--- a/packages/components/thinkpack-behaviors/test/Makefile
+++ b/packages/components/thinkpack-behaviors/test/Makefile
@@ -1,0 +1,37 @@
+# Makefile for thinkpack-behaviors host-based unit tests
+#
+# Compiles command_dispatcher.c and command_executor.c for Linux/macOS using
+# gcc and runs Unity-compatible tests without ESP-IDF or hardware.
+# Suitable for CI and local development.
+#
+# Usage:
+#   make test     — build and run tests (default)
+#   make clean    — remove build artefacts
+
+CC     = gcc
+CFLAGS = -std=c11 -Wall -Wextra \
+         -Wno-unused-function \
+         -I../include \
+         -I../../thinkpack-protocol/include \
+         -Istubs \
+         -I.
+
+SRCS   = test_commands.c \
+         ../command_dispatcher.c \
+         ../command_executor.c \
+         ../../thinkpack-protocol/thinkpack_protocol.c
+
+TARGET = test_runner
+
+.PHONY: all test clean
+
+all: test
+
+test: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS) unity_compat.h stubs/esp_log.h stubs/esp_err.h
+	$(CC) $(CFLAGS) -o $@ $(SRCS)
+
+clean:
+	rm -f $(TARGET)

--- a/packages/components/thinkpack-behaviors/test/stubs/esp_err.h
+++ b/packages/components/thinkpack-behaviors/test/stubs/esp_err.h
@@ -1,0 +1,14 @@
+/**
+ * @file esp_err.h
+ * @brief Minimal esp_err_t stub for host-based unit tests.
+ *
+ * Provides only the types and constants used by command_executor.h so the
+ * test suite compiles without ESP-IDF installed.
+ */
+#pragma once
+
+typedef int esp_err_t;
+
+#define ESP_OK 0
+#define ESP_ERR_NO_MEM 0x101
+#define ESP_ERR_INVALID_ARG 0x102

--- a/packages/components/thinkpack-behaviors/test/stubs/esp_log.h
+++ b/packages/components/thinkpack-behaviors/test/stubs/esp_log.h
@@ -1,0 +1,14 @@
+/**
+ * @file esp_log.h
+ * @brief Stub for ESP-IDF logging — prints to stderr/stdout for host tests.
+ */
+#pragma once
+
+#include <stdio.h>
+
+/* cppcheck-suppress [missingIncludeSystem] */
+#define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "[E][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "[W][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) fprintf(stdout, "[I][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) /* debug suppressed in host tests */
+#define ESP_LOGV(tag, fmt, ...) /* verbose suppressed in host tests */

--- a/packages/components/thinkpack-behaviors/test/test_commands.c
+++ b/packages/components/thinkpack-behaviors/test/test_commands.c
@@ -1,0 +1,437 @@
+/**
+ * @file test_commands.c
+ * @brief Host-based unit tests for thinkpack-behaviors (dispatcher + executor).
+ *
+ * Tests cover:
+ *   - Round-trip packet construction for all command builders
+ *   - Edge cases for CMD_PLAY_SEQUENCE (0 notes, 20 notes)
+ *   - command_executor_register: duplicate rejection, registry-full rejection
+ *   - command_executor_dispatch: correct routing, argument fidelity
+ *   - command_executor_dispatch: unknown command_id does not crash
+ *   - command_executor_reset: clears all registrations
+ *
+ * Build and run: make test
+ */
+
+#include <string.h>
+
+#include "command_dispatcher.h"
+#include "command_executor.h"
+#include "thinkpack_protocol.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* Shared test fixtures                                                */
+/* ------------------------------------------------------------------ */
+
+static const uint8_t TEST_MAC[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+static const uint8_t TEST_SEQ = 0x42;
+
+/** Verify magic bytes and checksum of any finalized packet. */
+static void assert_packet_valid(const thinkpack_packet_t *p)
+{
+    TEST_ASSERT_EQUAL(THINKPACK_MAGIC_0, p->magic[0]);
+    TEST_ASSERT_EQUAL(THINKPACK_MAGIC_VERSION, p->magic[1]);
+    TEST_ASSERT_TRUE(thinkpack_verify_checksum(p));
+}
+
+/** Extract the command envelope from a built packet. */
+static const thinkpack_command_data_t *get_cmd(const thinkpack_packet_t *p)
+{
+    return (const thinkpack_command_data_t *)(const void *)p->data;
+}
+
+/* ------------------------------------------------------------------ */
+/* command_build_led_pattern                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_build_led_pattern_round_trip(void)
+{
+    cmd_led_pattern_payload_t in = {
+        .r = 0xFF, .g = 0x80, .b = 0x10, .pattern = LED_PATTERN_RAINBOW};
+    thinkpack_packet_t pkt;
+
+    command_build_led_pattern(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    TEST_ASSERT_EQUAL(MSG_COMMAND, pkt.msg_type);
+    TEST_ASSERT_EQUAL(TEST_SEQ, pkt.sequence_number);
+    TEST_ASSERT_EQUAL_MEMORY(TEST_MAC, pkt.src_mac, 6);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(thinkpack_command_data_t), pkt.data_length);
+
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_LED_PATTERN, cmd->command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_led_pattern_payload_t), cmd->length);
+
+    cmd_led_pattern_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(0xFF, out.r);
+    TEST_ASSERT_EQUAL(0x80, out.g);
+    TEST_ASSERT_EQUAL(0x10, out.b);
+    TEST_ASSERT_EQUAL(LED_PATTERN_RAINBOW, out.pattern);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_build_set_mood                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_build_set_mood_round_trip(void)
+{
+    cmd_set_mood_payload_t in = {.hue = 200, .intensity = 75};
+    thinkpack_packet_t pkt;
+
+    command_build_set_mood(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    TEST_ASSERT_EQUAL(MSG_COMMAND, pkt.msg_type);
+
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_SET_MOOD, cmd->command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_set_mood_payload_t), cmd->length);
+
+    cmd_set_mood_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(200, out.hue);
+    TEST_ASSERT_EQUAL(75, out.intensity);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_build_play_melody                                           */
+/* ------------------------------------------------------------------ */
+
+static void test_build_play_melody_round_trip(void)
+{
+    cmd_play_melody_payload_t in = {.pattern_id = 2, .repeat_count = 8};
+    thinkpack_packet_t pkt;
+
+    command_build_play_melody(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_PLAY_MELODY, cmd->command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_play_melody_payload_t), cmd->length);
+
+    cmd_play_melody_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(2, out.pattern_id);
+    TEST_ASSERT_EQUAL(8, out.repeat_count);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_build_buzz                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_build_buzz_round_trip(void)
+{
+    cmd_buzz_payload_t in = {.note = 12, .duration_ms = 250, .semitone_shift = 0};
+    thinkpack_packet_t pkt;
+
+    command_build_buzz(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_BUZZ, cmd->command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_buzz_payload_t), cmd->length);
+
+    cmd_buzz_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(12, out.note);
+    TEST_ASSERT_EQUAL(250, out.duration_ms);
+    TEST_ASSERT_EQUAL(0, out.semitone_shift);
+}
+
+static void test_build_buzz_negative_semitone(void)
+{
+    cmd_buzz_payload_t in = {.note = 7, .duration_ms = 100, .semitone_shift = -3};
+    thinkpack_packet_t pkt;
+
+    command_build_buzz(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+
+    cmd_buzz_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(-3, (int8_t)out.semitone_shift);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_build_play_sequence — edge cases                            */
+/* ------------------------------------------------------------------ */
+
+static void test_build_play_sequence_zero_notes(void)
+{
+    cmd_play_sequence_payload_t in;
+    memset(&in, 0, sizeof(in));
+    in.note_count = 0;
+    in.note_duration_ms = 200;
+    in.semitone_shift = 0;
+
+    thinkpack_packet_t pkt;
+    command_build_play_sequence(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_PLAY_SEQUENCE, cmd->command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_play_sequence_payload_t), cmd->length);
+
+    cmd_play_sequence_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(0, out.note_count);
+}
+
+static void test_build_play_sequence_max_notes(void)
+{
+    cmd_play_sequence_payload_t in;
+    memset(&in, 0, sizeof(in));
+    in.note_count = CMD_SEQUENCE_MAX_NOTES;
+    in.note_duration_ms = 150;
+    in.semitone_shift = 2;
+    for (uint8_t i = 0; i < CMD_SEQUENCE_MAX_NOTES; i++) {
+        in.notes[i] = i;
+    }
+
+    thinkpack_packet_t pkt;
+    command_build_play_sequence(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_PLAY_SEQUENCE, cmd->command_id);
+
+    cmd_play_sequence_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(CMD_SEQUENCE_MAX_NOTES, out.note_count);
+    TEST_ASSERT_EQUAL(150, out.note_duration_ms);
+    TEST_ASSERT_EQUAL(2, (int8_t)out.semitone_shift);
+    for (uint8_t i = 0; i < CMD_SEQUENCE_MAX_NOTES; i++) {
+        TEST_ASSERT_EQUAL(i, out.notes[i]);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* command_build_display_line                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_build_display_line_round_trip(void)
+{
+    cmd_display_line_payload_t in;
+    memset(&in, 0, sizeof(in));
+    in.line = 3;
+    strncpy(in.text, "Hello ThinkPack", sizeof(in.text) - 1);
+
+    thinkpack_packet_t pkt;
+    command_build_display_line(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    assert_packet_valid(&pkt);
+    const thinkpack_command_data_t *cmd = get_cmd(&pkt);
+    TEST_ASSERT_EQUAL(CMD_DISPLAY_LINE, cmd->command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_display_line_payload_t), cmd->length);
+
+    cmd_display_line_payload_t out;
+    memcpy(&out, cmd->payload, sizeof(out));
+    TEST_ASSERT_EQUAL(3, out.line);
+    TEST_ASSERT_EQUAL_STRING("Hello ThinkPack", out.text);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_executor_register                                           */
+/* ------------------------------------------------------------------ */
+
+static void dummy_handler(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                          void *user_ctx)
+{
+    (void)command_id;
+    (void)payload;
+    (void)length;
+    (void)user_ctx;
+}
+
+static void test_executor_register_rejects_duplicate(void)
+{
+    command_executor_reset();
+
+    esp_err_t r1 = command_executor_register(CMD_LED_PATTERN, dummy_handler, NULL);
+    TEST_ASSERT_EQUAL(ESP_OK, r1);
+
+    esp_err_t r2 = command_executor_register(CMD_LED_PATTERN, dummy_handler, NULL);
+    TEST_ASSERT_EQUAL(ESP_ERR_INVALID_ARG, r2);
+}
+
+static void test_executor_register_rejects_when_full(void)
+{
+    command_executor_reset();
+
+    /* Fill all 16 slots with distinct command IDs */
+    for (int i = 0; i < 16; i++) {
+        esp_err_t r = command_executor_register((uint8_t)(0x50 + i), dummy_handler, NULL);
+        TEST_ASSERT_EQUAL(ESP_OK, r);
+    }
+
+    /* 17th registration must fail with ESP_ERR_NO_MEM */
+    esp_err_t r = command_executor_register(0xFE, dummy_handler, NULL);
+    TEST_ASSERT_EQUAL(ESP_ERR_NO_MEM, r);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_executor_dispatch — routing and argument fidelity           */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    int call_count;
+    uint8_t last_command_id;
+    uint8_t last_payload[48];
+    uint8_t last_length;
+    void *last_ctx;
+} capture_t;
+
+static void capturing_handler(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                              void *user_ctx)
+{
+    capture_t *cap = (capture_t *)user_ctx;
+    cap->call_count++;
+    cap->last_command_id = command_id;
+    cap->last_length = length;
+    cap->last_ctx = user_ctx;
+    if (length > 0 && length <= 48) {
+        memcpy(cap->last_payload, payload, length);
+    }
+}
+
+static void test_executor_dispatch_routes_correctly(void)
+{
+    command_executor_reset();
+
+    capture_t cap;
+    memset(&cap, 0, sizeof(cap));
+
+    esp_err_t r = command_executor_register(CMD_BUZZ, capturing_handler, &cap);
+    TEST_ASSERT_EQUAL(ESP_OK, r);
+
+    cmd_buzz_payload_t in = {.note = 5, .duration_ms = 300, .semitone_shift = -1};
+    thinkpack_packet_t pkt;
+    command_build_buzz(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    command_executor_dispatch(&pkt);
+
+    TEST_ASSERT_EQUAL(1, cap.call_count);
+    TEST_ASSERT_EQUAL(CMD_BUZZ, cap.last_command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_buzz_payload_t), cap.last_length);
+
+    cmd_buzz_payload_t out;
+    memcpy(&out, cap.last_payload, sizeof(out));
+    TEST_ASSERT_EQUAL(5, out.note);
+    TEST_ASSERT_EQUAL(300, out.duration_ms);
+    TEST_ASSERT_EQUAL(-1, (int8_t)out.semitone_shift);
+}
+
+static void test_executor_dispatch_unknown_id_does_not_crash(void)
+{
+    command_executor_reset();
+
+    /* Build a packet for CMD_LED_PATTERN but register nothing */
+    cmd_led_pattern_payload_t in = {.r = 1, .g = 2, .b = 3, .pattern = LED_PATTERN_SOLID};
+    thinkpack_packet_t pkt;
+    command_build_led_pattern(&pkt, TEST_SEQ, TEST_MAC, &in);
+
+    /* Must not crash; no handler is registered */
+    command_executor_dispatch(&pkt);
+
+    /* If we reach here the test passed */
+    TEST_ASSERT_TRUE(1);
+}
+
+static void test_executor_dispatch_wrong_msg_type_ignored(void)
+{
+    command_executor_reset();
+
+    capture_t cap;
+    memset(&cap, 0, sizeof(cap));
+    command_executor_register(CMD_PLAY_MELODY, capturing_handler, &cap);
+
+    /* Build a beacon packet — wrong msg_type */
+    thinkpack_beacon_data_t beacon;
+    memset(&beacon, 0, sizeof(beacon));
+    thinkpack_packet_t pkt;
+    thinkpack_prepare_beacon(&pkt, TEST_SEQ, TEST_MAC, &beacon);
+
+    command_executor_dispatch(&pkt);
+
+    TEST_ASSERT_EQUAL(0, cap.call_count);
+}
+
+/* ------------------------------------------------------------------ */
+/* command_executor_reset                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_executor_reset_clears_all(void)
+{
+    command_executor_reset();
+
+    /* Fill the registry */
+    for (int i = 0; i < 16; i++) {
+        command_executor_register((uint8_t)(0x60 + i), dummy_handler, NULL);
+    }
+
+    /* Reset */
+    command_executor_reset();
+
+    /* After reset we should be able to register 16 entries again */
+    for (int i = 0; i < 16; i++) {
+        esp_err_t r = command_executor_register((uint8_t)(0x60 + i), dummy_handler, NULL);
+        TEST_ASSERT_EQUAL(ESP_OK, r);
+    }
+}
+
+static void test_executor_reset_stops_dispatch(void)
+{
+    command_executor_reset();
+
+    capture_t cap;
+    memset(&cap, 0, sizeof(cap));
+    command_executor_register(CMD_SET_MOOD, capturing_handler, &cap);
+
+    command_executor_reset();
+
+    /* Dispatch a CMD_SET_MOOD — handler was cleared, call_count must stay 0 */
+    cmd_set_mood_payload_t in = {.hue = 10, .intensity = 50};
+    thinkpack_packet_t pkt;
+    command_build_set_mood(&pkt, TEST_SEQ, TEST_MAC, &in);
+    command_executor_dispatch(&pkt);
+
+    TEST_ASSERT_EQUAL(0, cap.call_count);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    /* Dispatcher round-trips */
+    RUN_TEST(test_build_led_pattern_round_trip);
+    RUN_TEST(test_build_set_mood_round_trip);
+    RUN_TEST(test_build_play_melody_round_trip);
+    RUN_TEST(test_build_buzz_round_trip);
+    RUN_TEST(test_build_buzz_negative_semitone);
+    RUN_TEST(test_build_play_sequence_zero_notes);
+    RUN_TEST(test_build_play_sequence_max_notes);
+    RUN_TEST(test_build_display_line_round_trip);
+
+    /* Executor registration */
+    RUN_TEST(test_executor_register_rejects_duplicate);
+    RUN_TEST(test_executor_register_rejects_when_full);
+
+    /* Executor dispatch */
+    RUN_TEST(test_executor_dispatch_routes_correctly);
+    RUN_TEST(test_executor_dispatch_unknown_id_does_not_crash);
+    RUN_TEST(test_executor_dispatch_wrong_msg_type_ignored);
+
+    /* Executor reset */
+    RUN_TEST(test_executor_reset_clears_all);
+    RUN_TEST(test_executor_reset_stops_dispatch);
+
+    int failures = UNITY_END();
+    return failures == 0 ? 0 : 1;
+}

--- a/packages/components/thinkpack-behaviors/test/unity_compat.h
+++ b/packages/components/thinkpack-behaviors/test/unity_compat.h
@@ -1,0 +1,114 @@
+/**
+ * @file unity_compat.h
+ * @brief Minimal Unity-compatible test framework for host-based testing.
+ *
+ * Provides a subset of the Unity API that compiles without the full Unity
+ * library. This allows running protocol and logic tests on the host (Linux/macOS)
+ * without ESP-IDF. Compatible macro names make migration to full ESP-IDF Unity
+ * straightforward.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int _unity_total = 0;
+static int _unity_failures = 0;
+
+static void _unity_begin(void)
+{
+    _unity_total = 0;
+    _unity_failures = 0;
+    printf("\n-----------------------\n");
+    printf("Running host unit tests\n");
+    printf("-----------------------\n\n");
+}
+
+static int _unity_end(void)
+{
+    printf("\n-----------------------\n");
+    printf("%d Tests %d Failures\n", _unity_total, _unity_failures);
+    printf("%s\n", _unity_failures == 0 ? "OK" : "FAIL");
+    printf("-----------------------\n\n");
+    return _unity_failures;
+}
+
+#define UNITY_BEGIN() _unity_begin()
+#define UNITY_END() _unity_end()
+
+#define RUN_TEST(fn)               \
+    do {                           \
+        printf("TEST(%s)\n", #fn); \
+        fn();                      \
+    } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Internal failure reporter                                               */
+/* ---------------------------------------------------------------------- */
+#define _UNITY_FAIL(fmt, ...)                                                    \
+    do {                                                                         \
+        _unity_failures++;                                                       \
+        printf("  FAIL at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Assertion macros                                                        */
+/* ---------------------------------------------------------------------- */
+#define TEST_ASSERT_TRUE(cond)                      \
+    do {                                            \
+        _unity_total++;                             \
+        if (!(cond))                                \
+            _UNITY_FAIL("expected TRUE was FALSE"); \
+    } while (0)
+
+#define TEST_ASSERT_FALSE(cond) TEST_ASSERT_TRUE(!(cond))
+
+#define TEST_ASSERT_EQUAL(expected, actual)                                                    \
+    do {                                                                                       \
+        _unity_total++;                                                                        \
+        if ((int64_t)(expected) != (int64_t)(actual))                                          \
+            _UNITY_FAIL("expected %lld was %lld", (long long)(expected), (long long)(actual)); \
+    } while (0)
+
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                        \
+    do {                                                                               \
+        _unity_total++;                                                                \
+        if ((int64_t)(expected) == (int64_t)(actual))                                  \
+            _UNITY_FAIL("expected values to differ (both %lld)", (long long)(actual)); \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_UINT8 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_UINT16 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_UINT32 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT8 TEST_ASSERT_EQUAL
+
+#define TEST_ASSERT_NULL(ptr)                     \
+    do {                                          \
+        _unity_total++;                           \
+        if ((ptr) != NULL)                        \
+            _UNITY_FAIL("expected NULL pointer"); \
+    } while (0)
+
+#define TEST_ASSERT_NOT_NULL(ptr)                     \
+    do {                                              \
+        _unity_total++;                               \
+        if ((ptr) == NULL)                            \
+            _UNITY_FAIL("expected non-NULL pointer"); \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_STRING(expected, actual)                           \
+    do {                                                                     \
+        _unity_total++;                                                      \
+        if (strcmp((expected), (actual)) != 0)                               \
+            _UNITY_FAIL("expected \"%s\" was \"%s\"", (expected), (actual)); \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)                 \
+    do {                                                                \
+        _unity_total++;                                                 \
+        if (memcmp((expected), (actual), (size_t)(len)) != 0)           \
+            _UNITY_FAIL("memory blocks differ (%d bytes)", (int)(len)); \
+    } while (0)

--- a/packages/components/thinkpack-mesh/CMakeLists.txt
+++ b/packages/components/thinkpack-mesh/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(SRCS "espnow_mesh.c"
                             "leader_election.c"
                             "group_manager.c"
+                            "fragment_reassembler.c"
                     INCLUDE_DIRS "include"
                     REQUIRES esp_wifi esp_event esp_netif nvs_flash esp_now log thinkpack-protocol
                     PRIV_REQUIRES freertos)

--- a/packages/components/thinkpack-mesh/espnow_mesh.c
+++ b/packages/components/thinkpack-mesh/espnow_mesh.c
@@ -28,6 +28,7 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 
+#include "fragment_reassembler.h"
 #include "group_manager.h"
 #include "leader_election.h"
 #include "thinkpack_protocol.h"
@@ -84,6 +85,16 @@ static void *s_event_cb_ctx = NULL;
 static SemaphoreHandle_t s_cb_mutex = NULL;
 
 static bool s_running = false;
+
+/* ------------------------------------------------------------------ */
+/* Fragmentation state                                                 */
+/* ------------------------------------------------------------------ */
+
+static reassembly_slot_t s_reassembly_cache[REASSEMBLY_CACHE_SIZE];
+static uint8_t s_large_msg_id = 0;
+
+/** Stale-fragment timeout: prune incomplete messages older than 5 s. */
+#define FRAGMENT_STALE_MS 5000u
 
 /* ------------------------------------------------------------------ */
 /* Internal helpers                                                    */
@@ -274,6 +285,9 @@ static void beacon_task(void *arg)
             /* Prune peers that have gone quiet. */
             group_manager_prune(t, stale_ms, on_peer_pruned, NULL);
 
+            /* Prune incomplete fragment reassembly slots older than 5 s. */
+            reassembler_prune(s_reassembly_cache, t, FRAGMENT_STALE_MS);
+
             last_beacon_ms = t;
         }
 
@@ -398,6 +412,58 @@ static void recv_task(void *arg)
                 fire_event(THINKPACK_EVENT_COMMAND_RECEIVED, entry.src_mac, pkt);
                 break;
 
+            case MSG_FRAGMENT: {
+                if (pkt->data_length < sizeof(thinkpack_fragment_data_t)) {
+                    ESP_LOGW(TAG, "Short MSG_FRAGMENT from " MACSTR " — discarding",
+                             MAC2STR(entry.src_mac));
+                    break;
+                }
+                const thinkpack_fragment_data_t *frag =
+                    (const thinkpack_fragment_data_t *)pkt->data;
+
+                reassembly_slot_t *completed = NULL;
+                reassemble_result_t result =
+                    reassembler_absorb(s_reassembly_cache, entry.src_mac, frag, t, &completed);
+
+                switch (result) {
+                    case REASSEMBLE_COMPLETE: {
+                        ESP_LOGD(TAG,
+                                 "Large message reassembled from " MACSTR
+                                 " msg_id=%u type=0x%02x len=%zu",
+                                 MAC2STR(entry.src_mac), frag->msg_id, completed->original_msg_type,
+                                 completed->reassembled_len);
+
+                        xSemaphoreTake(s_cb_mutex, portMAX_DELAY);
+                        thinkpack_mesh_event_cb_t cb = s_event_cb;
+                        void *ctx = s_event_cb_ctx;
+                        xSemaphoreGive(s_cb_mutex);
+
+                        if (cb) {
+                            thinkpack_mesh_event_data_t ev = {
+                                .type = THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED,
+                                .packet = NULL,
+                                .large_data = completed->buffer,
+                                .large_length = completed->reassembled_len,
+                                .original_msg_type = completed->original_msg_type,
+                            };
+                            memcpy(ev.peer_mac, entry.src_mac, 6);
+                            cb(&ev, ctx);
+                        }
+
+                        reassembler_release(completed);
+                        break;
+                    }
+                    case REASSEMBLE_ERROR:
+                        ESP_LOGW(TAG, "Fragment error from " MACSTR " msg_id=%u",
+                                 MAC2STR(entry.src_mac), frag->msg_id);
+                        break;
+                    case REASSEMBLE_INCOMPLETE:
+                    default:
+                        break;
+                }
+                break;
+            }
+
             default:
                 ESP_LOGD(TAG, "Unhandled msg_type 0x%02x from " MACSTR, pkt->msg_type,
                          MAC2STR(entry.src_mac));
@@ -478,6 +544,9 @@ esp_err_t thinkpack_mesh_init(const thinkpack_mesh_config_t *config)
     /* ---- Sub-modules ---- */
     ESP_ERROR_CHECK(group_manager_init());
     ESP_ERROR_CHECK(leader_election_init(s_own_priority, s_own_mac, on_leader_change, NULL));
+
+    /* ---- Fragment reassembler ---- */
+    reassembler_init(s_reassembly_cache);
 
     ESP_LOGI(TAG, "Mesh initialised on channel %d", config->channel);
     return ESP_OK;
@@ -570,4 +639,78 @@ void thinkpack_mesh_get_mac(uint8_t out_mac[6])
 size_t thinkpack_mesh_peer_count(void)
 {
     return group_manager_count();
+}
+
+esp_err_t thinkpack_mesh_send_large(const uint8_t *mac, uint8_t msg_type, const uint8_t *data,
+                                    size_t length)
+{
+    if (!data) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (length > THINKPACK_MAX_REASSEMBLED) {
+        ESP_LOGE(TAG, "send_large: length %zu exceeds THINKPACK_MAX_REASSEMBLED (%d)", length,
+                 THINKPACK_MAX_REASSEMBLED);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const uint8_t *dest = mac ? mac : BROADCAST_MAC;
+
+    if (mac) {
+        esp_err_t ret = ensure_peer(mac);
+        if (ret != ESP_OK) {
+            return ret;
+        }
+    }
+
+    /* Small enough to send as a single unfragmented packet. */
+    if (length <= THINKPACK_MAX_DATA_LEN) {
+        thinkpack_packet_t pkt;
+        memset(&pkt, 0, sizeof(pkt));
+        pkt.msg_type = msg_type;
+        pkt.sequence_number = s_seq++;
+        memcpy(pkt.src_mac, s_own_mac, 6);
+        pkt.data_length = (uint8_t)length;
+        memcpy(pkt.data, data, length);
+        thinkpack_finalize(&pkt);
+        return esp_now_send(dest, (const uint8_t *)&pkt, sizeof(pkt));
+    }
+
+    /* Split into fragments. */
+    uint8_t total = thinkpack_fragment_count(length);
+    uint8_t msg_id = s_large_msg_id++;
+
+    ESP_LOGI(TAG, "send_large: msg_id=%u type=0x%02x len=%zu total_fragments=%u", msg_id, msg_type,
+             length, total);
+
+    esp_err_t last_err = ESP_OK;
+    for (uint8_t i = 0; i < total; i++) {
+        size_t offset = (size_t)i * THINKPACK_MAX_FRAGMENT_DATA;
+        size_t remaining = length - offset;
+        size_t chunk =
+            remaining < THINKPACK_MAX_FRAGMENT_DATA ? remaining : THINKPACK_MAX_FRAGMENT_DATA;
+
+        thinkpack_fragment_data_t frag;
+        memset(&frag, 0, sizeof(frag));
+        frag.msg_id = msg_id;
+        frag.fragment_index = i;
+        frag.total_fragments = total;
+        frag.original_msg_type = msg_type;
+        frag.data_length = (uint8_t)chunk;
+        memcpy(frag.data, data + offset, chunk);
+
+        thinkpack_packet_t pkt;
+        thinkpack_prepare_fragment(&pkt, s_seq++, s_own_mac, &frag);
+
+        esp_err_t ret = esp_now_send(dest, (const uint8_t *)&pkt, sizeof(pkt));
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "send_large: fragment %u send failed: %s", i, esp_err_to_name(ret));
+            last_err = ret;
+        }
+
+        if (i < (uint8_t)(total - 1)) {
+            vTaskDelay(pdMS_TO_TICKS(5));
+        }
+    }
+
+    return last_err;
 }

--- a/packages/components/thinkpack-mesh/fragment_reassembler.c
+++ b/packages/components/thinkpack-mesh/fragment_reassembler.c
@@ -1,0 +1,149 @@
+/**
+ * @file fragment_reassembler.c
+ * @brief Pure-C fragment reassembly cache — no ESP-IDF dependencies.
+ *
+ * Intentionally free of ESP-IDF headers so the file compiles under plain gcc
+ * for host-based unit tests.  Logging about evictions and mismatches is
+ * deliberately omitted here; callers (espnow_mesh.c) can log using whatever
+ * logging facility is available in their build environment.
+ */
+
+#include "fragment_reassembler.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Internal helpers                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Return true if two 6-byte MACs are identical. */
+static bool mac_equal(const uint8_t a[6], const uint8_t b[6])
+{
+    return memcmp(a, b, 6) == 0;
+}
+
+/** Return the index of the oldest active slot, or -1 if all slots are free. */
+static int oldest_slot_index(const reassembly_slot_t *cache)
+{
+    int idx = -1;
+    uint32_t oldest_ms = UINT32_MAX;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].first_fragment_ms <= oldest_ms) {
+            oldest_ms = cache[i].first_fragment_ms;
+            idx = i;
+        }
+    }
+    return idx;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+void reassembler_init(reassembly_slot_t *cache)
+{
+    memset(cache, 0, sizeof(reassembly_slot_t) * REASSEMBLY_CACHE_SIZE);
+}
+
+void reassembler_prune(reassembly_slot_t *cache, uint32_t now_ms, uint32_t stale_ms)
+{
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments == 0) {
+            continue;
+        }
+        if ((now_ms - cache[i].first_fragment_ms) >= stale_ms) {
+            memset(&cache[i], 0, sizeof(reassembly_slot_t));
+        }
+    }
+}
+
+reassemble_result_t reassembler_absorb(reassembly_slot_t *cache, const uint8_t src_mac[6],
+                                       const thinkpack_fragment_data_t *fragment, uint32_t now_ms,
+                                       reassembly_slot_t **out_completed)
+{
+    if (!cache || !src_mac || !fragment || !out_completed) {
+        return REASSEMBLE_ERROR;
+    }
+
+    /* Validate fragment fields. */
+    if (fragment->total_fragments == 0 || fragment->total_fragments > THINKPACK_MAX_FRAGMENTS) {
+        return REASSEMBLE_ERROR;
+    }
+    if (fragment->fragment_index >= fragment->total_fragments) {
+        return REASSEMBLE_ERROR;
+    }
+    if (fragment->data_length > THINKPACK_MAX_FRAGMENT_DATA) {
+        return REASSEMBLE_ERROR;
+    }
+
+    /* Look for an existing slot matching (src_mac, msg_id). */
+    reassembly_slot_t *slot = NULL;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].msg_id == fragment->msg_id &&
+            mac_equal(cache[i].src_mac, src_mac)) {
+            slot = &cache[i];
+            break;
+        }
+    }
+
+    if (!slot) {
+        /* Try to find a free slot first. */
+        for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+            if (cache[i].total_fragments == 0) {
+                slot = &cache[i];
+                break;
+            }
+        }
+
+        /* Cache full — evict the oldest entry (caller may log this). */
+        if (!slot) {
+            int idx = oldest_slot_index(cache);
+            if (idx < 0) {
+                return REASSEMBLE_ERROR;
+            }
+            slot = &cache[idx];
+        }
+
+        /* Initialise the slot for this new message. */
+        memset(slot, 0, sizeof(*slot));
+        memcpy(slot->src_mac, src_mac, 6);
+        slot->msg_id = fragment->msg_id;
+        slot->total_fragments = fragment->total_fragments;
+        slot->original_msg_type = fragment->original_msg_type;
+        slot->first_fragment_ms = now_ms;
+    }
+
+    /* Consistency check: total_fragments must not change mid-stream. */
+    if (slot->total_fragments != fragment->total_fragments) {
+        memset(slot, 0, sizeof(*slot));
+        return REASSEMBLE_ERROR;
+    }
+
+    /* Idempotency: ignore duplicate fragments. */
+    uint16_t bit = (uint16_t)(1u << fragment->fragment_index);
+    if (slot->received_mask & bit) {
+        return REASSEMBLE_INCOMPLETE;
+    }
+
+    /* Copy this fragment's data into the correct position in the buffer. */
+    size_t offset = (size_t)fragment->fragment_index * THINKPACK_MAX_FRAGMENT_DATA;
+    memcpy(slot->buffer + offset, fragment->data, fragment->data_length);
+    slot->reassembled_len += fragment->data_length;
+    slot->received_mask |= bit;
+
+    /* Check if all fragments have arrived. */
+    uint16_t full_mask = (uint16_t)((1u << fragment->total_fragments) - 1u);
+    if (slot->received_mask == full_mask) {
+        *out_completed = slot;
+        return REASSEMBLE_COMPLETE;
+    }
+
+    return REASSEMBLE_INCOMPLETE;
+}
+
+void reassembler_release(reassembly_slot_t *slot)
+{
+    if (slot) {
+        memset(slot, 0, sizeof(*slot));
+    }
+}

--- a/packages/components/thinkpack-mesh/include/espnow_mesh.h
+++ b/packages/components/thinkpack-mesh/include/espnow_mesh.h
@@ -62,14 +62,15 @@ typedef struct {
  * @brief Event types delivered to the application via the event callback.
  */
 typedef enum {
-    THINKPACK_EVENT_PEER_DISCOVERED,  /**< A new peer was seen for the first time */
-    THINKPACK_EVENT_PEER_LOST,        /**< A previously known peer has gone stale */
-    THINKPACK_EVENT_LEADER_ELECTED,   /**< Election resolved; a leader is known */
-    THINKPACK_EVENT_LEADER_LOST,      /**< Leader went silent; re-election triggered */
-    THINKPACK_EVENT_BECAME_LEADER,    /**< This node won the election */
-    THINKPACK_EVENT_BECAME_FOLLOWER,  /**< This node deferred to a higher-priority peer */
-    THINKPACK_EVENT_SYNC_PULSE,       /**< MSG_SYNC_PULSE received from leader */
-    THINKPACK_EVENT_COMMAND_RECEIVED, /**< MSG_COMMAND received */
+    THINKPACK_EVENT_PEER_DISCOVERED,        /**< A new peer was seen for the first time    */
+    THINKPACK_EVENT_PEER_LOST,              /**< A previously known peer has gone stale    */
+    THINKPACK_EVENT_LEADER_ELECTED,         /**< Election resolved; a leader is known      */
+    THINKPACK_EVENT_LEADER_LOST,            /**< Leader went silent; re-election triggered */
+    THINKPACK_EVENT_BECAME_LEADER,          /**< This node won the election                */
+    THINKPACK_EVENT_BECAME_FOLLOWER,        /**< This node deferred to a higher-priority peer */
+    THINKPACK_EVENT_SYNC_PULSE,             /**< MSG_SYNC_PULSE received from leader       */
+    THINKPACK_EVENT_COMMAND_RECEIVED,       /**< MSG_COMMAND received                      */
+    THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED, /**< All fragments reassembled; full payload ready */
 } thinkpack_mesh_event_t;
 
 /**
@@ -79,11 +80,23 @@ typedef enum {
  * THINKPACK_EVENT_COMMAND_RECEIVED. It points into a temporary buffer
  * on the receive task stack and must not be retained after the callback
  * returns.
+ *
+ * For THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED:
+ *   - @p large_data points to the fully reassembled buffer (valid until the
+ *     callback returns; do not retain the pointer).
+ *   - @p large_length is the total number of reassembled bytes.
+ *   - @p original_msg_type is the logical message type that was fragmented
+ *     (e.g. MSG_LLM_RESPONSE).
+ *   - @p packet is NULL.
+ * All three fields are zeroed / NULL for every other event type.
  */
 typedef struct {
-    thinkpack_mesh_event_t type;      /**< Event kind */
-    uint8_t peer_mac[6];              /**< MAC address of the relevant peer */
-    const thinkpack_packet_t *packet; /**< Non-NULL for SYNC_PULSE / COMMAND_RECEIVED */
+    thinkpack_mesh_event_t type;      /**< Event kind                                       */
+    uint8_t peer_mac[6];              /**< MAC address of the relevant peer                 */
+    const thinkpack_packet_t *packet; /**< Non-NULL for SYNC_PULSE / COMMAND_RECEIVED       */
+    const uint8_t *large_data;        /**< Reassembled buffer (LARGE_MESSAGE_RECEIVED only) */
+    size_t large_length;              /**< Byte count of large_data                         */
+    uint8_t original_msg_type;        /**< Wrapped logical type (LARGE_MESSAGE_RECEIVED only) */
 } thinkpack_mesh_event_data_t;
 
 /**
@@ -164,6 +177,28 @@ esp_err_t thinkpack_mesh_set_event_callback(thinkpack_mesh_event_cb_t cb, void *
  * @return ESP_OK on success, or a forwarded ESP-IDF error code.
  */
 esp_err_t thinkpack_mesh_send(const uint8_t *mac, const thinkpack_packet_t *packet);
+
+/**
+ * @brief Send a large buffer, fragmenting if necessary.
+ *
+ * If @p length <= THINKPACK_MAX_DATA_LEN the data is sent as a single packet
+ * with @p msg_type directly (no fragmentation overhead). Otherwise the buffer
+ * is split into MSG_FRAGMENT packets (each wrapping @p msg_type) and sent
+ * sequentially with a 5 ms inter-frame delay to avoid overwhelming the
+ * ESP-NOW driver.
+ *
+ * The receiver collects all fragments and fires a single
+ * THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED event once every fragment arrives.
+ *
+ * @param mac      6-byte destination MAC, or NULL for broadcast.
+ * @param msg_type Logical message type (e.g. MSG_LLM_RESPONSE).
+ * @param data     Buffer to send (must not be NULL).
+ * @param length   Bytes in @p data (max THINKPACK_MAX_REASSEMBLED).
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG for bad arguments,
+ *         or a forwarded ESP-IDF error on send failure.
+ */
+esp_err_t thinkpack_mesh_send_large(const uint8_t *mac, uint8_t msg_type, const uint8_t *data,
+                                    size_t length);
 
 /* ------------------------------------------------------------------ */
 /* Accessors                                                           */

--- a/packages/components/thinkpack-mesh/include/fragment_reassembler.h
+++ b/packages/components/thinkpack-mesh/include/fragment_reassembler.h
@@ -1,0 +1,114 @@
+/**
+ * @file fragment_reassembler.h
+ * @brief Pure-C fragment reassembly cache for the ThinkPack mesh layer.
+ *
+ * This module is intentionally free of ESP-IDF dependencies so that it can
+ * be compiled and tested on the host (Linux/macOS) with plain gcc.  The mesh
+ * layer (espnow_mesh.c) calls these functions from its receive task.
+ *
+ * Concurrency: the caller must ensure that only one thread calls these
+ * functions at a time (the receive task provides this guarantee).
+ */
+
+#ifndef FRAGMENT_REASSEMBLER_H
+#define FRAGMENT_REASSEMBLER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "thinkpack_protocol.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Reassembly cache                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Number of concurrent in-progress large messages tracked. */
+#define REASSEMBLY_CACHE_SIZE 4
+
+/**
+ * @brief State for one in-progress large message.
+ *
+ * A slot is "active" when total_fragments > 0.  Call reassembler_release()
+ * to free it after processing a completed message.
+ */
+typedef struct {
+    uint8_t src_mac[6];                        /**< Source MAC of the sender                   */
+    uint8_t msg_id;                            /**< Unique large-message ID from the sender     */
+    uint8_t total_fragments;                   /**< Expected fragment count (0 = slot unused)   */
+    uint8_t original_msg_type;                 /**< Logical message type wrapped by fragments   */
+    uint16_t received_mask;                    /**< Bit N set once fragment N has been absorbed */
+    size_t reassembled_len;                    /**< Running byte count of assembled data        */
+    uint32_t first_fragment_ms;                /**< Timestamp of the first fragment received    */
+    uint8_t buffer[THINKPACK_MAX_REASSEMBLED]; /**< Assembled payload            */
+} reassembly_slot_t;
+
+/* ------------------------------------------------------------------ */
+/* Return codes                                                        */
+/* ------------------------------------------------------------------ */
+
+typedef enum {
+    REASSEMBLE_INCOMPLETE = 0, /**< More fragments still expected        */
+    REASSEMBLE_COMPLETE,       /**< All fragments received; slot is ready */
+    REASSEMBLE_ERROR,          /**< Protocol violation; slot discarded    */
+} reassemble_result_t;
+
+/* ------------------------------------------------------------------ */
+/* API                                                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Zero-initialise the reassembly cache.
+ *
+ * @param cache  Array of REASSEMBLY_CACHE_SIZE slots.
+ */
+void reassembler_init(reassembly_slot_t *cache);
+
+/**
+ * @brief Free entries whose first_fragment_ms is older than stale_ms.
+ *
+ * @param cache     Array of REASSEMBLY_CACHE_SIZE slots.
+ * @param now_ms    Current time in milliseconds.
+ * @param stale_ms  Age threshold; slots older than this are pruned.
+ */
+void reassembler_prune(reassembly_slot_t *cache, uint32_t now_ms, uint32_t stale_ms);
+
+/**
+ * @brief Absorb one fragment into the reassembly cache.
+ *
+ * Looks up or allocates a slot keyed on (src_mac, msg_id).  If all
+ * fragments for the message have now been received the function sets
+ * *out_completed and returns REASSEMBLE_COMPLETE.  The caller must call
+ * reassembler_release() on the completed slot after processing it.
+ *
+ * If the cache is full and a new (src_mac, msg_id) pair arrives the oldest
+ * slot is overwritten (the new fragment is then placed into it).
+ *
+ * @param cache          Array of REASSEMBLY_CACHE_SIZE slots.
+ * @param src_mac        6-byte source MAC of the sender.
+ * @param fragment       Decoded fragment payload.
+ * @param now_ms         Current time in milliseconds.
+ * @param out_completed  Set to the completed slot on REASSEMBLE_COMPLETE;
+ *                       unchanged otherwise.
+ * @return               REASSEMBLE_INCOMPLETE / COMPLETE / ERROR.
+ */
+reassemble_result_t reassembler_absorb(reassembly_slot_t *cache, const uint8_t src_mac[6],
+                                       const thinkpack_fragment_data_t *fragment, uint32_t now_ms,
+                                       reassembly_slot_t **out_completed);
+
+/**
+ * @brief Mark a completed slot as free so it can be reused.
+ *
+ * @param slot  The slot returned via out_completed by reassembler_absorb().
+ */
+void reassembler_release(reassembly_slot_t *slot);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FRAGMENT_REASSEMBLER_H */

--- a/packages/components/thinkpack-mesh/test/Makefile
+++ b/packages/components/thinkpack-mesh/test/Makefile
@@ -1,0 +1,35 @@
+# Makefile for thinkpack-mesh fragment reassembler host-based unit tests
+#
+# Compiles fragment_reassembler.c + thinkpack_protocol.c under plain gcc
+# (no ESP-IDF, no hardware). Stubs supply any missing headers.
+#
+# Usage:
+#   make test     — build and run tests (default)
+#   make clean    — remove build artefacts
+
+CC     = gcc
+CFLAGS = -std=c11 -Wall -Wextra \
+         -Wno-unused-function \
+         -I../include \
+         -I../../thinkpack-protocol/include \
+         -Istubs \
+         -I.
+
+SRCS   = test_fragment_reassembler.c \
+         ../fragment_reassembler.c \
+         ../../thinkpack-protocol/thinkpack_protocol.c
+
+TARGET = test_runner
+
+.PHONY: all test clean
+
+all: test
+
+test: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS) unity_compat.h stubs/esp_log.h
+	$(CC) $(CFLAGS) -o $@ $(SRCS)
+
+clean:
+	rm -f $(TARGET)

--- a/packages/components/thinkpack-mesh/test/stubs/esp_log.h
+++ b/packages/components/thinkpack-mesh/test/stubs/esp_log.h
@@ -1,0 +1,14 @@
+/**
+ * @file esp_log.h
+ * @brief Stub for ESP-IDF logging — prints to stderr/stdout for host tests.
+ */
+#pragma once
+
+#include <stdio.h>
+
+/* cppcheck-suppress [missingIncludeSystem] */
+#define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "[E][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "[W][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) fprintf(stdout, "[I][%s] " fmt "\n", (tag), ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) /* debug suppressed in host tests */
+#define ESP_LOGV(tag, fmt, ...) /* verbose suppressed in host tests */

--- a/packages/components/thinkpack-mesh/test/test_fragment_reassembler.c
+++ b/packages/components/thinkpack-mesh/test/test_fragment_reassembler.c
@@ -1,0 +1,478 @@
+/**
+ * @file test_fragment_reassembler.c
+ * @brief Host-based unit tests for fragment_reassembler.c.
+ *
+ * Tests pure reassembly logic: slot lookup, ordering, duplicates, concurrent
+ * messages, cache eviction, pruning, and error handling.  No hardware required.
+ *
+ * Build and run: make test
+ */
+
+#include <string.h>
+
+#include "fragment_reassembler.h"
+#include "thinkpack_protocol.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* Test fixtures                                                       */
+/* ------------------------------------------------------------------ */
+
+static const uint8_t MAC_A[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x01};
+static const uint8_t MAC_B[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0x00, 0x02};
+
+/** Fill a fragment with predictable content for a given (msg_id, index). */
+static void make_fragment(thinkpack_fragment_data_t *f, uint8_t msg_id, uint8_t index,
+                          uint8_t total, uint8_t original_type, uint8_t data_byte)
+{
+    memset(f, 0, sizeof(*f));
+    f->msg_id = msg_id;
+    f->fragment_index = index;
+    f->total_fragments = total;
+    f->original_msg_type = original_type;
+    f->data_length = 4;
+    memset(f->data, data_byte, 4);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_single_fragment_is_incomplete                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_single_fragment_is_incomplete(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 1, 0, 3, MSG_LLM_RESPONSE, 0xAA);
+
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r = reassembler_absorb(cache, MAC_A, &f, 1000, &completed);
+
+    TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r);
+    TEST_ASSERT_NULL(completed);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_all_fragments_in_order_complete                                */
+/* ------------------------------------------------------------------ */
+
+static void test_all_fragments_in_order_complete(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    const uint8_t total = 3;
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r;
+
+    for (uint8_t i = 0; i < total - 1; i++) {
+        thinkpack_fragment_data_t f;
+        make_fragment(&f, 10, i, total, MSG_LLM_RESPONSE, (uint8_t)(0x10 + i));
+        completed = NULL;
+        r = reassembler_absorb(cache, MAC_A, &f, 1000 + i, &completed);
+        TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r);
+        TEST_ASSERT_NULL(completed);
+    }
+
+    /* Last fragment — should complete. */
+    thinkpack_fragment_data_t last;
+    make_fragment(&last, 10, total - 1, total, MSG_LLM_RESPONSE, 0x1F);
+    completed = NULL;
+    r = reassembler_absorb(cache, MAC_A, &last, 1002, &completed);
+
+    TEST_ASSERT_EQUAL(REASSEMBLE_COMPLETE, r);
+    TEST_ASSERT_NOT_NULL(completed);
+    TEST_ASSERT_EQUAL(MSG_LLM_RESPONSE, completed->original_msg_type);
+    /* 3 fragments × 4 bytes each = 12 bytes. */
+    TEST_ASSERT_EQUAL(12, (int)completed->reassembled_len);
+
+    reassembler_release(completed);
+    /* Slot should be free now. */
+    TEST_ASSERT_EQUAL(0, (int)completed->total_fragments);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_out_of_order_complete                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_out_of_order_complete(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    /* Send fragments 2, 0, 1 — should complete after fragment 1. */
+    const uint8_t total = 3;
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r;
+
+    uint8_t order[] = {2, 0, 1};
+    for (int step = 0; step < 3; step++) {
+        thinkpack_fragment_data_t f;
+        make_fragment(&f, 20, order[step], total, MSG_LLM_REQUEST, (uint8_t)(0x20 + order[step]));
+        completed = NULL;
+        r = reassembler_absorb(cache, MAC_A, &f, 2000 + (uint32_t)step, &completed);
+        if (step < 2) {
+            TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r);
+            TEST_ASSERT_NULL(completed);
+        }
+    }
+
+    TEST_ASSERT_EQUAL(REASSEMBLE_COMPLETE, r);
+    TEST_ASSERT_NOT_NULL(completed);
+    TEST_ASSERT_EQUAL(12, (int)completed->reassembled_len);
+
+    /* Verify data was placed at the right offsets — data_byte was 0x20 + fragment_index,
+     * so fragment 0 wrote 0x20, fragment 1 wrote 0x21, fragment 2 wrote 0x22. */
+    TEST_ASSERT_EQUAL(0x20, completed->buffer[0]); /* fragment 0 data byte */
+    TEST_ASSERT_EQUAL(0x21, completed->buffer[THINKPACK_MAX_FRAGMENT_DATA]);     /* frag 1 */
+    TEST_ASSERT_EQUAL(0x22, completed->buffer[2 * THINKPACK_MAX_FRAGMENT_DATA]); /* frag 2 */
+
+    reassembler_release(completed);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_duplicate_fragment_idempotent                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_duplicate_fragment_idempotent(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 30, 0, 2, MSG_STATUS, 0xDD);
+
+    reassembly_slot_t *completed = NULL;
+
+    /* First absorption — incomplete. */
+    reassemble_result_t r1 = reassembler_absorb(cache, MAC_A, &f, 3000, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r1);
+
+    /* Duplicate — still incomplete, no state change. */
+    reassemble_result_t r2 = reassembler_absorb(cache, MAC_A, &f, 3001, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r2);
+    TEST_ASSERT_NULL(completed);
+
+    /* The slot's received_mask should still have only bit 0 set. */
+    TEST_ASSERT_EQUAL(1, (int)cache[0].received_mask);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_two_concurrent_messages_from_different_macs                   */
+/* ------------------------------------------------------------------ */
+
+static void test_two_concurrent_messages_from_different_macs(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    /* Both senders use the same msg_id — slots are keyed by (mac, msg_id). */
+    const uint8_t total = 2;
+    thinkpack_fragment_data_t fA0, fA1, fB0, fB1;
+    make_fragment(&fA0, 5, 0, total, MSG_LLM_RESPONSE, 0xA0);
+    make_fragment(&fA1, 5, 1, total, MSG_LLM_RESPONSE, 0xA1);
+    make_fragment(&fB0, 5, 0, total, MSG_COMMAND, 0xB0);
+    make_fragment(&fB1, 5, 1, total, MSG_COMMAND, 0xB1);
+
+    reassembly_slot_t *completed = NULL;
+
+    /* Interleave: A0, B0, A1, B1. */
+    reassemble_result_t rA0 = reassembler_absorb(cache, MAC_A, &fA0, 100, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, rA0);
+
+    reassemble_result_t rB0 = reassembler_absorb(cache, MAC_B, &fB0, 101, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, rB0);
+
+    completed = NULL;
+    reassemble_result_t rA1 = reassembler_absorb(cache, MAC_A, &fA1, 102, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_COMPLETE, rA1);
+    TEST_ASSERT_NOT_NULL(completed);
+    TEST_ASSERT_EQUAL(MSG_LLM_RESPONSE, completed->original_msg_type);
+    reassembler_release(completed);
+
+    completed = NULL;
+    reassemble_result_t rB1 = reassembler_absorb(cache, MAC_B, &fB1, 103, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_COMPLETE, rB1);
+    TEST_ASSERT_NOT_NULL(completed);
+    TEST_ASSERT_EQUAL(MSG_COMMAND, completed->original_msg_type);
+    reassembler_release(completed);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_cache_full_evicts_oldest                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_cache_full_evicts_oldest(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    /* Fill all REASSEMBLY_CACHE_SIZE slots with 2-fragment messages. */
+    /* Use distinct MACs so the keying is unambiguous. */
+    uint8_t macs[REASSEMBLY_CACHE_SIZE + 1][6];
+    for (int i = 0; i <= REASSEMBLY_CACHE_SIZE; i++) {
+        memset(macs[i], 0, 6);
+        macs[i][5] = (uint8_t)(i + 1);
+    }
+
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        thinkpack_fragment_data_t f;
+        make_fragment(&f, (uint8_t)i, 0, 2, MSG_STATUS, (uint8_t)i);
+        reassembly_slot_t *completed = NULL;
+        reassemble_result_t r =
+            reassembler_absorb(cache, macs[i], &f, (uint32_t)(1000 + i), /* oldest = slot 0 */
+                               &completed);
+        TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r);
+    }
+
+    /* Cache is now full.  Send a fragment for a brand-new (mac, msg_id). */
+    thinkpack_fragment_data_t f_new;
+    make_fragment(&f_new, 99, 0, 2, MSG_STATUS, 0xFF);
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r = reassembler_absorb(cache, macs[REASSEMBLY_CACHE_SIZE], &f_new,
+                                               9000, /* much later — slot 0 is oldest */
+                                               &completed);
+    /* Should be INCOMPLETE (not an error) — new slot was allocated by evicting oldest. */
+    TEST_ASSERT_EQUAL(REASSEMBLE_INCOMPLETE, r);
+    TEST_ASSERT_NULL(completed);
+
+    /* Verify the new slot is in the cache with msg_id=99. */
+    bool found = false;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].msg_id == 99) {
+            found = true;
+            break;
+        }
+    }
+    TEST_ASSERT_TRUE(found);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_prune_stale_entries                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_prune_stale_entries(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    /* Insert a fragment at t=0. */
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 42, 0, 3, MSG_STATUS, 0x55);
+    reassembly_slot_t *completed = NULL;
+    reassembler_absorb(cache, MAC_A, &f, 0, &completed);
+
+    /* Prune with stale_ms=5000 at t=4999 — slot should survive. */
+    reassembler_prune(cache, 4999, 5000);
+    bool found_before = false;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].msg_id == 42) {
+            found_before = true;
+        }
+    }
+    TEST_ASSERT_TRUE(found_before);
+
+    /* Prune at t=5000 — slot should be freed. */
+    reassembler_prune(cache, 5000, 5000);
+    bool found_after = false;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].msg_id == 42) {
+            found_after = true;
+        }
+    }
+    TEST_ASSERT_FALSE(found_after);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_total_fragments_mismatch_returns_error                         */
+/* ------------------------------------------------------------------ */
+
+static void test_total_fragments_mismatch_returns_error(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    /* Fragment 0 claims total=3. */
+    thinkpack_fragment_data_t f0;
+    make_fragment(&f0, 77, 0, 3, MSG_STATUS, 0x01);
+    reassembly_slot_t *completed = NULL;
+    reassembler_absorb(cache, MAC_A, &f0, 100, &completed);
+
+    /* Fragment 1 claims total=2 — mismatch. */
+    thinkpack_fragment_data_t f1;
+    make_fragment(&f1, 77, 1, 2, MSG_STATUS, 0x02);
+    completed = NULL;
+    reassemble_result_t r = reassembler_absorb(cache, MAC_A, &f1, 101, &completed);
+
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, r);
+    TEST_ASSERT_NULL(completed);
+
+    /* Slot should have been cleared. */
+    bool found = false;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].msg_id == 77) {
+            found = true;
+        }
+    }
+    TEST_ASSERT_FALSE(found);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_invalid_total_fragments_returns_error                          */
+/* ------------------------------------------------------------------ */
+
+static void test_invalid_total_fragments_returns_error(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    memset(&f, 0, sizeof(f));
+    f.msg_id = 1;
+    f.fragment_index = 0;
+    f.total_fragments = 0; /* invalid */
+    f.data_length = 1;
+
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r = reassembler_absorb(cache, MAC_A, &f, 0, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, r);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_fragment_index_out_of_range_returns_error                      */
+/* ------------------------------------------------------------------ */
+
+static void test_fragment_index_out_of_range_returns_error(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    memset(&f, 0, sizeof(f));
+    f.msg_id = 2;
+    f.fragment_index = 3; /* >= total_fragments=2 */
+    f.total_fragments = 2;
+    f.data_length = 1;
+
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r = reassembler_absorb(cache, MAC_A, &f, 0, &completed);
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, r);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_null_args_return_error                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_null_args_return_error(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 1, 0, 1, MSG_STATUS, 0x01);
+    reassembly_slot_t *completed = NULL;
+
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, reassembler_absorb(NULL, MAC_A, &f, 0, &completed));
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, reassembler_absorb(cache, NULL, &f, 0, &completed));
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, reassembler_absorb(cache, MAC_A, NULL, 0, &completed));
+    TEST_ASSERT_EQUAL(REASSEMBLE_ERROR, reassembler_absorb(cache, MAC_A, &f, 0, NULL));
+}
+
+/* ------------------------------------------------------------------ */
+/* test_single_fragment_message_completes                              */
+/* ------------------------------------------------------------------ */
+
+static void test_single_fragment_message_completes(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 55, 0, 1, MSG_BEACON, 0xBB);
+
+    reassembly_slot_t *completed = NULL;
+    reassemble_result_t r = reassembler_absorb(cache, MAC_A, &f, 500, &completed);
+
+    TEST_ASSERT_EQUAL(REASSEMBLE_COMPLETE, r);
+    TEST_ASSERT_NOT_NULL(completed);
+    TEST_ASSERT_EQUAL(4, (int)completed->reassembled_len);
+    TEST_ASSERT_EQUAL(MSG_BEACON, completed->original_msg_type);
+
+    reassembler_release(completed);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_reassembler_release_zeroes_slot                                */
+/* ------------------------------------------------------------------ */
+
+static void test_reassembler_release_zeroes_slot(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 60, 0, 1, MSG_STATUS, 0xCC);
+
+    reassembly_slot_t *completed = NULL;
+    reassembler_absorb(cache, MAC_A, &f, 1, &completed);
+    TEST_ASSERT_NOT_NULL(completed);
+
+    reassembler_release(completed);
+    TEST_ASSERT_EQUAL(0, (int)completed->total_fragments);
+    TEST_ASSERT_EQUAL(0, (int)completed->received_mask);
+    TEST_ASSERT_EQUAL(0, (int)completed->reassembled_len);
+}
+
+/* ------------------------------------------------------------------ */
+/* test_prune_does_not_affect_fresh_entries                            */
+/* ------------------------------------------------------------------ */
+
+static void test_prune_does_not_affect_fresh_entries(void)
+{
+    reassembly_slot_t cache[REASSEMBLY_CACHE_SIZE];
+    reassembler_init(cache);
+
+    thinkpack_fragment_data_t f;
+    make_fragment(&f, 70, 0, 2, MSG_STATUS, 0x77);
+    reassembly_slot_t *completed = NULL;
+    reassembler_absorb(cache, MAC_A, &f, 10000, &completed);
+
+    /* Prune at t=10001, stale_ms=5000 — entry is only 1 ms old. */
+    reassembler_prune(cache, 10001, 5000);
+
+    bool found = false;
+    for (int i = 0; i < REASSEMBLY_CACHE_SIZE; i++) {
+        if (cache[i].total_fragments > 0 && cache[i].msg_id == 70) {
+            found = true;
+        }
+    }
+    TEST_ASSERT_TRUE(found);
+}
+
+/* ------------------------------------------------------------------ */
+/* main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_single_fragment_is_incomplete);
+    RUN_TEST(test_all_fragments_in_order_complete);
+    RUN_TEST(test_out_of_order_complete);
+    RUN_TEST(test_duplicate_fragment_idempotent);
+    RUN_TEST(test_two_concurrent_messages_from_different_macs);
+    RUN_TEST(test_cache_full_evicts_oldest);
+    RUN_TEST(test_prune_stale_entries);
+    RUN_TEST(test_total_fragments_mismatch_returns_error);
+    RUN_TEST(test_invalid_total_fragments_returns_error);
+    RUN_TEST(test_fragment_index_out_of_range_returns_error);
+    RUN_TEST(test_null_args_return_error);
+    RUN_TEST(test_single_fragment_message_completes);
+    RUN_TEST(test_reassembler_release_zeroes_slot);
+    RUN_TEST(test_prune_does_not_affect_fresh_entries);
+
+    int failures = UNITY_END();
+    return (failures > 0) ? 1 : 0;
+}

--- a/packages/components/thinkpack-mesh/test/unity_compat.h
+++ b/packages/components/thinkpack-mesh/test/unity_compat.h
@@ -1,0 +1,114 @@
+/**
+ * @file unity_compat.h
+ * @brief Minimal Unity-compatible test framework for host-based testing.
+ *
+ * Provides a subset of the Unity API that compiles without the full Unity
+ * library. This allows running protocol and logic tests on the host (Linux/macOS)
+ * without ESP-IDF. Compatible macro names make migration to full ESP-IDF Unity
+ * straightforward.
+ */
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int _unity_total = 0;
+static int _unity_failures = 0;
+
+static void _unity_begin(void)
+{
+    _unity_total = 0;
+    _unity_failures = 0;
+    printf("\n-----------------------\n");
+    printf("Running host unit tests\n");
+    printf("-----------------------\n\n");
+}
+
+static int _unity_end(void)
+{
+    printf("\n-----------------------\n");
+    printf("%d Tests %d Failures\n", _unity_total, _unity_failures);
+    printf("%s\n", _unity_failures == 0 ? "OK" : "FAIL");
+    printf("-----------------------\n\n");
+    return _unity_failures;
+}
+
+#define UNITY_BEGIN() _unity_begin()
+#define UNITY_END() _unity_end()
+
+#define RUN_TEST(fn)               \
+    do {                           \
+        printf("TEST(%s)\n", #fn); \
+        fn();                      \
+    } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Internal failure reporter                                               */
+/* ---------------------------------------------------------------------- */
+#define _UNITY_FAIL(fmt, ...)                                                    \
+    do {                                                                         \
+        _unity_failures++;                                                       \
+        printf("  FAIL at %s:%d: " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__); \
+    } while (0)
+
+/* ---------------------------------------------------------------------- */
+/* Assertion macros                                                        */
+/* ---------------------------------------------------------------------- */
+#define TEST_ASSERT_TRUE(cond)                      \
+    do {                                            \
+        _unity_total++;                             \
+        if (!(cond))                                \
+            _UNITY_FAIL("expected TRUE was FALSE"); \
+    } while (0)
+
+#define TEST_ASSERT_FALSE(cond) TEST_ASSERT_TRUE(!(cond))
+
+#define TEST_ASSERT_EQUAL(expected, actual)                                                    \
+    do {                                                                                       \
+        _unity_total++;                                                                        \
+        if ((int64_t)(expected) != (int64_t)(actual))                                          \
+            _UNITY_FAIL("expected %lld was %lld", (long long)(expected), (long long)(actual)); \
+    } while (0)
+
+#define TEST_ASSERT_NOT_EQUAL(expected, actual)                                        \
+    do {                                                                               \
+        _unity_total++;                                                                \
+        if ((int64_t)(expected) == (int64_t)(actual))                                  \
+            _UNITY_FAIL("expected values to differ (both %lld)", (long long)(actual)); \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_UINT8 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_UINT16 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_UINT32 TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT TEST_ASSERT_EQUAL
+#define TEST_ASSERT_EQUAL_INT8 TEST_ASSERT_EQUAL
+
+#define TEST_ASSERT_NULL(ptr)                     \
+    do {                                          \
+        _unity_total++;                           \
+        if ((ptr) != NULL)                        \
+            _UNITY_FAIL("expected NULL pointer"); \
+    } while (0)
+
+#define TEST_ASSERT_NOT_NULL(ptr)                     \
+    do {                                              \
+        _unity_total++;                               \
+        if ((ptr) == NULL)                            \
+            _UNITY_FAIL("expected non-NULL pointer"); \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_STRING(expected, actual)                           \
+    do {                                                                     \
+        _unity_total++;                                                      \
+        if (strcmp((expected), (actual)) != 0)                               \
+            _UNITY_FAIL("expected \"%s\" was \"%s\"", (expected), (actual)); \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_MEMORY(expected, actual, len)                 \
+    do {                                                                \
+        _unity_total++;                                                 \
+        if (memcmp((expected), (actual), (size_t)(len)) != 0)           \
+            _UNITY_FAIL("memory blocks differ (%d bytes)", (int)(len)); \
+    } while (0)

--- a/packages/components/thinkpack-protocol/include/thinkpack_protocol.h
+++ b/packages/components/thinkpack-protocol/include/thinkpack_protocol.h
@@ -34,6 +34,17 @@
 #define THINKPACK_BOX_NAME_LEN 16
 
 /* ------------------------------------------------------------------ */
+/* Fragmentation constants                                             */
+/* ------------------------------------------------------------------ */
+
+/** Data bytes per fragment — leaves room for the fragment header. */
+#define THINKPACK_MAX_FRAGMENT_DATA 192
+/** Maximum fragments per large message (16 × 192 = 3072 bytes). */
+#define THINKPACK_MAX_FRAGMENTS 16
+/** Maximum bytes a reassembled large message may span. */
+#define THINKPACK_MAX_REASSEMBLED (THINKPACK_MAX_FRAGMENTS * THINKPACK_MAX_FRAGMENT_DATA)
+
+/* ------------------------------------------------------------------ */
 /* Message types                                                       */
 /* ------------------------------------------------------------------ */
 
@@ -48,7 +59,8 @@ typedef enum {
     MSG_LLM_REQUEST = 0x08,
     MSG_LLM_RESPONSE = 0x09,
     MSG_SYNC_PULSE = 0x0A,
-    MSG_COLLECTIVE_TRIGGER = 0x0B
+    MSG_COLLECTIVE_TRIGGER = 0x0B,
+    MSG_FRAGMENT = 0x0C /**< Fragment of a large message */
 } thinkpack_msg_type_t;
 
 /* ------------------------------------------------------------------ */
@@ -168,6 +180,23 @@ typedef struct __attribute__((packed)) {
     uint8_t payload[48]; /**< Command-specific data                  */
 } thinkpack_command_data_t;
 
+/**
+ * @brief Payload for MSG_FRAGMENT — one slice of a large message.
+ *
+ * Senders split a large buffer into up to THINKPACK_MAX_FRAGMENTS fragments
+ * and send each as a separate MSG_FRAGMENT packet.  Receivers accumulate
+ * fragments and emit a single THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED event
+ * once all fragments for a (src_mac, msg_id) arrive.
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t msg_id;                            /**< Unique ID per large message (wraps mod 256) */
+    uint8_t fragment_index;                    /**< 0-based index of this fragment              */
+    uint8_t total_fragments;                   /**< Total number of fragments in the message    */
+    uint8_t original_msg_type;                 /**< Logical type wrapped (e.g. MSG_LLM_RESPONSE) */
+    uint8_t data_length;                       /**< Bytes of data[] populated in this fragment  */
+    uint8_t data[THINKPACK_MAX_FRAGMENT_DATA]; /**< Fragment payload bytes     */
+} thinkpack_fragment_data_t;
+
 /* ------------------------------------------------------------------ */
 /* Helper function prototypes                                          */
 /* ------------------------------------------------------------------ */
@@ -252,5 +281,34 @@ void thinkpack_prepare_sync_pulse(thinkpack_packet_t *p, uint8_t seq, const uint
  * @return              32-bit priority value.
  */
 uint32_t thinkpack_priority_for_capabilities(uint16_t capabilities, const uint8_t mac[6]);
+
+/**
+ * @brief Build a MSG_FRAGMENT packet.
+ *
+ * @param p        Packet buffer to populate.
+ * @param seq      Sequence number.
+ * @param src_mac  Sender's 6-byte MAC.
+ * @param fragment Fragment payload to embed.
+ */
+void thinkpack_prepare_fragment(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                const thinkpack_fragment_data_t *fragment);
+
+/**
+ * @brief Compute the number of fragments needed to send @p total_bytes.
+ *
+ * Returns 0 for zero-length input; otherwise ceil(total_bytes /
+ * THINKPACK_MAX_FRAGMENT_DATA), capped at THINKPACK_MAX_FRAGMENTS.
+ *
+ * @param total_bytes  Total number of bytes to fragment.
+ * @return             Number of fragments (0 … THINKPACK_MAX_FRAGMENTS).
+ */
+static inline uint8_t thinkpack_fragment_count(size_t total_bytes)
+{
+    if (total_bytes == 0) {
+        return 0;
+    }
+    size_t count = (total_bytes + THINKPACK_MAX_FRAGMENT_DATA - 1) / THINKPACK_MAX_FRAGMENT_DATA;
+    return (uint8_t)(count > THINKPACK_MAX_FRAGMENTS ? THINKPACK_MAX_FRAGMENTS : count);
+}
 
 #endif /* THINKPACK_PROTOCOL_H */

--- a/packages/components/thinkpack-protocol/test/test_thinkpack_protocol.c
+++ b/packages/components/thinkpack-protocol/test/test_thinkpack_protocol.c
@@ -400,6 +400,107 @@ static void test_payload_structs_fit_in_max_data_len(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* thinkpack_fragment_count                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_fragment_count_zero(void)
+{
+    TEST_ASSERT_EQUAL(0, thinkpack_fragment_count(0));
+}
+
+static void test_fragment_count_one_byte(void)
+{
+    TEST_ASSERT_EQUAL(1, thinkpack_fragment_count(1));
+}
+
+static void test_fragment_count_exactly_one_fragment(void)
+{
+    TEST_ASSERT_EQUAL(1, thinkpack_fragment_count(THINKPACK_MAX_FRAGMENT_DATA));
+}
+
+static void test_fragment_count_one_over_boundary(void)
+{
+    TEST_ASSERT_EQUAL(2, thinkpack_fragment_count(THINKPACK_MAX_FRAGMENT_DATA + 1));
+}
+
+static void test_fragment_count_max_payload(void)
+{
+    TEST_ASSERT_EQUAL(THINKPACK_MAX_FRAGMENTS, thinkpack_fragment_count(THINKPACK_MAX_REASSEMBLED));
+}
+
+/* ------------------------------------------------------------------ */
+/* thinkpack_prepare_fragment                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_prepare_fragment_fields(void)
+{
+    thinkpack_packet_t pkt = {0};
+    thinkpack_fragment_data_t frag = {0};
+    frag.msg_id = 7;
+    frag.fragment_index = 2;
+    frag.total_fragments = 5;
+    frag.original_msg_type = MSG_LLM_RESPONSE;
+    frag.data_length = 3;
+    frag.data[0] = 0xAB;
+    frag.data[1] = 0xCD;
+    frag.data[2] = 0xEF;
+
+    thinkpack_prepare_fragment(&pkt, 0x60, TEST_MAC, &frag);
+
+    TEST_ASSERT_EQUAL(MSG_FRAGMENT, pkt.msg_type);
+    TEST_ASSERT_EQUAL(0x60, pkt.sequence_number);
+    TEST_ASSERT_EQUAL_MEMORY(TEST_MAC, pkt.src_mac, 6);
+    TEST_ASSERT_EQUAL(sizeof(thinkpack_fragment_data_t), pkt.data_length);
+    assert_magic_valid(&pkt);
+    assert_packet_checksum_valid(&pkt);
+}
+
+static void test_prepare_fragment_round_trip(void)
+{
+    thinkpack_packet_t pkt = {0};
+    thinkpack_fragment_data_t frag = {0};
+    frag.msg_id = 42;
+    frag.fragment_index = 0;
+    frag.total_fragments = 3;
+    frag.original_msg_type = MSG_LLM_RESPONSE;
+    frag.data_length = 8;
+    for (int i = 0; i < 8; i++) {
+        frag.data[i] = (uint8_t)(0x10 + i);
+    }
+
+    thinkpack_prepare_fragment(&pkt, 0x01, TEST_MAC, &frag);
+
+    TEST_ASSERT_TRUE(thinkpack_verify_checksum(&pkt));
+
+    thinkpack_fragment_data_t out = {0};
+    memcpy(&out, pkt.data, sizeof(out));
+
+    TEST_ASSERT_EQUAL(42, out.msg_id);
+    TEST_ASSERT_EQUAL(0, out.fragment_index);
+    TEST_ASSERT_EQUAL(3, out.total_fragments);
+    TEST_ASSERT_EQUAL(MSG_LLM_RESPONSE, out.original_msg_type);
+    TEST_ASSERT_EQUAL(8, out.data_length);
+    for (int i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL(0x10 + i, out.data[i]);
+    }
+}
+
+static void test_prepare_fragment_null_no_crash(void)
+{
+    thinkpack_fragment_data_t frag = {0};
+    thinkpack_prepare_fragment(NULL, 0, TEST_MAC, &frag);
+
+    thinkpack_packet_t pkt = {0};
+    thinkpack_prepare_fragment(&pkt, 0, TEST_MAC, NULL);
+}
+
+static void test_fragment_data_size_fits_max_data_len(void)
+{
+    /* Runtime counterpart to the _Static_assert in thinkpack_protocol.c */
+    TEST_ASSERT_TRUE((int)sizeof(thinkpack_fragment_data_t) <= THINKPACK_MAX_DATA_LEN);
+}
+
+/* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
 
@@ -457,6 +558,19 @@ int main(void)
     RUN_TEST(test_packet_size_within_espnow_limit);
     RUN_TEST(test_packet_size_exact);
     RUN_TEST(test_payload_structs_fit_in_max_data_len);
+
+    /* thinkpack_fragment_count */
+    RUN_TEST(test_fragment_count_zero);
+    RUN_TEST(test_fragment_count_one_byte);
+    RUN_TEST(test_fragment_count_exactly_one_fragment);
+    RUN_TEST(test_fragment_count_one_over_boundary);
+    RUN_TEST(test_fragment_count_max_payload);
+
+    /* thinkpack_prepare_fragment */
+    RUN_TEST(test_prepare_fragment_fields);
+    RUN_TEST(test_prepare_fragment_round_trip);
+    RUN_TEST(test_prepare_fragment_null_no_crash);
+    RUN_TEST(test_fragment_data_size_fits_max_data_len);
 
     int failures = UNITY_END();
     return (failures > 0) ? 1 : 0;

--- a/packages/components/thinkpack-protocol/thinkpack_protocol.c
+++ b/packages/components/thinkpack-protocol/thinkpack_protocol.c
@@ -25,6 +25,8 @@ _Static_assert(sizeof(thinkpack_sync_pulse_data_t) <= THINKPACK_MAX_DATA_LEN,
                "thinkpack_sync_pulse_data_t exceeds THINKPACK_MAX_DATA_LEN");
 _Static_assert(sizeof(thinkpack_command_data_t) <= THINKPACK_MAX_DATA_LEN,
                "thinkpack_command_data_t exceeds THINKPACK_MAX_DATA_LEN");
+_Static_assert(sizeof(thinkpack_fragment_data_t) <= THINKPACK_MAX_DATA_LEN,
+               "thinkpack_fragment_data_t exceeds THINKPACK_MAX_DATA_LEN");
 
 /* ------------------------------------------------------------------ */
 /* Checksum                                                            */
@@ -171,5 +173,21 @@ void thinkpack_prepare_sync_pulse(thinkpack_packet_t *p, uint8_t seq, const uint
     memcpy(p->src_mac, src_mac, 6);
     p->data_length = sizeof(thinkpack_sync_pulse_data_t);
     memcpy(p->data, &pulse, sizeof(thinkpack_sync_pulse_data_t));
+    thinkpack_finalize(p);
+}
+
+void thinkpack_prepare_fragment(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                                const thinkpack_fragment_data_t *fragment)
+{
+    if (!p || !fragment) {
+        return;
+    }
+
+    memset(p, 0, sizeof(*p));
+    p->msg_type = MSG_FRAGMENT;
+    p->sequence_number = seq;
+    memcpy(p->src_mac, src_mac, 6);
+    p->data_length = sizeof(thinkpack_fragment_data_t);
+    memcpy(p->data, fragment, sizeof(thinkpack_fragment_data_t));
     thinkpack_finalize(p);
 }


### PR DESCRIPTION
## Summary

Phase 3 foundation (part of #196, epic #193). Split into two PRs to keep the AI secret scanner happy after #240; this is PR A — transport + command envelope. Phase 3B follows with the Brainbox firmware.

### thinkpack-protocol

- New `MSG_FRAGMENT = 0x0C` + `thinkpack_fragment_data_t` payload (192-byte slice per fragment, up to 16 fragments ⇒ 3072-byte messages).
- `thinkpack_prepare_fragment`, `thinkpack_fragment_count` helpers.
- Static asserts confirm fit.

### thinkpack-mesh

- **`fragment_reassembler.{c,h}`** — pure-logic cache (no ESP-IDF deps), 4 in-progress slots, in/out-of-order tolerance, duplicate-idempotent, stale-prune.
- **`thinkpack_mesh_send_large(mac, msg_type, data, length)`** — transparently fragments > 200 B buffers, 5 ms inter-frame gap; messages ≤ 200 B go straight through.
- **`THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED`** — delivers the reassembled buffer with its original logical `msg_type`.

### thinkpack-behaviors (new component)

- Command envelope: `CMD_LED_PATTERN`, `CMD_SET_MOOD`, `CMD_PLAY_MELODY`, `CMD_BUZZ`, `CMD_PLAY_SEQUENCE`, `CMD_DISPLAY_LINE` with packed payload structs.
- Leader-side `command_build_*` helpers that produce a `thinkpack_packet_t`.
- Follower-side `command_executor_register` + `command_executor_dispatch` with a 16-slot registry.
- Decoupled from transport — depends only on `thinkpack-protocol`, not `thinkpack-mesh`. Keeps command definitions reusable if the transport ever changes.

## Tests

| Component | Assertions |
|---|---:|
| thinkpack-protocol | 95 |
| thinkpack-mesh (reassembler) | 60 |
| thinkpack-behaviors | 125 |

All pass. `clang-format -n -Werror` clean on every new/modified file.

## Follow-up — Phase 3B

- Brainbox firmware consumes these APIs: AI backend vtable, prompt builder, LLM response → `command_build_*` → `thinkpack_mesh_send_large`.
- Glowbug + Boombox migrate from ad-hoc COMMAND handling to `command_executor_register`.

## Test plan

- [x] Host-based tests (all three components) pass
- [x] CI — all code-side checks
- [ ] Integration verified in Phase 3B (Brainbox → Glowbug / Boombox end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)