### PR TITLE
feat(thinkpack): PR B — thinkpack-audio + thinkpack-nfc pure-logic components

### DIFF
--- a/packages/components/thinkpack-audio/CMakeLists.txt
+++ b/packages/components/thinkpack-audio/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "thinkpack_audio.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES log)

--- a/packages/components/thinkpack-audio/include/thinkpack_audio.h
+++ b/packages/components/thinkpack-audio/include/thinkpack_audio.h
@@ -1,0 +1,195 @@
+/**
+ * @file thinkpack_audio.h
+ * @brief Pure-logic audio helpers for ThinkPack Chatterbox and Finderbox.
+ *
+ * This component packages four reusable, host-testable pieces:
+ *
+ *  - Toddler-safe volume cap (in-place gain reduction).
+ *  - A lock-free single-producer/single-consumer ring buffer of int16 PCM.
+ *  - A nearest-neighbor pitch-shift resampler driven by semitone shift.
+ *  - A record/playback state machine that models a hold-to-record toggle.
+ *
+ * No ESP-IDF dependencies; safe to compile on a host with gcc/clang.
+ */
+
+#ifndef THINKPACK_AUDIO_H
+#define THINKPACK_AUDIO_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Audio constants                                                     */
+/* ------------------------------------------------------------------ */
+
+/** 16 kHz mono — matches INMP441 / MAX98357A target for Chatterbox. */
+#define THINKPACK_AUDIO_SAMPLE_RATE 16000
+
+/** Longest clip we ever keep in PSRAM (2 s). */
+#define THINKPACK_AUDIO_CLIP_MAX_MS 2000
+
+/** Maximum clip length in samples (32000 @ 16 kHz). */
+#define THINKPACK_AUDIO_CLIP_MAX_SAMPLES \
+    ((THINKPACK_AUDIO_SAMPLE_RATE * THINKPACK_AUDIO_CLIP_MAX_MS) / 1000)
+
+/** Toddler-safe attenuation: 60 % of full-scale int16 range. */
+#define THINKPACK_AUDIO_VOLUME_SCALE_NUM 60
+#define THINKPACK_AUDIO_VOLUME_SCALE_DEN 100
+
+/** Clamp for semitone shift — two octaves is more than enough for a toy. */
+#define THINKPACK_AUDIO_PITCH_MIN_SEMITONES (-12)
+#define THINKPACK_AUDIO_PITCH_MAX_SEMITONES (+12)
+
+/* ------------------------------------------------------------------ */
+/* Volume cap                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Apply the toddler-safe volume cap in place.
+ *
+ * Scales every sample by THINKPACK_AUDIO_VOLUME_SCALE_NUM /
+ * THINKPACK_AUDIO_VOLUME_SCALE_DEN.  Samples are clamped to the int16
+ * range on overflow, which can happen only if an upstream stage has
+ * already amplified beyond full scale.
+ *
+ * @param samples      PCM buffer to modify.  Safe to pass NULL when
+ *                     sample_count is 0.
+ * @param sample_count Number of samples in @p samples.
+ */
+void thinkpack_audio_apply_volume_cap(int16_t *samples, size_t sample_count);
+
+/* ------------------------------------------------------------------ */
+/* Ring buffer                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Single-producer/single-consumer ring buffer of int16 samples.
+ *
+ * The buffer is supplied by the caller; this struct only tracks indices.
+ * Pass the same @p buffer and @p capacity to init() that backs the
+ * storage for the lifetime of the ring.
+ */
+typedef struct {
+    int16_t *buffer;
+    size_t capacity;
+    size_t head;
+    size_t tail;
+    size_t count;
+} thinkpack_audio_ring_t;
+
+/** Initialise the ring. @p capacity must be > 0. */
+void thinkpack_audio_ring_init(thinkpack_audio_ring_t *ring, int16_t *buffer, size_t capacity);
+
+/** Drop all samples without freeing the storage. */
+void thinkpack_audio_ring_reset(thinkpack_audio_ring_t *ring);
+
+/** Number of samples currently stored. */
+size_t thinkpack_audio_ring_used(const thinkpack_audio_ring_t *ring);
+
+/** Free space available for writes. */
+size_t thinkpack_audio_ring_free(const thinkpack_audio_ring_t *ring);
+
+/**
+ * @brief Copy up to @p count samples from @p samples into the ring.
+ *
+ * Writes stop early once the ring is full.
+ *
+ * @return Number of samples actually written (<= @p count).
+ */
+size_t thinkpack_audio_ring_write(thinkpack_audio_ring_t *ring, const int16_t *samples,
+                                  size_t count);
+
+/**
+ * @brief Read up to @p count samples from the ring into @p out.
+ *
+ * Reads stop early once the ring is empty.
+ *
+ * @return Number of samples actually read (<= @p count).
+ */
+size_t thinkpack_audio_ring_read(thinkpack_audio_ring_t *ring, int16_t *out, size_t count);
+
+/* ------------------------------------------------------------------ */
+/* Pitch-shift resampler                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Nearest-neighbor pitch-shift via integer resampling.
+ *
+ * @p semitone_shift is clamped to
+ * [THINKPACK_AUDIO_PITCH_MIN_SEMITONES, THINKPACK_AUDIO_PITCH_MAX_SEMITONES].
+ * Positive shift raises pitch (reads input faster, so fewer output
+ * samples per input sample).  The resampler is intentionally simple —
+ * it is good enough for 2 s toy clips but does not implement any
+ * anti-alias filtering.
+ *
+ * @param in            Input PCM samples.
+ * @param in_samples    Number of samples in @p in.
+ * @param semitone_shift Signed semitone offset.
+ * @param out           Destination buffer.
+ * @param out_capacity  Size of @p out in samples.
+ * @return              Number of output samples produced (<= @p out_capacity).
+ */
+size_t thinkpack_audio_pitch_shift(const int16_t *in, size_t in_samples, int8_t semitone_shift,
+                                   int16_t *out, size_t out_capacity);
+
+/* ------------------------------------------------------------------ */
+/* Record/playback state machine                                       */
+/* ------------------------------------------------------------------ */
+
+typedef enum {
+    THINKPACK_AUDIO_STATE_IDLE = 0,
+    THINKPACK_AUDIO_STATE_RECORDING,
+    THINKPACK_AUDIO_STATE_PLAYING,
+} thinkpack_audio_state_t;
+
+typedef enum {
+    THINKPACK_AUDIO_EVENT_TOUCH_START = 0,
+    THINKPACK_AUDIO_EVENT_TOUCH_END,
+    THINKPACK_AUDIO_EVENT_CLIP_DONE,
+    THINKPACK_AUDIO_EVENT_LIMIT_REACHED,
+    THINKPACK_AUDIO_EVENT_CANCEL,
+} thinkpack_audio_event_t;
+
+typedef struct {
+    thinkpack_audio_state_t state;
+    uint32_t recorded_samples;
+} thinkpack_audio_sm_t;
+
+/** Reset to IDLE with zero recorded samples. */
+void thinkpack_audio_sm_init(thinkpack_audio_sm_t *sm);
+
+/**
+ * @brief Advance the state machine by one event.
+ *
+ * Transitions:
+ *   IDLE      + TOUCH_START    -> RECORDING (recorded_samples := 0)
+ *   RECORDING + TOUCH_END      -> PLAYING if recorded_samples > 0 else IDLE
+ *   RECORDING + LIMIT_REACHED  -> PLAYING
+ *   RECORDING + CANCEL         -> IDLE (recorded_samples := 0)
+ *   PLAYING   + CLIP_DONE      -> IDLE
+ *   PLAYING   + TOUCH_START    -> RECORDING (recorded_samples := 0)
+ *   PLAYING   + CANCEL         -> IDLE
+ *   anything else              -> no state change
+ *
+ * @return the new state.
+ */
+thinkpack_audio_state_t thinkpack_audio_sm_handle(thinkpack_audio_sm_t *sm,
+                                                  thinkpack_audio_event_t ev);
+
+/**
+ * @brief Account for @p n additional recorded samples while in RECORDING.
+ *
+ * No-op if the state machine is not in RECORDING.
+ */
+void thinkpack_audio_sm_add_samples(thinkpack_audio_sm_t *sm, uint32_t n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* THINKPACK_AUDIO_H */

--- a/packages/components/thinkpack-audio/test/Makefile
+++ b/packages/components/thinkpack-audio/test/Makefile
@@ -1,0 +1,33 @@
+# Makefile for thinkpack-audio host-based unit tests.
+#
+# Compiles thinkpack_audio.c on Linux/macOS with gcc and runs the
+# Unity-compat host tests.  Reuses the shared stubs and unity_compat.h
+# from packages/components/thinkpack-behaviors/test.
+#
+# Usage:
+#   make test
+#   make clean
+
+CC     = gcc
+CFLAGS = -std=c11 -Wall -Wextra \
+         -I../include \
+         -I../../thinkpack-behaviors/test \
+         -I../../thinkpack-behaviors/test/stubs
+
+SRCS   = test_audio.c \
+         ../thinkpack_audio.c
+
+TARGET = test_runner
+
+.PHONY: all test clean
+
+all: test
+
+test: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS)
+	$(CC) $(CFLAGS) -o $@ $(SRCS)
+
+clean:
+	rm -f $(TARGET)

