### PR TITLE
feat(thinkpack): PR A — command_executor migration + Glowbug long-press factory-reset

### DIFF
--- a/packages/components/thinkpack-behaviors/test/test_commands.c
+++ b/packages/components/thinkpack-behaviors/test/test_commands.c
@@ -402,6 +402,105 @@ static void test_executor_reset_stops_dispatch(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* Registration-flow integration: replicate glowbug+boombox pattern     */
+/* ------------------------------------------------------------------ */
+
+/* Capture context for the LED handler (glowbug-style). */
+static capture_t s_led_cap;
+
+static void led_pattern_handler(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                                void *user_ctx)
+{
+    (void)user_ctx;
+    s_led_cap.call_count++;
+    s_led_cap.last_command_id = command_id;
+    s_led_cap.last_length = length;
+    if (length <= sizeof(s_led_cap.last_payload)) {
+        memcpy(s_led_cap.last_payload, payload, length);
+    }
+}
+
+/* Capture context for the melody handler (boombox-style). */
+static capture_t s_melody_cap;
+
+static void play_melody_handler(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                                void *user_ctx)
+{
+    (void)user_ctx;
+    s_melody_cap.call_count++;
+    s_melody_cap.last_command_id = command_id;
+    s_melody_cap.last_length = length;
+    if (length <= sizeof(s_melody_cap.last_payload)) {
+        memcpy(s_melody_cap.last_payload, payload, length);
+    }
+}
+
+/**
+ * @brief End-to-end: two followers register disjoint handlers; each
+ *        receives only the command it registered for.
+ *
+ * This mirrors how packages/thinkpack/glowbug and packages/thinkpack/boombox
+ * wire group_mode_init() → command_executor_register() at startup.  The
+ * executor is a shared singleton per binary, so this test instantiates it
+ * once with both handlers (as if a single hypothetical follower was handling
+ * both domains) and verifies routing fidelity.
+ */
+static void test_registration_flow_routes_to_registered_handlers(void)
+{
+    command_executor_reset();
+    memset(&s_led_cap, 0, sizeof(s_led_cap));
+    memset(&s_melody_cap, 0, sizeof(s_melody_cap));
+
+    /* Register both handlers, each for a different command id. */
+    TEST_ASSERT_EQUAL(ESP_OK,
+                      command_executor_register(CMD_LED_PATTERN, led_pattern_handler, NULL));
+    TEST_ASSERT_EQUAL(ESP_OK,
+                      command_executor_register(CMD_PLAY_MELODY, play_melody_handler, NULL));
+
+    /* Dispatch an LED packet — only led handler should fire. */
+    cmd_led_pattern_payload_t led_in = {.r = 10, .g = 20, .b = 30, .pattern = LED_PATTERN_BREATHE};
+    thinkpack_packet_t led_pkt;
+    command_build_led_pattern(&led_pkt, TEST_SEQ, TEST_MAC, &led_in);
+    command_executor_dispatch(&led_pkt);
+
+    TEST_ASSERT_EQUAL(1, s_led_cap.call_count);
+    TEST_ASSERT_EQUAL(0, s_melody_cap.call_count);
+    TEST_ASSERT_EQUAL(CMD_LED_PATTERN, s_led_cap.last_command_id);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(cmd_led_pattern_payload_t), s_led_cap.last_length);
+
+    cmd_led_pattern_payload_t led_out;
+    memcpy(&led_out, s_led_cap.last_payload, sizeof(led_out));
+    TEST_ASSERT_EQUAL(10, led_out.r);
+    TEST_ASSERT_EQUAL(20, led_out.g);
+    TEST_ASSERT_EQUAL(30, led_out.b);
+    TEST_ASSERT_EQUAL(LED_PATTERN_BREATHE, led_out.pattern);
+
+    /* Dispatch a melody packet — only melody handler should fire. */
+    cmd_play_melody_payload_t mel_in = {.pattern_id = 1, .repeat_count = 4};
+    thinkpack_packet_t mel_pkt;
+    command_build_play_melody(&mel_pkt, TEST_SEQ, TEST_MAC, &mel_in);
+    command_executor_dispatch(&mel_pkt);
+
+    TEST_ASSERT_EQUAL(1, s_led_cap.call_count); /* still only the earlier LED dispatch */
+    TEST_ASSERT_EQUAL(1, s_melody_cap.call_count);
+    TEST_ASSERT_EQUAL(CMD_PLAY_MELODY, s_melody_cap.last_command_id);
+
+    cmd_play_melody_payload_t mel_out;
+    memcpy(&mel_out, s_melody_cap.last_payload, sizeof(mel_out));
+    TEST_ASSERT_EQUAL(1, mel_out.pattern_id);
+    TEST_ASSERT_EQUAL(4, mel_out.repeat_count);
+
+    /* Unregistered command_id — neither handler fires. */
+    cmd_set_mood_payload_t mood_in = {.hue = 100, .intensity = 50};
+    thinkpack_packet_t mood_pkt;
+    command_build_set_mood(&mood_pkt, TEST_SEQ, TEST_MAC, &mood_in);
+    command_executor_dispatch(&mood_pkt);
+
+    TEST_ASSERT_EQUAL(1, s_led_cap.call_count);
+    TEST_ASSERT_EQUAL(1, s_melody_cap.call_count);
+}
+
+/* ------------------------------------------------------------------ */
 /* main                                                                */
 /* ------------------------------------------------------------------ */
 
@@ -431,6 +530,9 @@ int main(void)
     /* Executor reset */
     RUN_TEST(test_executor_reset_clears_all);
     RUN_TEST(test_executor_reset_stops_dispatch);
+
+    /* End-to-end registration flow (PR A: glowbug+boombox migration) */
+    RUN_TEST(test_registration_flow_routes_to_registered_handlers);
 
     int failures = UNITY_END();
     return failures == 0 ? 0 : 1;

--- a/packages/thinkpack/boombox/main/CMakeLists.txt
+++ b/packages/thinkpack/boombox/main/CMakeLists.txt
@@ -9,5 +9,5 @@ idf_component_register(
         "standalone_mode.c"
         "group_mode.c"
     INCLUDE_DIRS "."
-    REQUIRES driver esp_adc led_strip thinkpack-protocol thinkpack-mesh
+    REQUIRES driver esp_adc led_strip thinkpack-protocol thinkpack-mesh thinkpack-behaviors
 )

--- a/packages/thinkpack/boombox/main/group_mode.c
+++ b/packages/thinkpack/boombox/main/group_mode.c
@@ -1,11 +1,15 @@
 /**
  * @file group_mode.c
  * @brief Mesh event handling: sync-pulse beat alignment, hello chime,
- *        PLAY_MELODY command, leader sync-pulse broadcast timer.
+ *        PLAY_MELODY via command_executor, leader sync-pulse broadcast timer.
  *
  * The hello chime (C5 E5 G5, 80 ms each) is executed note-by-note in
  * group_mode_tick() using a small state machine so it never blocks the
  * mesh receive task.
+ *
+ * CMD_PLAY_MELODY is registered with command_executor in group_mode_init;
+ * the executor unpacks the envelope and invokes play_melody_handler,
+ * which installs a temporary pattern override for N beats.
  *
  * The sync-pulse broadcast timer is a FreeRTOS timer created on
  * BECAME_LEADER and deleted on BECAME_FOLLOWER. Timer period is
@@ -18,6 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "command_executor.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
@@ -26,16 +31,11 @@
 #include "melody_gen.h"
 #include "pot_reader.h"
 #include "standalone_mode.h"
+#include "thinkpack_commands.h"
 #include "thinkpack_protocol.h"
 #include "tone_engine.h"
 
 static const char *TAG = "group_mode";
-
-/* ------------------------------------------------------------------ */
-/* PLAY_MELODY command id                                              */
-/* ------------------------------------------------------------------ */
-
-#define CMD_PLAY_MELODY 0x20u
 
 /* ------------------------------------------------------------------ */
 /* Hello chime                                                         */
@@ -57,7 +57,7 @@ static uint8_t s_chime_step;
 static uint32_t s_chime_deadline_ms;
 
 /* ------------------------------------------------------------------ */