--- a/packages/components/thinkpack-audio/test/test_audio.c
+++ b/packages/components/thinkpack-audio/test/test_audio.c
@@ -1,0 +1,330 @@
+/**
+ * @file test_audio.c
+ * @brief Host-based unit tests for thinkpack-audio.
+ */
+
+#include <string.h>
+
+#include "thinkpack_audio.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* Volume cap                                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_volume_cap_scales_samples(void)
+{
+    int16_t samples[4] = {10000, -10000, 0, 20000};
+    thinkpack_audio_apply_volume_cap(samples, 4);
+    /* 60% scale: 10000*60/100 = 6000; -10000 -> -6000; 0 -> 0; 20000 -> 12000 */
+    TEST_ASSERT_EQUAL(6000, samples[0]);
+    TEST_ASSERT_EQUAL(-6000, samples[1]);
+    TEST_ASSERT_EQUAL(0, samples[2]);
+    TEST_ASSERT_EQUAL(12000, samples[3]);
+}
+
+static void test_volume_cap_handles_null_and_zero(void)
+{
+    thinkpack_audio_apply_volume_cap(NULL, 0);
+    int16_t s = 100;
+    thinkpack_audio_apply_volume_cap(&s, 0);
+    TEST_ASSERT_EQUAL(100, s);
+}
+
+/* ------------------------------------------------------------------ */
+/* Ring buffer                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_ring_basic_write_read(void)
+{
+    int16_t storage[8];
+    thinkpack_audio_ring_t ring;
+    thinkpack_audio_ring_init(&ring, storage, 8);
+
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_ring_used(&ring));
+    TEST_ASSERT_EQUAL(8, thinkpack_audio_ring_free(&ring));
+
+    int16_t in[] = {1, 2, 3, 4, 5};
+    size_t w = thinkpack_audio_ring_write(&ring, in, 5);
+    TEST_ASSERT_EQUAL(5, w);
+    TEST_ASSERT_EQUAL(5, thinkpack_audio_ring_used(&ring));
+    TEST_ASSERT_EQUAL(3, thinkpack_audio_ring_free(&ring));
+
+    int16_t out[10] = {0};
+    size_t r = thinkpack_audio_ring_read(&ring, out, 10);
+    TEST_ASSERT_EQUAL(5, r);
+    TEST_ASSERT_EQUAL(1, out[0]);
+    TEST_ASSERT_EQUAL(5, out[4]);
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_ring_used(&ring));
+}
+
+static void test_ring_write_full_rejects_overflow(void)
+{
+    int16_t storage[4];
+    thinkpack_audio_ring_t ring;
+    thinkpack_audio_ring_init(&ring, storage, 4);
+
+    int16_t in[] = {10, 20, 30, 40, 50, 60};
+    size_t w = thinkpack_audio_ring_write(&ring, in, 6);
+    TEST_ASSERT_EQUAL(4, w);
+    TEST_ASSERT_EQUAL(4, thinkpack_audio_ring_used(&ring));
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_ring_free(&ring));
+
+    /* Further writes return 0 and do not corrupt content */
+    size_t w2 = thinkpack_audio_ring_write(&ring, in + 4, 2);
+    TEST_ASSERT_EQUAL(0, w2);
+
+    int16_t out[4];
+    size_t r = thinkpack_audio_ring_read(&ring, out, 4);
+    TEST_ASSERT_EQUAL(4, r);
+    TEST_ASSERT_EQUAL(10, out[0]);
+    TEST_ASSERT_EQUAL(40, out[3]);
+}
+
+static void test_ring_wraparound(void)
+{
+    int16_t storage[4];
+    thinkpack_audio_ring_t ring;
+    thinkpack_audio_ring_init(&ring, storage, 4);
+
+    /* Fill, drain 2, refill across the seam */
+    int16_t in1[] = {1, 2, 3, 4};
+    thinkpack_audio_ring_write(&ring, in1, 4);
+    int16_t tmp[2];
+    thinkpack_audio_ring_read(&ring, tmp, 2);
+    TEST_ASSERT_EQUAL(1, tmp[0]);
+    TEST_ASSERT_EQUAL(2, tmp[1]);
+
+    int16_t in2[] = {5, 6};
+    size_t w = thinkpack_audio_ring_write(&ring, in2, 2);
+    TEST_ASSERT_EQUAL(2, w);
+    TEST_ASSERT_EQUAL(4, thinkpack_audio_ring_used(&ring));
+
+    /* Drain — must read 3,4,5,6 in order despite head wrap */
+    int16_t out[4];
+    thinkpack_audio_ring_read(&ring, out, 4);
+    TEST_ASSERT_EQUAL(3, out[0]);
+    TEST_ASSERT_EQUAL(4, out[1]);
+    TEST_ASSERT_EQUAL(5, out[2]);
+    TEST_ASSERT_EQUAL(6, out[3]);
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_ring_used(&ring));
+}
+
+static void test_ring_reset_drops_content(void)
+{
+    int16_t storage[4];
+    thinkpack_audio_ring_t ring;
+    thinkpack_audio_ring_init(&ring, storage, 4);
+
+    int16_t in[] = {7, 8, 9};
+    thinkpack_audio_ring_write(&ring, in, 3);
+    thinkpack_audio_ring_reset(&ring);
+
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_ring_used(&ring));
+    TEST_ASSERT_EQUAL(4, thinkpack_audio_ring_free(&ring));
+
+    int16_t out[4];
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_ring_read(&ring, out, 4));
+}
+
+/* ------------------------------------------------------------------ */
+/* Pitch-shift resampler                                               */
+/* ------------------------------------------------------------------ */
+
+static void test_pitch_shift_zero_passes_through(void)
+{
+    int16_t in[] = {1, 2, 3, 4, 5, 6};
+    int16_t out[6] = {0};
+    size_t n = thinkpack_audio_pitch_shift(in, 6, 0, out, 6);
+    TEST_ASSERT_EQUAL(6, n);
+    for (size_t i = 0; i < 6; i++) {
+        TEST_ASSERT_EQUAL(in[i], out[i]);
+    }
+}
+
+static void test_pitch_shift_octave_up_halves_output(void)
+{
+    int16_t in[8];
+    for (int i = 0; i < 8; i++)
+        in[i] = (int16_t)i;
+
+    int16_t out[8] = {0};
+    size_t n = thinkpack_audio_pitch_shift(in, 8, +12, out, 8);
+    /* Octave up: ratio = 2, consumes input twice as fast.  From 8 input
+     * samples we should emit 4 output samples before exhausting input. */
+    TEST_ASSERT_EQUAL(4, n);
+    TEST_ASSERT_EQUAL(0, out[0]);
+    TEST_ASSERT_EQUAL(2, out[1]);
+    TEST_ASSERT_EQUAL(4, out[2]);
+    TEST_ASSERT_EQUAL(6, out[3]);
+}
+
+static void test_pitch_shift_octave_down_doubles_output(void)
+{
+    int16_t in[4] = {10, 20, 30, 40};
+    int16_t out[8] = {0};
+    size_t n = thinkpack_audio_pitch_shift(in, 4, -12, out, 8);
+    /* Octave down: ratio = 0.5, each input sample emits two copies. */
+    TEST_ASSERT_EQUAL(8, n);
+    TEST_ASSERT_EQUAL(10, out[0]);
+    TEST_ASSERT_EQUAL(10, out[1]);
+    TEST_ASSERT_EQUAL(20, out[2]);
+    TEST_ASSERT_EQUAL(20, out[3]);
+    TEST_ASSERT_EQUAL(40, out[6]);
+    TEST_ASSERT_EQUAL(40, out[7]);
+}
+
+static void test_pitch_shift_respects_out_capacity(void)
+{
+    int16_t in[16];
+    for (int i = 0; i < 16; i++)
+        in[i] = (int16_t)(100 + i);
+    int16_t out[4] = {0};
+    size_t n = thinkpack_audio_pitch_shift(in, 16, -12, out, 4);
+    TEST_ASSERT_EQUAL(4, n);
+}
+
+static void test_pitch_shift_clamps_extreme_shift(void)
+{
+    int16_t in[4] = {1, 2, 3, 4};
+    int16_t out1[4] = {0};
+    int16_t out2[4] = {0};
+    size_t a = thinkpack_audio_pitch_shift(in, 4, +40, out1, 4);
+    size_t b = thinkpack_audio_pitch_shift(in, 4, +12, out2, 4);
+    TEST_ASSERT_EQUAL(b, a);
+    TEST_ASSERT_EQUAL_MEMORY(out2, out1, sizeof(out1));
+}
+
+static void test_pitch_shift_handles_empty_inputs(void)
+{
+    int16_t out[4] = {0};
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_pitch_shift(NULL, 0, 0, out, 4));
+
+    int16_t in[1] = {1};
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_pitch_shift(in, 1, 0, NULL, 0));
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_pitch_shift(in, 0, 0, out, 4));
+    TEST_ASSERT_EQUAL(0, thinkpack_audio_pitch_shift(in, 1, 0, out, 0));
+}
+
+/* ------------------------------------------------------------------ */
+/* State machine                                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_sm_initial_state(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_IDLE, sm.state);
+    TEST_ASSERT_EQUAL(0, sm.recorded_samples);
+}
+
+static void test_sm_happy_path_record_play_done(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_RECORDING,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START));
+    thinkpack_audio_sm_add_samples(&sm, 8000);
+    TEST_ASSERT_EQUAL(8000, sm.recorded_samples);
+
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_PLAYING,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_END));
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_IDLE,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_CLIP_DONE));
+}
+
+static void test_sm_empty_recording_returns_to_idle(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START);
+    /* No samples recorded */
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_IDLE,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_END));
+}
+
+static void test_sm_limit_reached_forces_playback(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START);
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_PLAYING,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_LIMIT_REACHED));
+}
+
+static void test_sm_cancel_during_recording(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START);
+    thinkpack_audio_sm_add_samples(&sm, 4000);
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_IDLE,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_CANCEL));
+    TEST_ASSERT_EQUAL(0, sm.recorded_samples);
+}
+
+static void test_sm_retrigger_during_playback(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START);
+    thinkpack_audio_sm_add_samples(&sm, 1234);
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_END);
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_PLAYING, sm.state);
+
+    TEST_ASSERT_EQUAL(THINKPACK_AUDIO_STATE_RECORDING,
+                      thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START));
+    TEST_ASSERT_EQUAL(0, sm.recorded_samples);
+}
+
+static void test_sm_add_samples_only_in_recording(void)
+{
+    thinkpack_audio_sm_t sm;
+    thinkpack_audio_sm_init(&sm);
+    /* IDLE: add_samples is a no-op */
+    thinkpack_audio_sm_add_samples(&sm, 999);
+    TEST_ASSERT_EQUAL(0, sm.recorded_samples);
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_TOUCH_START);
+    thinkpack_audio_sm_add_samples(&sm, 100);
+    thinkpack_audio_sm_handle(&sm, THINKPACK_AUDIO_EVENT_LIMIT_REACHED);
+    /* PLAYING: add_samples is a no-op */
+    thinkpack_audio_sm_add_samples(&sm, 999);
+    TEST_ASSERT_EQUAL(100, sm.recorded_samples);
+}
+
+/* ------------------------------------------------------------------ */
+/* Test runner                                                         */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_volume_cap_scales_samples);
+    RUN_TEST(test_volume_cap_handles_null_and_zero);
+
+    RUN_TEST(test_ring_basic_write_read);
+    RUN_TEST(test_ring_write_full_rejects_overflow);
+    RUN_TEST(test_ring_wraparound);
+    RUN_TEST(test_ring_reset_drops_content);
+
+    RUN_TEST(test_pitch_shift_zero_passes_through);
+    RUN_TEST(test_pitch_shift_octave_up_halves_output);
+    RUN_TEST(test_pitch_shift_octave_down_doubles_output);
+    RUN_TEST(test_pitch_shift_respects_out_capacity);
+    RUN_TEST(test_pitch_shift_clamps_extreme_shift);
+    RUN_TEST(test_pitch_shift_handles_empty_inputs);
+
+    RUN_TEST(test_sm_initial_state);
+    RUN_TEST(test_sm_happy_path_record_play_done);
+    RUN_TEST(test_sm_empty_recording_returns_to_idle);
+    RUN_TEST(test_sm_limit_reached_forces_playback);
+    RUN_TEST(test_sm_cancel_during_recording);
+    RUN_TEST(test_sm_retrigger_during_playback);
+    RUN_TEST(test_sm_add_samples_only_in_recording);
+
+    int failures = UNITY_END();
+    return failures == 0 ? 0 : 1;
+}