-/* Temporary pattern override (PLAY_MELODY command)                   */
+/* Temporary pattern override (CMD_PLAY_MELODY)                        */
 /* ------------------------------------------------------------------ */
 
 static bool s_override_active;
@@ -65,7 +65,7 @@ static melody_pattern_t s_saved_pattern;
 static uint32_t s_override_end_beat;
 
 /* ------------------------------------------------------------------ */
-/* Leader sync-pulse timer                                            */
+/* Leader sync-pulse timer                                             */
 /* ------------------------------------------------------------------ */
 
 static TimerHandle_t s_sync_timer;
@@ -98,6 +98,39 @@ static void sync_timer_cb(TimerHandle_t xTimer)
 }
 
 /* ------------------------------------------------------------------ */
+/* Command handlers                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Handler for CMD_PLAY_MELODY — registered with command_executor. */
+static void play_melody_handler(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                                void *user_ctx)
+{
+    (void)command_id;
+    (void)user_ctx;
+
+    if (length < sizeof(cmd_play_melody_payload_t)) {
+        ESP_LOGW(TAG, "CMD_PLAY_MELODY: payload too short (%u bytes)", length);
+        return;
+    }
+
+    cmd_play_melody_payload_t p;
+    memcpy(&p, payload, sizeof(p));
+
+    melody_pattern_t new_pattern = (melody_pattern_t)p.pattern_id;
+    if (new_pattern >= MELODY_COUNT || p.repeat_count == 0) {
+        ESP_LOGW(TAG, "CMD_PLAY_MELODY: bad args pattern=%u repeat=%u", p.pattern_id,
+                 p.repeat_count);
+        return;
+    }
+
+    s_saved_pattern = melody_gen_get_pattern();
+    melody_gen_set_pattern(new_pattern);
+    s_override_end_beat = standalone_mode_get_beat_index() + (uint32_t)p.repeat_count;
+    s_override_active = true;
+    ESP_LOGI(TAG, "PLAY_MELODY: pattern %d for %u beats", (int)new_pattern, p.repeat_count);
+}
+
+/* ------------------------------------------------------------------ */
 /* Public API                                                          */
 /* ------------------------------------------------------------------ */
 
@@ -110,6 +143,12 @@ void group_mode_init(void)
     s_saved_pattern = MELODY_MARCH;
     s_override_end_beat = 0;
     s_sync_timer = NULL;
+
+    esp_err_t err = command_executor_register(CMD_PLAY_MELODY, play_melody_handler, NULL);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register CMD_PLAY_MELODY handler: %s", esp_err_to_name(err));
+    }
+
     ESP_LOGI(TAG, "Group mode initialized");
 }
 
@@ -138,23 +177,11 @@ void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ct
             ESP_LOGI(TAG, "Peer discovered: " MACSTR, MAC2STR(event->peer_mac));
             break;
 
-        case THINKPACK_EVENT_COMMAND_RECEIVED: {
-            const thinkpack_command_data_t *cmd =
-                (const thinkpack_command_data_t *)event->packet->data;
-            if (cmd->command_id == CMD_PLAY_MELODY && cmd->length >= 2) {
-                melody_pattern_t new_pattern = (melody_pattern_t)cmd->payload[0];
-                uint8_t repeat_count = cmd->payload[1];
-                if (new_pattern < MELODY_COUNT && repeat_count > 0) {
-                    s_saved_pattern = melody_gen_get_pattern();
-                    melody_gen_set_pattern(new_pattern);
-                    s_override_end_beat = standalone_mode_get_beat_index() + (uint32_t)repeat_count;
-                    s_override_active = true;
-                    ESP_LOGI(TAG, "PLAY_MELODY: pattern %d for %u beats", (int)new_pattern,
-                             repeat_count);
-                }
+        case THINKPACK_EVENT_COMMAND_RECEIVED:
+            if (event->packet != NULL) {
+                command_executor_dispatch(event->packet);
             }
             break;
-        }
 
         case THINKPACK_EVENT_BECAME_LEADER: {
             ESP_LOGI(TAG, "Became leader — starting sync-pulse timer");

--- a/packages/thinkpack/glowbug/main/CMakeLists.txt
+++ b/packages/thinkpack/glowbug/main/CMakeLists.txt
@@ -12,8 +12,10 @@ idf_component_register(
     REQUIRES
         driver
         esp_adc
+        nvs_flash
         thinkpack-protocol
         thinkpack-mesh
+        thinkpack-behaviors
     PRIV_REQUIRES
         led_strip
         esp_timer

--- a/packages/thinkpack/glowbug/main/button.c
+++ b/packages/thinkpack/glowbug/main/button.c
@@ -3,12 +3,17 @@
  * @brief Debounced button driver — GPIO9, active LOW, internal pull-up.
  *
  * ISR posts a notification to a dedicated task that enforces a 50 ms
- * debounce window before firing the user callback.
+ * debounce window before firing the user callback.  The task also
+ * polls the pin in 10 ms increments while the button is held to fire
+ * a long-press callback at BUTTON_LONG_PRESS_MS; a long press inhibits
+ * the short-press callback for the same press.
  *
  * See https://github.com/laurigates/mcu-tinkering-lab/issues/195
  */
 
 #include "button.h"
+
+#include <stdbool.h>
 
 #include "driver/gpio.h"
 #include "esp_log.h"
@@ -17,7 +22,8 @@
 
 static const char *TAG = "button";
 
-static button_callback_t s_cb;
+static button_callback_t s_short_cb;
+static button_callback_t s_long_cb;
 static TaskHandle_t s_task_handle;
 
 /* ------------------------------------------------------------------ */
@@ -33,7 +39,7 @@ static void IRAM_ATTR gpio_isr_handler(void *arg)
 }
 
 /* ------------------------------------------------------------------ */
-/* Debounce task                                                        */
+/* Debounce + long-press task                                          */
 /* ------------------------------------------------------------------ */
 
 static void button_task(void *arg)
@@ -46,11 +52,36 @@ static void button_task(void *arg)
 
         /* Debounce: wait then verify pin is still low */
         vTaskDelay(pdMS_TO_TICKS(BUTTON_DEBOUNCE_MS));
-        if (gpio_get_level(BUTTON_GPIO) == 0) {
-            s_cb();
+        if (gpio_get_level(BUTTON_GPIO) != 0) {
+            /* Spurious edge — drain and wait for the next one */
+            ulTaskNotifyTake(pdTRUE, 0);
+            continue;
         }
 
-        /* Drain any spurious notifications accumulated during debounce */
+        /* Pin confirmed LOW. Poll in 10 ms increments until release to
+         * detect long-press crossing.  Once the long-press threshold is
+         * hit we fire the long callback and suppress the short callback
+         * for this press. */
+        uint32_t held_ms = BUTTON_DEBOUNCE_MS;
+        bool long_fired = false;
+
+        while (gpio_get_level(BUTTON_GPIO) == 0) {
+            if (!long_fired && held_ms >= BUTTON_LONG_PRESS_MS) {
+                long_fired = true;
+                ESP_LOGI(TAG, "Long press detected (%u ms)", (unsigned)held_ms);
+                if (s_long_cb != NULL) {
+                    s_long_cb();
+                }
+            }
+            vTaskDelay(pdMS_TO_TICKS(10));
+            held_ms += 10;
+        }
+
+        if (!long_fired && s_short_cb != NULL) {
+            s_short_cb();
+        }
+
+        /* Drain any spurious notifications accumulated during hold */
         ulTaskNotifyTake(pdTRUE, 0);
     }
 }
@@ -59,9 +90,10 @@ static void button_task(void *arg)
 /* Public API                                                          */
 /* ------------------------------------------------------------------ */
 
-esp_err_t button_init(button_callback_t cb)
+esp_err_t button_init(button_callback_t on_short, button_callback_t on_long)
 {
-    s_cb = cb;
+    s_short_cb = on_short;
+    s_long_cb = on_long;
 
     gpio_config_t io_cfg = {
         .pin_bit_mask = (1ULL << BUTTON_GPIO),
@@ -96,7 +128,7 @@ esp_err_t button_init(button_callback_t cb)
         return ret;
     }
 
-    ESP_LOGI(TAG, "Button initialized on GPIO%d (active LOW, debounce %d ms)", BUTTON_GPIO,
-             BUTTON_DEBOUNCE_MS);
+    ESP_LOGI(TAG, "Button initialized on GPIO%d (active LOW, debounce %d ms, long-press %d ms)",
+             BUTTON_GPIO, BUTTON_DEBOUNCE_MS, BUTTON_LONG_PRESS_MS);
     return ESP_OK;
 }

--- a/packages/thinkpack/glowbug/main/button.h
+++ b/packages/thinkpack/glowbug/main/button.h
@@ -2,9 +2,12 @@
  * @file button.h
  * @brief Debounced button driver on GPIO9 (active LOW, internal pull-up).
  *
- * Installs a GPIO ISR and fires a user callback after a 50 ms software
- * debounce window.  The callback runs from a small helper task, not from
- * interrupt context, so it may call FreeRTOS APIs.
+ * Installs a GPIO ISR and fires user callbacks after a 50 ms software
+ * debounce window.  Short-press callback fires on release; long-press
+ * callback fires once when the button has been held for
+ * BUTTON_LONG_PRESS_MS and inhibits the short-press callback for the
+ * same press.  Callbacks run from a small helper task, not from
+ * interrupt context, so they may call FreeRTOS APIs.
  *
  * See https://github.com/laurigates/mcu-tinkering-lab/issues/195
  */
@@ -24,7 +27,10 @@ extern "C" {
 /** Software debounce window in milliseconds. */
 #define BUTTON_DEBOUNCE_MS 50
 
-/** Callback type fired once per confirmed button press. */
+/** Long-press threshold in milliseconds (2 s factory-reset hold). */
+#define BUTTON_LONG_PRESS_MS 2000
+
+/** Callback type fired once per confirmed short press or long press. */
 typedef void (*button_callback_t)(void);
 
 /**
@@ -33,10 +39,14 @@ typedef void (*button_callback_t)(void);
  * Configures GPIO9 as input with internal pull-up, registers a
  * falling-edge ISR, and spawns the debounce task.
  *
- * @param cb  Function to call on each confirmed press.  Must not be NULL.
+ * @param on_short  Called on a confirmed short press (release before
+ *                  BUTTON_LONG_PRESS_MS).  Must not be NULL.
+ * @param on_long   Called once when the button crosses
+ *                  BUTTON_LONG_PRESS_MS of continuous hold.  May be
+ *                  NULL if no long-press action is required.
  * @return ESP_OK on success, forwarded ESP-IDF error otherwise.
  */
-esp_err_t button_init(button_callback_t cb);
+esp_err_t button_init(button_callback_t on_short, button_callback_t on_long);
 
 #ifdef __cplusplus
 }

--- a/packages/thinkpack/glowbug/main/group_mode.c
+++ b/packages/thinkpack/glowbug/main/group_mode.c
@@ -2,10 +2,13 @@
  * @file group_mode.c
  * @brief Mesh event handler for glowbug group behaviour.
  *
- * Handles three event types:
- *  - THINKPACK_EVENT_SYNC_PULSE      → ANIM_SYNC_PULSE (200 ms flash)
- *  - THINKPACK_EVENT_COMMAND_RECEIVED → CMD_LED_PATTERN (0x10) dispatch
+ * Event handling:
+ *  - THINKPACK_EVENT_SYNC_PULSE       → ANIM_SYNC_PULSE (phase-locked)
+ *  - THINKPACK_EVENT_COMMAND_RECEIVED → command_executor_dispatch()
  *  - THINKPACK_EVENT_PEER_DISCOVERED  → 150 ms white hello-chime flash
+ *
+ * CMD_LED_PATTERN is registered with command_executor in group_mode_init;
+ * the executor unpacks the envelope and invokes led_pattern_handler.
  *
  * Called from the receive task on Core 0; must not block.
  *
@@ -17,12 +20,45 @@
 #include <string.h>
 
 #include "animations.h"
+#include "command_executor.h"
 #include "esp_log.h"
 #include "esp_mac.h"
 #include "led_ring.h"
+#include "thinkpack_commands.h"
 #include "thinkpack_protocol.h"
 
 static const char *TAG = "group_mode";
+
+/* ------------------------------------------------------------------ */
+/* Command handlers                                                    */
+/* ------------------------------------------------------------------ */
+
+/** Handler for CMD_LED_PATTERN — registered with command_executor. */
+static void led_pattern_handler(uint8_t command_id, const uint8_t *payload, uint8_t length,
+                                void *user_ctx)
+{
+    (void)command_id;
+    (void)user_ctx;
+
+    if (length < sizeof(cmd_led_pattern_payload_t)) {
+        ESP_LOGW(TAG, "CMD_LED_PATTERN: payload too short (%u bytes)", length);
+        return;
+    }
+
+    cmd_led_pattern_payload_t p;
+    memcpy(&p, payload, sizeof(p));
+
+    ESP_LOGI(TAG, "CMD_LED_PATTERN r=%u g=%u b=%u mode=%u", p.r, p.g, p.b, p.pattern);
+
+    /* Validate mode byte (shared with anim_mode_t enum range) */
+    if (p.pattern > (uint8_t)ANIM_MOOD_MIRROR) {
+        ESP_LOGW(TAG, "CMD_LED_PATTERN: unknown mode %u, ignoring", p.pattern);
+        return;
+    }
+
+    /* Derive hue from r channel (compatible with prior behaviour) */
+    animations_set_mode((anim_mode_t)p.pattern, p.r);
+}
 
 /* ------------------------------------------------------------------ */
 /* Internal helpers                                                    */
@@ -41,47 +77,6 @@ static void handle_sync_pulse(const thinkpack_packet_t *pkt)
 
     ESP_LOGD(TAG, "SYNC_PULSE ts=%lu phase=%u", (unsigned long)pulse->timestamp_ms, pulse->phase);
     animations_set_mode(ANIM_SYNC_PULSE, pulse->phase);
-}
-
-/** Handle MSG_COMMAND: dispatch on command_id. */
-static void handle_command(const thinkpack_packet_t *pkt, const uint8_t peer_mac[6])
-{
-    if (pkt->data_length < sizeof(thinkpack_command_data_t)) {
-        ESP_LOGW(TAG, "COMMAND payload too short (%u bytes)", pkt->data_length);
-        return;
-    }
-
-    const thinkpack_command_data_t *cmd = (const thinkpack_command_data_t *)(const void *)pkt->data;
-
-    switch (cmd->command_id) {
-        case CMD_LED_PATTERN: {
-            if (cmd->length < 4) {
-                ESP_LOGW(TAG, "CMD_LED_PATTERN: payload too short (%u bytes)", cmd->length);
-                break;
-            }
-            uint8_t r = cmd->payload[0];
-            uint8_t g = cmd->payload[1];
-            uint8_t b = cmd->payload[2];
-            uint8_t mode_byte = cmd->payload[3];
-
-            ESP_LOGI(TAG, "CMD_LED_PATTERN from " MACSTR " r=%u g=%u b=%u mode=%u",
-                     MAC2STR(peer_mac), r, g, b, mode_byte);
-
-            /* Validate mode byte */
-            if (mode_byte <= (uint8_t)ANIM_MOOD_MIRROR) {
-                /* Derive hue from r/g/b: use r as a simple hue approximation */
-                animations_set_mode((anim_mode_t)mode_byte, r);
-            } else {
-                ESP_LOGW(TAG, "CMD_LED_PATTERN: unknown mode %u, ignoring", mode_byte);
-            }
-            break;
-        }
-
-        default:
-            ESP_LOGI(TAG, "Unknown command 0x%02x from " MACSTR " — ignored", cmd->command_id,
-                     MAC2STR(peer_mac));
-            break;
-    }
 }
 
 /** Handle PEER_DISCOVERED: brief white hello-chime flash (150 ms). */