--- a/packages/components/thinkpack-audio/thinkpack_audio.c
+++ b/packages/components/thinkpack-audio/thinkpack_audio.c
@@ -1,0 +1,209 @@
+/**
+ * @file thinkpack_audio.c
+ * @brief Implementation of thinkpack-audio (pure logic: no ESP-IDF deps).
+ */
+
+#include "thinkpack_audio.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Volume cap                                                          */
+/* ------------------------------------------------------------------ */
+
+void thinkpack_audio_apply_volume_cap(int16_t *samples, size_t sample_count)
+{
+    if (samples == NULL || sample_count == 0) {
+        return;
+    }
+    for (size_t i = 0; i < sample_count; i++) {
+        int32_t scaled = (int32_t)samples[i] * THINKPACK_AUDIO_VOLUME_SCALE_NUM /
+                         THINKPACK_AUDIO_VOLUME_SCALE_DEN;
+        if (scaled > INT16_MAX) {
+            scaled = INT16_MAX;
+        } else if (scaled < INT16_MIN) {
+            scaled = INT16_MIN;
+        }
+        samples[i] = (int16_t)scaled;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Ring buffer                                                         */
+/* ------------------------------------------------------------------ */
+
+void thinkpack_audio_ring_init(thinkpack_audio_ring_t *ring, int16_t *buffer, size_t capacity)
+{
+    ring->buffer = buffer;
+    ring->capacity = capacity;
+    ring->head = 0;
+    ring->tail = 0;
+    ring->count = 0;
+}
+
+void thinkpack_audio_ring_reset(thinkpack_audio_ring_t *ring)
+{
+    ring->head = 0;
+    ring->tail = 0;
+    ring->count = 0;
+}
+
+size_t thinkpack_audio_ring_used(const thinkpack_audio_ring_t *ring)
+{
+    return ring->count;
+}
+
+size_t thinkpack_audio_ring_free(const thinkpack_audio_ring_t *ring)
+{
+    return ring->capacity - ring->count;
+}
+
+size_t thinkpack_audio_ring_write(thinkpack_audio_ring_t *ring, const int16_t *samples,
+                                  size_t count)
+{
+    if (ring->buffer == NULL || ring->capacity == 0) {
+        return 0;
+    }
+    size_t free_space = ring->capacity - ring->count;
+    size_t to_write = (count < free_space) ? count : free_space;
+    for (size_t i = 0; i < to_write; i++) {
+        ring->buffer[ring->head] = samples[i];
+        ring->head = (ring->head + 1) % ring->capacity;
+    }
+    ring->count += to_write;
+    return to_write;
+}
+
+size_t thinkpack_audio_ring_read(thinkpack_audio_ring_t *ring, int16_t *out, size_t count)
+{
+    if (ring->buffer == NULL || ring->capacity == 0) {
+        return 0;
+    }
+    size_t to_read = (count < ring->count) ? count : ring->count;
+    for (size_t i = 0; i < to_read; i++) {
+        out[i] = ring->buffer[ring->tail];
+        ring->tail = (ring->tail + 1) % ring->capacity;
+    }
+    ring->count -= to_read;
+    return to_read;
+}
+
+/* ------------------------------------------------------------------ */
+/* Pitch-shift resampler                                               */
+/* ------------------------------------------------------------------ */
+
+/* Q16.16 ratio table for semitones -12..+12.
+ * ratio = 2^(n/12), stored as round(ratio * 65536).
+ * For positive shift, output advances through input faster → pitch up.
+ */
+static const uint32_t k_pitch_ratio_q16[] = {
+    32768,  /* -12 */
+    34716,  /* -11 */
+    36780,  /* -10 */
+    38967,  /* -9  */
+    41285,  /* -8  */
+    43740,  /* -7  */
+    46341,  /* -6  */
+    49097,  /* -5  */
+    52016,  /* -4  */
+    55109,  /* -3  */
+    58386,  /* -2  */
+    61858,  /* -1  */
+    65536,  /* 0   */
+    69433,  /* +1  */
+    73562,  /* +2  */
+    77936,  /* +3  */
+    82570,  /* +4  */
+    87480,  /* +5  */
+    92682,  /* +6  */
+    98193,  /* +7  */
+    104032, /* +8  */
+    110218, /* +9  */
+    116772, /* +10 */
+    123715, /* +11 */
+    131072, /* +12 */
+};
+
+size_t thinkpack_audio_pitch_shift(const int16_t *in, size_t in_samples, int8_t semitone_shift,
+                                   int16_t *out, size_t out_capacity)
+{
+    if (in == NULL || out == NULL || in_samples == 0 || out_capacity == 0) {
+        return 0;
+    }
+    if (semitone_shift < THINKPACK_AUDIO_PITCH_MIN_SEMITONES) {
+        semitone_shift = THINKPACK_AUDIO_PITCH_MIN_SEMITONES;
+    }
+    if (semitone_shift > THINKPACK_AUDIO_PITCH_MAX_SEMITONES) {
+        semitone_shift = THINKPACK_AUDIO_PITCH_MAX_SEMITONES;
+    }
+    int index = (int)semitone_shift - THINKPACK_AUDIO_PITCH_MIN_SEMITONES;
+    uint32_t ratio_q16 = k_pitch_ratio_q16[index];
+
+    /* accumulator counts input-sample offsets in Q16.16.
+     * For each output sample we read input[acc >> 16] then advance by ratio_q16. */
+    uint32_t acc = 0;
+    size_t produced = 0;
+    while (produced < out_capacity) {
+        size_t idx = (size_t)(acc >> 16);
+        if (idx >= in_samples) {
+            break;
+        }
+        out[produced++] = in[idx];
+        acc += ratio_q16;
+    }
+    return produced;
+}
+
+/* ------------------------------------------------------------------ */
+/* Record/playback state machine                                       */
+/* ------------------------------------------------------------------ */
+
+void thinkpack_audio_sm_init(thinkpack_audio_sm_t *sm)
+{
+    sm->state = THINKPACK_AUDIO_STATE_IDLE;
+    sm->recorded_samples = 0;
+}
+
+thinkpack_audio_state_t thinkpack_audio_sm_handle(thinkpack_audio_sm_t *sm,
+                                                  thinkpack_audio_event_t ev)
+{
+    switch (sm->state) {
+        case THINKPACK_AUDIO_STATE_IDLE:
+            if (ev == THINKPACK_AUDIO_EVENT_TOUCH_START) {
+                sm->state = THINKPACK_AUDIO_STATE_RECORDING;
+                sm->recorded_samples = 0;
+            }
+            break;
+
+        case THINKPACK_AUDIO_STATE_RECORDING:
+            if (ev == THINKPACK_AUDIO_EVENT_TOUCH_END) {
+                sm->state = (sm->recorded_samples > 0) ? THINKPACK_AUDIO_STATE_PLAYING
+                                                       : THINKPACK_AUDIO_STATE_IDLE;
+            } else if (ev == THINKPACK_AUDIO_EVENT_LIMIT_REACHED) {
+                sm->state = THINKPACK_AUDIO_STATE_PLAYING;
+            } else if (ev == THINKPACK_AUDIO_EVENT_CANCEL) {
+                sm->state = THINKPACK_AUDIO_STATE_IDLE;
+                sm->recorded_samples = 0;
+            }
+            break;
+
+        case THINKPACK_AUDIO_STATE_PLAYING:
+            if (ev == THINKPACK_AUDIO_EVENT_CLIP_DONE || ev == THINKPACK_AUDIO_EVENT_CANCEL) {
+                sm->state = THINKPACK_AUDIO_STATE_IDLE;
+            } else if (ev == THINKPACK_AUDIO_EVENT_TOUCH_START) {
+                sm->state = THINKPACK_AUDIO_STATE_RECORDING;
+                sm->recorded_samples = 0;
+            }
+            break;
+    }
+    return sm->state;
+}
+
+void thinkpack_audio_sm_add_samples(thinkpack_audio_sm_t *sm, uint32_t n)
+{
+    if (sm->state == THINKPACK_AUDIO_STATE_RECORDING) {
+        sm->recorded_samples += n;
+    }
+}

--- a/packages/components/thinkpack-nfc/CMakeLists.txt
+++ b/packages/components/thinkpack-nfc/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(SRCS "thinkpack_nfc.c"
+                    INCLUDE_DIRS "include"
+                    REQUIRES log)

--- a/packages/components/thinkpack-nfc/include/thinkpack_nfc.h
+++ b/packages/components/thinkpack-nfc/include/thinkpack_nfc.h
@@ -1,0 +1,143 @@
+/**
+ * @file thinkpack_nfc.h
+ * @brief Pure-logic NFC tag registry for ThinkPack Finderbox.
+ *
+ * Maps NFC UID bytes to behaviour labels and parameters, and provides
+ * a compact blob (de)serialiser suitable for the ESP32 NVS blob API.
+ *
+ * No ESP-IDF dependencies — safe to compile on a host with gcc/clang.
+ */
+
+#ifndef THINKPACK_NFC_H
+#define THINKPACK_NFC_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum UID length supported (MIFARE 7-byte UID). */
+#define THINKPACK_NFC_UID_MAX_LEN 7
+
+/** Maximum number of tag entries in a registry. */
+#define THINKPACK_NFC_MAX_TAGS 16
+
+/** Maximum label length including trailing NUL. */
+#define THINKPACK_NFC_LABEL_MAX_LEN 24
+
+/** Blob magic byte: 't' for thinkpack. */
+#define THINKPACK_NFC_BLOB_MAGIC 0x74u
+
+/** Blob format version byte. */
+#define THINKPACK_NFC_BLOB_VERSION 0x01u
+
+/** Named behaviours carried in thinkpack_nfc_entry_t::behavior. */
+typedef enum {
+    THINKPACK_NFC_BEHAVIOR_NONE = 0,
+    THINKPACK_NFC_BEHAVIOR_CHIME = 1, /**< Play chime + LED colour (param = hue) */
+    THINKPACK_NFC_BEHAVIOR_STORY = 2, /**< Trigger LLM story (param = track_id) */
+    THINKPACK_NFC_BEHAVIOR_COLOR = 3, /**< Set global mood colour (param = hue) */
+    THINKPACK_NFC_BEHAVIOR_SEEK = 4,  /**< Hot-Cold seek target (param unused) */
+} thinkpack_nfc_behavior_t;
+
+typedef struct {
+    uint8_t uid[THINKPACK_NFC_UID_MAX_LEN];
+    uint8_t uid_len; /**< Valid length 1..THINKPACK_NFC_UID_MAX_LEN. */
+    uint8_t behavior;
+    uint8_t param;
+    char label[THINKPACK_NFC_LABEL_MAX_LEN];
+} thinkpack_nfc_entry_t;
+
+typedef struct {
+    thinkpack_nfc_entry_t entries[THINKPACK_NFC_MAX_TAGS];
+    uint8_t count;
+} thinkpack_nfc_registry_t;
+
+/* ------------------------------------------------------------------ */
+/* UID helpers                                                         */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Copy @p src into @p dst, clamping to THINKPACK_NFC_UID_MAX_LEN.
+ *
+ * Unused trailing bytes in @p dst are zero-filled.  If @p src_len
+ * exceeds the max, only the first MAX bytes are copied and dst_len is
+ * set to MAX.
+ */
+void thinkpack_nfc_normalize_uid(const uint8_t *src, uint8_t src_len, uint8_t *dst,
+                                 uint8_t *dst_len);
+
+/** True if UIDs compare equal byte-for-byte (same length required). */
+bool thinkpack_nfc_uid_equals(const uint8_t *a, uint8_t a_len, const uint8_t *b, uint8_t b_len);
+
+/* ------------------------------------------------------------------ */
+/* Registry operations                                                 */
+/* ------------------------------------------------------------------ */
+
+/** Reset @p reg to zero entries. */
+void thinkpack_nfc_registry_init(thinkpack_nfc_registry_t *reg);
+
+/**
+ * @brief Look up an entry by UID.
+ * @return Non-NULL pointer into @p reg if found, NULL otherwise.
+ */
+const thinkpack_nfc_entry_t *thinkpack_nfc_lookup(const thinkpack_nfc_registry_t *reg,
+                                                  const uint8_t *uid, uint8_t uid_len);
+
+/**
+ * @brief Insert or replace an entry.
+ *
+ * If an entry with the same UID exists it is overwritten in place.
+ * Otherwise the entry is appended; returns false if the registry is
+ * already full.
+ */
+bool thinkpack_nfc_registry_upsert(thinkpack_nfc_registry_t *reg,
+                                   const thinkpack_nfc_entry_t *entry);
+
+/**
+ * @brief Remove an entry by UID.
+ * @return true if an entry was removed.
+ */
+bool thinkpack_nfc_registry_remove(thinkpack_nfc_registry_t *reg, const uint8_t *uid,
+                                   uint8_t uid_len);
+
+/* ------------------------------------------------------------------ */
+/* NVS blob format                                                     */
+/* ------------------------------------------------------------------ */
+
+/** Exact size of a serialised registry in bytes. */
+#define THINKPACK_NFC_BLOB_HEADER_SIZE 3
+#define THINKPACK_NFC_BLOB_ENTRY_SIZE \
+    (1 + THINKPACK_NFC_UID_MAX_LEN + 1 + 1 + THINKPACK_NFC_LABEL_MAX_LEN)
+#define THINKPACK_NFC_BLOB_MAX_SIZE \
+    (THINKPACK_NFC_BLOB_HEADER_SIZE + (THINKPACK_NFC_MAX_TAGS * THINKPACK_NFC_BLOB_ENTRY_SIZE))
+
+/**
+ * @brief Serialise @p reg to a flat byte buffer.
+ *
+ * Layout: [magic][version][count] then count×entry.
+ * Each entry: [uid_len][uid[7]][behavior][param][label[24]].
+ *
+ * @return Number of bytes written, or 0 if @p buf is NULL or too small.
+ */
+size_t thinkpack_nfc_registry_serialize(const thinkpack_nfc_registry_t *reg, uint8_t *buf,
+                                        size_t buf_len);
+
+/**
+ * @brief Deserialise a blob into @p reg.
+ *
+ * Validates magic, version, and declared entry count.
+ *
+ * @return true on success, false on format error.
+ */
+bool thinkpack_nfc_registry_deserialize(thinkpack_nfc_registry_t *reg, const uint8_t *buf,
+                                        size_t buf_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* THINKPACK_NFC_H */

--- a/packages/components/thinkpack-nfc/test/Makefile
+++ b/packages/components/thinkpack-nfc/test/Makefile
@@ -1,0 +1,32 @@
+# Makefile for thinkpack-nfc host-based unit tests.
+#
+# Compiles thinkpack_nfc.c on the host with gcc.  Reuses the shared stubs
+# and unity_compat.h from packages/components/thinkpack-behaviors/test.
+#
+# Usage:
+#   make test
+#   make clean
+
+CC     = gcc
+CFLAGS = -std=c11 -Wall -Wextra \
+         -I../include \
+         -I../../thinkpack-behaviors/test \
+         -I../../thinkpack-behaviors/test/stubs
+
+SRCS   = test_nfc.c \
+         ../thinkpack_nfc.c
+
+TARGET = test_runner
+
+.PHONY: all test clean
+
+all: test
+
+test: $(TARGET)
+	./$(TARGET)
+
+$(TARGET): $(SRCS)
+	$(CC) $(CFLAGS) -o $@ $(SRCS)
+
+clean:
+	rm -f $(TARGET)

--- a/packages/components/thinkpack-nfc/test/test_nfc.c
+++ b/packages/components/thinkpack-nfc/test/test_nfc.c
@@ -1,0 +1,280 @@
+/**
+ * @file test_nfc.c
+ * @brief Host-based unit tests for thinkpack-nfc.
+ */
+
+#include <string.h>
+
+#include "thinkpack_nfc.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* UID helpers                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_normalize_short_uid_zero_pads(void)
+{
+    const uint8_t in[] = {0xAA, 0xBB, 0xCC, 0xDD};
+    uint8_t out[THINKPACK_NFC_UID_MAX_LEN];
+    uint8_t out_len = 0xFF;
+    thinkpack_nfc_normalize_uid(in, 4, out, &out_len);
+
+    TEST_ASSERT_EQUAL(4, out_len);
+    TEST_ASSERT_EQUAL(0xAA, out[0]);
+    TEST_ASSERT_EQUAL(0xBB, out[1]);
+    TEST_ASSERT_EQUAL(0xCC, out[2]);
+    TEST_ASSERT_EQUAL(0xDD, out[3]);
+    TEST_ASSERT_EQUAL(0x00, out[4]);
+    TEST_ASSERT_EQUAL(0x00, out[5]);
+    TEST_ASSERT_EQUAL(0x00, out[6]);
+}
+
+static void test_normalize_clamps_oversize_uid(void)
+{
+    const uint8_t in[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    uint8_t out[THINKPACK_NFC_UID_MAX_LEN];
+    uint8_t out_len = 0;
+    thinkpack_nfc_normalize_uid(in, 10, out, &out_len);
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_UID_MAX_LEN, out_len);
+    TEST_ASSERT_EQUAL(1, out[0]);
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_UID_MAX_LEN, out[THINKPACK_NFC_UID_MAX_LEN - 1]);
+}
+
+static void test_uid_equals(void)
+{
+    const uint8_t a[] = {1, 2, 3, 4};
+    const uint8_t b[] = {1, 2, 3, 4};
+    const uint8_t c[] = {1, 2, 3, 5};
+    TEST_ASSERT_TRUE(thinkpack_nfc_uid_equals(a, 4, b, 4));
+    TEST_ASSERT_FALSE(thinkpack_nfc_uid_equals(a, 4, c, 4));
+    TEST_ASSERT_FALSE(thinkpack_nfc_uid_equals(a, 4, b, 3)); /* length mismatch */
+}
+
+/* ------------------------------------------------------------------ */
+/* Registry                                                            */
+/* ------------------------------------------------------------------ */
+
+static thinkpack_nfc_entry_t make_entry(uint8_t seed, const char *label, thinkpack_nfc_behavior_t b,
+                                        uint8_t param)
+{
+    thinkpack_nfc_entry_t e;
+    memset(&e, 0, sizeof(e));
+    for (uint8_t i = 0; i < THINKPACK_NFC_UID_MAX_LEN; i++) {
+        e.uid[i] = seed + i;
+    }
+    e.uid_len = THINKPACK_NFC_UID_MAX_LEN;
+    e.behavior = (uint8_t)b;
+    e.param = param;
+    strncpy(e.label, label, THINKPACK_NFC_LABEL_MAX_LEN - 1);
+    return e;
+}
+
+static void test_registry_empty_lookup_returns_null(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+    const uint8_t uid[] = {1, 2, 3, 4, 5, 6, 7};
+    TEST_ASSERT_NULL(thinkpack_nfc_lookup(&reg, uid, 7));
+}
+
+static void test_registry_upsert_and_lookup(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+
+    thinkpack_nfc_entry_t e = make_entry(0x10, "dinosaur", THINKPACK_NFC_BEHAVIOR_STORY, 3);
+    TEST_ASSERT_TRUE(thinkpack_nfc_registry_upsert(&reg, &e));
+    TEST_ASSERT_EQUAL(1, reg.count);
+
+    const thinkpack_nfc_entry_t *got = thinkpack_nfc_lookup(&reg, e.uid, e.uid_len);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQUAL_STRING("dinosaur", got->label);
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_BEHAVIOR_STORY, got->behavior);
+    TEST_ASSERT_EQUAL(3, got->param);
+}
+
+static void test_registry_upsert_overwrites_existing(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+
+    thinkpack_nfc_entry_t a = make_entry(0x20, "dino", THINKPACK_NFC_BEHAVIOR_CHIME, 10);
+    thinkpack_nfc_entry_t b = make_entry(0x20, "t-rex", THINKPACK_NFC_BEHAVIOR_STORY, 99);
+    TEST_ASSERT_TRUE(thinkpack_nfc_registry_upsert(&reg, &a));
+    TEST_ASSERT_TRUE(thinkpack_nfc_registry_upsert(&reg, &b));
+    TEST_ASSERT_EQUAL(1, reg.count);
+
+    const thinkpack_nfc_entry_t *got = thinkpack_nfc_lookup(&reg, a.uid, a.uid_len);
+    TEST_ASSERT_NOT_NULL(got);
+    TEST_ASSERT_EQUAL_STRING("t-rex", got->label);
+    TEST_ASSERT_EQUAL(99, got->param);
+}
+
+static void test_registry_upsert_rejects_when_full(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+
+    for (int i = 0; i < THINKPACK_NFC_MAX_TAGS; i++) {
+        thinkpack_nfc_entry_t e =
+            make_entry((uint8_t)(0x30 + i), "x", THINKPACK_NFC_BEHAVIOR_CHIME, (uint8_t)i);
+        TEST_ASSERT_TRUE(thinkpack_nfc_registry_upsert(&reg, &e));
+    }
+    thinkpack_nfc_entry_t extra = make_entry(0xFE, "extra", THINKPACK_NFC_BEHAVIOR_STORY, 0);
+    TEST_ASSERT_FALSE(thinkpack_nfc_registry_upsert(&reg, &extra));
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_MAX_TAGS, reg.count);
+}
+
+static void test_registry_remove(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+
+    thinkpack_nfc_entry_t a = make_entry(0x40, "a", THINKPACK_NFC_BEHAVIOR_CHIME, 1);
+    thinkpack_nfc_entry_t b = make_entry(0x50, "b", THINKPACK_NFC_BEHAVIOR_STORY, 2);
+    thinkpack_nfc_entry_t c = make_entry(0x60, "c", THINKPACK_NFC_BEHAVIOR_COLOR, 3);
+    thinkpack_nfc_registry_upsert(&reg, &a);
+    thinkpack_nfc_registry_upsert(&reg, &b);
+    thinkpack_nfc_registry_upsert(&reg, &c);
+
+    TEST_ASSERT_TRUE(thinkpack_nfc_registry_remove(&reg, b.uid, b.uid_len));
+    TEST_ASSERT_EQUAL(2, reg.count);
+    TEST_ASSERT_NULL(thinkpack_nfc_lookup(&reg, b.uid, b.uid_len));
+    /* a and c must survive */
+    TEST_ASSERT_NOT_NULL(thinkpack_nfc_lookup(&reg, a.uid, a.uid_len));
+    TEST_ASSERT_NOT_NULL(thinkpack_nfc_lookup(&reg, c.uid, c.uid_len));
+
+    /* Removing missing UID returns false */
+    TEST_ASSERT_FALSE(thinkpack_nfc_registry_remove(&reg, b.uid, b.uid_len));
+}
+
+/* ------------------------------------------------------------------ */
+/* NVS blob round-trip                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_blob_round_trip(void)
+{
+    thinkpack_nfc_registry_t src;
+    thinkpack_nfc_registry_init(&src);
+
+    thinkpack_nfc_entry_t a = make_entry(0x70, "red-bird", THINKPACK_NFC_BEHAVIOR_CHIME, 200);
+    thinkpack_nfc_entry_t b = make_entry(0x80, "purple-whale", THINKPACK_NFC_BEHAVIOR_STORY, 5);
+    thinkpack_nfc_registry_upsert(&src, &a);
+    thinkpack_nfc_registry_upsert(&src, &b);
+
+    uint8_t buf[THINKPACK_NFC_BLOB_MAX_SIZE];
+    size_t n = thinkpack_nfc_registry_serialize(&src, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_BLOB_HEADER_SIZE + 2 * THINKPACK_NFC_BLOB_ENTRY_SIZE, n);
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_BLOB_MAGIC, buf[0]);
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_BLOB_VERSION, buf[1]);
+    TEST_ASSERT_EQUAL(2, buf[2]);
+
+    thinkpack_nfc_registry_t dst;
+    TEST_ASSERT_TRUE(thinkpack_nfc_registry_deserialize(&dst, buf, n));
+    TEST_ASSERT_EQUAL(2, dst.count);
+
+    const thinkpack_nfc_entry_t *got_a = thinkpack_nfc_lookup(&dst, a.uid, a.uid_len);
+    TEST_ASSERT_NOT_NULL(got_a);
+    TEST_ASSERT_EQUAL_STRING("red-bird", got_a->label);
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_BEHAVIOR_CHIME, got_a->behavior);
+    TEST_ASSERT_EQUAL(200, got_a->param);
+
+    const thinkpack_nfc_entry_t *got_b = thinkpack_nfc_lookup(&dst, b.uid, b.uid_len);
+    TEST_ASSERT_NOT_NULL(got_b);
+    TEST_ASSERT_EQUAL_STRING("purple-whale", got_b->label);
+}
+
+static void test_blob_serialize_rejects_small_buffer(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+    thinkpack_nfc_entry_t e = make_entry(0x90, "x", THINKPACK_NFC_BEHAVIOR_NONE, 0);
+    thinkpack_nfc_registry_upsert(&reg, &e);
+
+    uint8_t buf[4]; /* too small */
+    TEST_ASSERT_EQUAL(0, thinkpack_nfc_registry_serialize(&reg, buf, sizeof(buf)));
+}
+
+static void test_blob_deserialize_rejects_bad_magic(void)
+{
+    uint8_t buf[THINKPACK_NFC_BLOB_HEADER_SIZE] = {0x00, THINKPACK_NFC_BLOB_VERSION, 0};
+    thinkpack_nfc_registry_t dst;
+    TEST_ASSERT_FALSE(thinkpack_nfc_registry_deserialize(&dst, buf, sizeof(buf)));
+}
+
+static void test_blob_deserialize_rejects_bad_version(void)
+{
+    uint8_t buf[THINKPACK_NFC_BLOB_HEADER_SIZE] = {THINKPACK_NFC_BLOB_MAGIC, 0xFF, 0};
+    thinkpack_nfc_registry_t dst;
+    TEST_ASSERT_FALSE(thinkpack_nfc_registry_deserialize(&dst, buf, sizeof(buf)));
+}
+
+static void test_blob_deserialize_rejects_oversize_count(void)
+{
+    uint8_t buf[THINKPACK_NFC_BLOB_HEADER_SIZE] = {
+        THINKPACK_NFC_BLOB_MAGIC, THINKPACK_NFC_BLOB_VERSION, THINKPACK_NFC_MAX_TAGS + 1};
+    thinkpack_nfc_registry_t dst;
+    TEST_ASSERT_FALSE(thinkpack_nfc_registry_deserialize(&dst, buf, sizeof(buf)));
+}
+
+static void test_blob_deserialize_rejects_truncated(void)
+{
+    thinkpack_nfc_registry_t reg;
+    thinkpack_nfc_registry_init(&reg);
+    thinkpack_nfc_entry_t a = make_entry(0xA0, "a", THINKPACK_NFC_BEHAVIOR_CHIME, 1);
+    thinkpack_nfc_entry_t b = make_entry(0xB0, "b", THINKPACK_NFC_BEHAVIOR_STORY, 2);
+    thinkpack_nfc_registry_upsert(&reg, &a);
+    thinkpack_nfc_registry_upsert(&reg, &b);
+
+    uint8_t buf[THINKPACK_NFC_BLOB_MAX_SIZE];
+    size_t n = thinkpack_nfc_registry_serialize(&reg, buf, sizeof(buf));
+    TEST_ASSERT_TRUE(n > 0);
+
+    thinkpack_nfc_registry_t dst;
+    /* Cut the last entry off */
+    TEST_ASSERT_FALSE(thinkpack_nfc_registry_deserialize(&dst, buf, n - 5));
+}
+
+static void test_blob_empty_registry_round_trip(void)
+{
+    thinkpack_nfc_registry_t src;
+    thinkpack_nfc_registry_init(&src);
+
+    uint8_t buf[THINKPACK_NFC_BLOB_MAX_SIZE];
+    size_t n = thinkpack_nfc_registry_serialize(&src, buf, sizeof(buf));
+    TEST_ASSERT_EQUAL(THINKPACK_NFC_BLOB_HEADER_SIZE, n);
+
+    thinkpack_nfc_registry_t dst;
+    TEST_ASSERT_TRUE(thinkpack_nfc_registry_deserialize(&dst, buf, n));
+    TEST_ASSERT_EQUAL(0, dst.count);
+}
+
+/* ------------------------------------------------------------------ */
+/* Test runner                                                         */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_normalize_short_uid_zero_pads);
+    RUN_TEST(test_normalize_clamps_oversize_uid);
+    RUN_TEST(test_uid_equals);
+
+    RUN_TEST(test_registry_empty_lookup_returns_null);
+    RUN_TEST(test_registry_upsert_and_lookup);
+    RUN_TEST(test_registry_upsert_overwrites_existing);
+    RUN_TEST(test_registry_upsert_rejects_when_full);
+    RUN_TEST(test_registry_remove);
+
+    RUN_TEST(test_blob_round_trip);
+    RUN_TEST(test_blob_serialize_rejects_small_buffer);
+    RUN_TEST(test_blob_deserialize_rejects_bad_magic);
+    RUN_TEST(test_blob_deserialize_rejects_bad_version);
+    RUN_TEST(test_blob_deserialize_rejects_oversize_count);
+    RUN_TEST(test_blob_deserialize_rejects_truncated);
+    RUN_TEST(test_blob_empty_registry_round_trip);
+
+    int failures = UNITY_END();
+    return failures == 0 ? 0 : 1;
+}

--- a/packages/components/thinkpack-nfc/thinkpack_nfc.c
+++ b/packages/components/thinkpack-nfc/thinkpack_nfc.c
@@ -1,0 +1,189 @@
+/**
+ * @file thinkpack_nfc.c
+ * @brief Implementation of the thinkpack-nfc pure-logic component.
+ */
+
+#include "thinkpack_nfc.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* UID helpers                                                         */
+/* ------------------------------------------------------------------ */
+
+void thinkpack_nfc_normalize_uid(const uint8_t *src, uint8_t src_len, uint8_t *dst,
+                                 uint8_t *dst_len)
+{
+    if (dst == NULL || dst_len == NULL) {
+        return;
+    }
+
+    uint8_t n = (src_len > THINKPACK_NFC_UID_MAX_LEN) ? THINKPACK_NFC_UID_MAX_LEN : src_len;
+    memset(dst, 0, THINKPACK_NFC_UID_MAX_LEN);
+    if (src != NULL && n > 0) {
+        memcpy(dst, src, n);
+    }
+    *dst_len = n;
+}
+
+bool thinkpack_nfc_uid_equals(const uint8_t *a, uint8_t a_len, const uint8_t *b, uint8_t b_len)
+{
+    if (a_len != b_len) {
+        return false;
+    }
+    if (a == NULL || b == NULL) {
+        return false;
+    }
+    return memcmp(a, b, a_len) == 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Registry operations                                                 */
+/* ------------------------------------------------------------------ */
+
+void thinkpack_nfc_registry_init(thinkpack_nfc_registry_t *reg)
+{
+    memset(reg, 0, sizeof(*reg));
+}
+
+const thinkpack_nfc_entry_t *thinkpack_nfc_lookup(const thinkpack_nfc_registry_t *reg,
+                                                  const uint8_t *uid, uint8_t uid_len)
+{
+    if (reg == NULL || uid == NULL) {
+        return NULL;
+    }
+    for (uint8_t i = 0; i < reg->count; i++) {
+        const thinkpack_nfc_entry_t *e = &reg->entries[i];
+        if (thinkpack_nfc_uid_equals(e->uid, e->uid_len, uid, uid_len)) {
+            return e;
+        }
+    }
+    return NULL;
+}
+
+/** Find slot index for a UID, or -1 if not present. */
+static int find_slot(const thinkpack_nfc_registry_t *reg, const uint8_t *uid, uint8_t uid_len)
+{
+    for (uint8_t i = 0; i < reg->count; i++) {
+        const thinkpack_nfc_entry_t *e = &reg->entries[i];
+        if (thinkpack_nfc_uid_equals(e->uid, e->uid_len, uid, uid_len)) {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+bool thinkpack_nfc_registry_upsert(thinkpack_nfc_registry_t *reg,
+                                   const thinkpack_nfc_entry_t *entry)
+{
+    if (reg == NULL || entry == NULL) {
+        return false;
+    }
+    int slot = find_slot(reg, entry->uid, entry->uid_len);
+    if (slot >= 0) {
+        reg->entries[slot] = *entry;
+        return true;
+    }
+    if (reg->count >= THINKPACK_NFC_MAX_TAGS) {
+        return false;
+    }
+    reg->entries[reg->count++] = *entry;
+    return true;
+}
+
+bool thinkpack_nfc_registry_remove(thinkpack_nfc_registry_t *reg, const uint8_t *uid,
+                                   uint8_t uid_len)
+{
+    if (reg == NULL) {
+        return false;
+    }
+    int slot = find_slot(reg, uid, uid_len);
+    if (slot < 0) {
+        return false;
+    }
+    /* Swap-with-last to keep the registry compact. */
+    reg->count--;
+    if ((uint8_t)slot != reg->count) {
+        reg->entries[slot] = reg->entries[reg->count];
+    }
+    memset(&reg->entries[reg->count], 0, sizeof(reg->entries[0]));
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* NVS blob format                                                     */
+/* ------------------------------------------------------------------ */
+
+size_t thinkpack_nfc_registry_serialize(const thinkpack_nfc_registry_t *reg, uint8_t *buf,
+                                        size_t buf_len)
+{
+    if (reg == NULL || buf == NULL) {
+        return 0;
+    }
+    size_t need =
+        THINKPACK_NFC_BLOB_HEADER_SIZE + (size_t)reg->count * THINKPACK_NFC_BLOB_ENTRY_SIZE;
+    if (buf_len < need) {
+        return 0;
+    }
+
+    size_t offset = 0;
+    buf[offset++] = THINKPACK_NFC_BLOB_MAGIC;
+    buf[offset++] = THINKPACK_NFC_BLOB_VERSION;
+    buf[offset++] = reg->count;
+
+    for (uint8_t i = 0; i < reg->count; i++) {
+        const thinkpack_nfc_entry_t *e = &reg->entries[i];
+        buf[offset++] = e->uid_len;
+        memcpy(&buf[offset], e->uid, THINKPACK_NFC_UID_MAX_LEN);
+        offset += THINKPACK_NFC_UID_MAX_LEN;
+        buf[offset++] = e->behavior;
+        buf[offset++] = e->param;
+        memcpy(&buf[offset], e->label, THINKPACK_NFC_LABEL_MAX_LEN);
+        offset += THINKPACK_NFC_LABEL_MAX_LEN;
+    }
+    return offset;
+}
+
+bool thinkpack_nfc_registry_deserialize(thinkpack_nfc_registry_t *reg, const uint8_t *buf,
+                                        size_t buf_len)
+{
+    if (reg == NULL || buf == NULL) {
+        return false;
+    }
+    if (buf_len < THINKPACK_NFC_BLOB_HEADER_SIZE) {
+        return false;
+    }
+    if (buf[0] != THINKPACK_NFC_BLOB_MAGIC) {
+        return false;
+    }
+    if (buf[1] != THINKPACK_NFC_BLOB_VERSION) {
+        return false;
+    }
+    uint8_t count = buf[2];
+    if (count > THINKPACK_NFC_MAX_TAGS) {
+        return false;
+    }
+    size_t need = THINKPACK_NFC_BLOB_HEADER_SIZE + (size_t)count * THINKPACK_NFC_BLOB_ENTRY_SIZE;
+    if (buf_len < need) {
+        return false;
+    }
+
+    thinkpack_nfc_registry_init(reg);
+    size_t offset = THINKPACK_NFC_BLOB_HEADER_SIZE;
+    for (uint8_t i = 0; i < count; i++) {
+        thinkpack_nfc_entry_t *e = &reg->entries[i];
+        e->uid_len = buf[offset++];
+        memcpy(e->uid, &buf[offset], THINKPACK_NFC_UID_MAX_LEN);
+        offset += THINKPACK_NFC_UID_MAX_LEN;
+        e->behavior = buf[offset++];
+        e->param = buf[offset++];
+        memcpy(e->label, &buf[offset], THINKPACK_NFC_LABEL_MAX_LEN);
+        offset += THINKPACK_NFC_LABEL_MAX_LEN;
+        /* Guard against UIDs longer than MAX (corrupt blob). */
+        if (e->uid_len > THINKPACK_NFC_UID_MAX_LEN) {
+            return false;
+        }
+    }
+    reg->count = count;
+    return true;
+}


### PR DESCRIPTION
## Summary

Second of seven PRs completing the ThinkPack epic (#193). Two new host-testable components that lay the groundwork for Chatterbox (#197) and Finderbox (#198):

- **thinkpack-audio** — volume cap, SPSC ring buffer, nearest-neighbor pitch-shift resampler (Q16.16 semitone table), record/playback state machine. Constants locked to 16 kHz mono / 2 s / 32000-sample max clip.
- **thinkpack-nfc** — UID normalisation/comparison, fixed-capacity tag registry, NVS-compatible blob (de)serialiser with magic+version+truncation guards.

Both components reuse the Unity-compat stubs at \`packages/components/thinkpack-behaviors/test/\` so the two new test suites compile with plain \`gcc\` — no ESP-IDF required.

Unblocks PRs C/D/E. No hardware behaviour changes.

## Test plan

- [x] \`cd packages/components/thinkpack-audio/test && make test\` — 74 tests, 0 failures.
- [x] \`cd packages/components/thinkpack-nfc/test && make test\` — 72 tests, 0 failures.
- [x] \`clang-format -n -Werror\` on all new files — clean.
- [ ] CI matrix picks up the new components (no matrix entry needed until firmware consumes them in PR C/D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)