@@ -104,6 +99,16 @@ static void handle_peer_discovered(const uint8_t peer_mac[6])
 /* Public API                                                          */
 /* ------------------------------------------------------------------ */
 
+void group_mode_init(void)
+{
+    esp_err_t err = command_executor_register(CMD_LED_PATTERN, led_pattern_handler, NULL);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to register CMD_LED_PATTERN handler: %s", esp_err_to_name(err));
+    } else {
+        ESP_LOGI(TAG, "Registered CMD_LED_PATTERN handler");
+    }
+}
+
 void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ctx)
 {
     (void)user_ctx;
@@ -117,7 +122,7 @@ void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ct
 
         case THINKPACK_EVENT_COMMAND_RECEIVED:
             if (event->packet != NULL) {
-                handle_command(event->packet, event->peer_mac);
+                command_executor_dispatch(event->packet);
             }
             break;
 

--- a/packages/thinkpack/glowbug/main/group_mode.h
+++ b/packages/thinkpack/glowbug/main/group_mode.h
@@ -3,8 +3,8 @@
  * @brief Mesh event handler for glowbug group (multi-box) behaviour.
  *
  * Register group_mode_on_event as the thinkpack_mesh event callback.
- * Handles SYNC_PULSE, COMMAND_RECEIVED, and PEER_DISCOVERED events and
- * translates them into animation directives.
+ * Handles SYNC_PULSE, COMMAND_RECEIVED (via command_executor), and
+ * PEER_DISCOVERED events and translates them into animation directives.
  *
  * See https://github.com/laurigates/mcu-tinkering-lab/issues/195
  */
@@ -19,19 +19,19 @@ extern "C" {
 #endif
 
 /**
- * @brief LED_PATTERN command ID (MSG_COMMAND payload command_id).
+ * @brief Initialise group-mode state and register command handlers.
  *
- * Payload layout: {r, g, b, mode} — 4 bytes.
- *   r, g, b: target colour (full-scale; brightness cap applied by led_ring).
- *   mode:    anim_mode_t to switch to (ignored if out of range).
+ * Must be called once before thinkpack_mesh_start().  Registers the
+ * CMD_LED_PATTERN (0x10) handler with command_executor so that
+ * incoming MSG_COMMAND packets are dispatched to animation helpers.
  */
-#define CMD_LED_PATTERN 0x10u
+void group_mode_init(void);
 
 /**
  * @brief Mesh event callback — register with thinkpack_mesh_set_event_callback().
  *
  * Called from the receive task on Core 0.  Dispatches to animation helpers
- * without blocking.
+ * without blocking.  Command packets are forwarded to command_executor.
  *
  * @param event     Event descriptor; valid only for the duration of this call.
  * @param user_ctx  Unused; pass NULL.

--- a/packages/thinkpack/glowbug/main/main.c
+++ b/packages/thinkpack/glowbug/main/main.c
@@ -35,12 +35,17 @@
 static const char *TAG = "glowbug";
 
 /* ------------------------------------------------------------------ */
-/* Button callback                                                     */
+/* Button callbacks                                                    */
 /* ------------------------------------------------------------------ */
 
-static void on_button_press(void)
+static void on_button_short_press(void)
 {
     standalone_mode_cycle_override();
+}
+
+static void on_button_long_press(void)
+{
+    standalone_mode_factory_reset();
 }
 
 /* ------------------------------------------------------------------ */
@@ -74,11 +79,12 @@ void app_main(void)
     ESP_ERROR_CHECK(led_ring_init());
     ESP_ERROR_CHECK(imu_init());
     ESP_ERROR_CHECK(light_sensor_init());
-    ESP_ERROR_CHECK(button_init(on_button_press));
+    ESP_ERROR_CHECK(button_init(on_button_short_press, on_button_long_press));
 
     /* Animation engine + standalone state machine */
     animations_init();
     standalone_mode_init();
+    group_mode_init();
 
     /* Mesh */
     thinkpack_mesh_config_t cfg;

--- a/packages/thinkpack/glowbug/main/standalone_mode.c
+++ b/packages/thinkpack/glowbug/main/standalone_mode.c
@@ -18,8 +18,13 @@
 
 #include "animations.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 #include "imu.h"
+#include "led_ring.h"
 #include "light_sensor.h"
+#include "nvs.h"
+#include "nvs_flash.h"
 
 static const char *TAG = "standalone";
 
@@ -125,4 +130,34 @@ void standalone_mode_cycle_override(void)
 
     const char *names[] = {"AUTO", "BREATHE", "RAINBOW_CHASE", "SPARKLE_BURST"};
     ESP_LOGI(TAG, "Override -> %s", names[s_override]);
+}
+
+void standalone_mode_factory_reset(void)
+{
+    ESP_LOGW(TAG, "Factory reset: clearing override + NVS 'thinkpack' namespace");
+
+    s_override = OVERRIDE_AUTO;
+    s_auto_mode = ANIM_BREATHE;
+    s_in_sparkle = false;
+
+    /* Best-effort NVS erase — thinkpack namespace may not exist yet. */
+    nvs_handle_t handle;
+    esp_err_t err = nvs_open("thinkpack", NVS_READWRITE, &handle);
+    if (err == ESP_OK) {
+        err = nvs_erase_all(handle);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "nvs_erase_all failed: %s", esp_err_to_name(err));
+        }
+        (void)nvs_commit(handle);
+        nvs_close(handle);
+    } else if (err != ESP_ERR_NVS_NOT_FOUND) {
+        ESP_LOGW(TAG, "nvs_open failed: %s", esp_err_to_name(err));
+    }
+
+    /* ~300 ms red flash as visual confirmation. */
+    led_ring_fill(255, 0, 0);
+    (void)led_ring_show();
+    vTaskDelay(pdMS_TO_TICKS(300));
+    led_ring_clear();
+    (void)led_ring_show();
 }

--- a/packages/thinkpack/glowbug/main/standalone_mode.h
+++ b/packages/thinkpack/glowbug/main/standalone_mode.h
@@ -42,6 +42,16 @@ void standalone_mode_tick(uint32_t now_ms);
  */
 void standalone_mode_cycle_override(void);
 
+/**
+ * @brief Soft factory reset: clear override + persistent state.
+ *
+ * Invoked on a 2 s long-press.  Clears any override, erases the
+ * "thinkpack" NVS namespace (best-effort — missing namespace is not
+ * an error), and flashes the LED ring red for ~300 ms as visual
+ * feedback.  Returns after the flash completes.
+ */
+void standalone_mode_factory_reset(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Summary

First of seven PRs completing the ThinkPack epic (#193). Migrates Glowbug and Boombox to use the shared `command_executor` registry (introduced in #243) and adds a 2 s long-press factory-reset to Glowbug.

- **Glowbug button** — adds `BUTTON_LONG_PRESS_MS` (2000 ms) handling; `button_init` now takes separate short- and long-press callbacks, long press inhibits the short callback for the same press.
- **Glowbug `standalone_mode_factory_reset()`** — clears override, erases the \"thinkpack\" NVS namespace (best-effort), flashes the LED ring red for ~300 ms.
- **Glowbug + Boombox `group_mode.c`** — replaces inline `switch(cmd->command_id)` with `command_executor_register(CMD_LED_PATTERN, …)` / `command_executor_register(CMD_PLAY_MELODY, …)` and forwards `THINKPACK_EVENT_COMMAND_RECEIVED` to `command_executor_dispatch()`.
- **Host tests** — new `test_registration_flow_routes_to_registered_handlers` exercises the exact registration pattern used by Glowbug+Boombox.

Closes #242. Part of epic #193.

## Test plan

- [x] `cd packages/components/thinkpack-behaviors/test && make test` — 142 tests, 0 failures.
- [x] `clang-format -n -Werror` on all touched `.c`/`.h` files — clean.
- [ ] Hardware smoke: flash Glowbug, hold button 2 s → red flash + log \"Factory reset\".
- [ ] Hardware smoke: Brainbox broadcasts `CMD_LED_PATTERN` / `CMD_PLAY_MELODY` → Glowbug/Boombox respond identically to pre-migration behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)