### PR TITLE
feat(thinkpack): PR C — Chatterbox firmware + Echo Chamber behaviour

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,6 +23,7 @@ mod thinkpack-mesh-demo 'packages/thinkpack/mesh-demo'
 mod thinkpack-glowbug 'packages/thinkpack/glowbug'
 mod thinkpack-boombox 'packages/thinkpack/boombox'
 mod thinkpack-brainbox 'packages/thinkpack/brainbox'
+mod thinkpack-chatterbox 'packages/thinkpack/chatterbox'
 
 # Auto-detect ESP32-S3 USB-Serial-JTAG by Espressif VID; override with S3_PORT env var
 s3_port := env("S3_PORT", `tools/detect-esp32s3-port.sh --quiet 2>/dev/null || true`)

--- a/packages/components/thinkpack-behaviors/CMakeLists.txt
+++ b/packages/components/thinkpack-behaviors/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(SRCS "command_dispatcher.c"
                             "command_executor.c"
+                            "echo_chamber.c"
                     INCLUDE_DIRS "include"
                     REQUIRES thinkpack-protocol log esp_common
                     PRIV_REQUIRES freertos)

--- a/packages/components/thinkpack-behaviors/echo_chamber.c
+++ b/packages/components/thinkpack-behaviors/echo_chamber.c
@@ -1,0 +1,124 @@
+/**
+ * @file echo_chamber.c
+ * @brief Echo Chamber behaviour dispatch — builds
+ *        MSG_AUDIO_CLIP_BROADCAST packets.
+ *
+ * Pure logic — no ESP-IDF or hardware dependencies; host-testable.
+ */
+
+#include "echo_chamber.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Compile-time payload size assertion                                 */
+/* ------------------------------------------------------------------ */
+
+_Static_assert(sizeof(audio_clip_broadcast_payload_t) <= THINKPACK_MAX_DATA_LEN,
+               "audio_clip_broadcast_payload_t exceeds packet data limit");
+
+/* ------------------------------------------------------------------ */
+/* Pitch-shift policy                                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Pitch step applied to each successive slot pair.
+ *
+ * Slot 0 stays at 0 (reference).  Odd slots go down in -2 steps; even slots
+ * (>0) go up in +2 steps.  Both directions saturate at the protocol clamps
+ * defined in thinkpack_audio.h (±12 semitones).
+ */
+#define ECHO_CHAMBER_PITCH_STEP 2
+#define ECHO_CHAMBER_PITCH_MIN (-12)
+#define ECHO_CHAMBER_PITCH_MAX (+12)
+
+static int8_t clamp_semitones(int value)
+{
+    if (value < ECHO_CHAMBER_PITCH_MIN) {
+        return (int8_t)ECHO_CHAMBER_PITCH_MIN;
+    }
+    if (value > ECHO_CHAMBER_PITCH_MAX) {
+        return (int8_t)ECHO_CHAMBER_PITCH_MAX;
+    }
+    return (int8_t)value;
+}
+
+static int8_t slot_semitone(uint8_t slot)
+{
+    if (slot == 0) {
+        return 0;
+    }
+    if ((slot & 1u) != 0u) {
+        /* Odd slots: 1 → -2, 3 → -4, 5 → -6 ... */
+        int step = (int)((slot + 1u) / 2u);
+        return clamp_semitones(-(ECHO_CHAMBER_PITCH_STEP * step));
+    }
+    /* Even non-zero slots: 2 → +2, 4 → +4, 6 → +6 ... */
+    int step = (int)(slot / 2u);
+    return clamp_semitones(ECHO_CHAMBER_PITCH_STEP * step);
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+void echo_chamber_compute_pitch_table(uint8_t peer_count, int8_t *table, uint8_t len)
+{
+    if (table == NULL || len == 0u) {
+        return;
+    }
+
+    uint8_t active = peer_count;
+    if (active > len) {
+        active = len;
+    }
+
+    for (uint8_t i = 0; i < active; i++) {
+        table[i] = slot_semitone(i);
+    }
+    for (uint8_t i = active; i < len; i++) {
+        table[i] = 0;
+    }
+}
+
+void echo_chamber_build_payload(audio_clip_broadcast_payload_t *out, uint8_t clip_id,
+                                uint16_t sample_count, uint8_t peer_count)
+{
+    if (out == NULL) {
+        return;
+    }
+
+    memset(out, 0, sizeof(*out));
+    out->clip_id = clip_id;
+
+    /* Clamp sample count to the protocol maximum defined in thinkpack_audio.h
+     * (32000 samples == 2 s @ 16 kHz).  We hardcode the ceiling here to avoid
+     * a compile-time dependency on the audio component from the behaviour
+     * layer. */
+    const uint16_t max_samples = 32000u;
+    out->sample_count = sample_count > max_samples ? max_samples : sample_count;
+
+    echo_chamber_compute_pitch_table(peer_count, out->per_peer_semitone_shift,
+                                     (uint8_t)sizeof(out->per_peer_semitone_shift));
+
+    out->flags = 0u;
+}
+
+void echo_chamber_build_packet(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                               uint8_t clip_id, uint16_t sample_count, uint8_t peer_count)
+{
+    if (p == NULL) {
+        return;
+    }
+
+    audio_clip_broadcast_payload_t payload;
+    echo_chamber_build_payload(&payload, clip_id, sample_count, peer_count);
+
+    memset(p, 0, sizeof(*p));
+    p->msg_type = (uint8_t)MSG_AUDIO_CLIP_BROADCAST;
+    p->sequence_number = seq;
+    memcpy(p->src_mac, src_mac, 6);
+    p->data_length = (uint8_t)sizeof(payload);
+    memcpy(p->data, &payload, sizeof(payload));
+    thinkpack_finalize(p);
+}

--- a/packages/components/thinkpack-behaviors/include/echo_chamber.h
+++ b/packages/components/thinkpack-behaviors/include/echo_chamber.h
@@ -1,0 +1,78 @@
+/**
+ * @file echo_chamber.h
+ * @brief Pure-logic Echo Chamber behaviour dispatch for Chatterbox.
+ *
+ * Composes the per-peer pitch-shift policy and builds a
+ * MSG_AUDIO_CLIP_BROADCAST packet carrying an
+ * audio_clip_broadcast_payload_t.  Transmission over the mesh is the
+ * caller's responsibility — this module only builds the payload and
+ * packet.  No PCM data is touched here; the actual clip is streamed via
+ * thinkpack_mesh_send_large() separately.
+ *
+ * The pitch-shift policy is intentionally small and documented inline:
+ *   slot 0       →  0 semitones (leader / local playback reference)
+ *   odd slots    → -2, -4, -6, … (clamped to PITCH_MIN)
+ *   even slots   → +2, +4, +6, … (clamped to PITCH_MAX)
+ *
+ * This mirrors the "answering call" toy behaviour: each box chirps back
+ * the same clip at a different pitch, giving the impression of an
+ * echo-chamber conversation between the boxes.
+ */
+
+#ifndef ECHO_CHAMBER_H
+#define ECHO_CHAMBER_H
+
+#include <stdint.h>
+
+#include "thinkpack_protocol.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Compute the per-peer pitch-shift table for an echo-chamber broadcast.
+ *
+ * Fills @p table[0 .. len-1] with signed semitone offsets according to the
+ * policy documented above.  Slots beyond @p peer_count are set to 0 to keep
+ * the payload deterministic.
+ *
+ * @param peer_count  Number of peers currently in the mesh (>= 0).  Values
+ *                    greater than @p len are clamped to @p len.
+ * @param table       Output buffer; must be non-NULL if @p len > 0.
+ * @param len         Capacity of @p table in entries.
+ */
+void echo_chamber_compute_pitch_table(uint8_t peer_count, int8_t *table, uint8_t len);
+
+/**
+ * @brief Populate an audio_clip_broadcast_payload_t for the echo-chamber.
+ *
+ * @param out          Payload to fill.  Must not be NULL.
+ * @param clip_id      Monotonically increasing (wraps mod 256) per broadcast.
+ * @param sample_count PCM sample count (clamped to
+ *                     THINKPACK_AUDIO_CLIP_MAX_SAMPLES).
+ * @param peer_count   Number of peers currently in the mesh.
+ */
+void echo_chamber_build_payload(audio_clip_broadcast_payload_t *out, uint8_t clip_id,
+                                uint16_t sample_count, uint8_t peer_count);
+
+/**
+ * @brief Build the full MSG_AUDIO_CLIP_BROADCAST packet ready to send.
+ *
+ * Stamps magic bytes and checksum via thinkpack_finalize().
+ *
+ * @param p            Output packet.  Must not be NULL.
+ * @param seq          Sequence number.
+ * @param src_mac      Sender MAC.
+ * @param clip_id      Broadcast id.
+ * @param sample_count PCM sample count.
+ * @param peer_count   Current peer count.
+ */
+void echo_chamber_build_packet(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
+                               uint8_t clip_id, uint16_t sample_count, uint8_t peer_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ECHO_CHAMBER_H */

--- a/packages/components/thinkpack-behaviors/test/Makefile
+++ b/packages/components/thinkpack-behaviors/test/Makefile
@@ -1,12 +1,14 @@
 # Makefile for thinkpack-behaviors host-based unit tests
 #
-# Compiles command_dispatcher.c and command_executor.c for Linux/macOS using
-# gcc and runs Unity-compatible tests without ESP-IDF or hardware.
-# Suitable for CI and local development.
+# Compiles command_dispatcher.c, command_executor.c, and echo_chamber.c for
+# Linux/macOS using gcc and runs Unity-compatible tests without ESP-IDF or
+# hardware.  Suitable for CI and local development.
 #
 # Usage:
-#   make test     — build and run tests (default)
-#   make clean    — remove build artefacts
+#   make test         — build and run all test binaries (default)
+#   make test_runner  — build/run the commands test binary
+#   make echo_chamber_test_runner — build/run the echo-chamber test binary
+#   make clean        — remove build artefacts
 
 CC     = gcc
 CFLAGS = -std=c11 -Wall -Wextra \
@@ -16,22 +18,32 @@ CFLAGS = -std=c11 -Wall -Wextra \
          -Istubs \
          -I.
 
-SRCS   = test_commands.c \
-         ../command_dispatcher.c \
-         ../command_executor.c \
-         ../../thinkpack-protocol/thinkpack_protocol.c
+COMMON_SRCS   = ../../thinkpack-protocol/thinkpack_protocol.c
 
-TARGET = test_runner
+COMMANDS_SRCS = test_commands.c \
+                ../command_dispatcher.c \
+                ../command_executor.c \
+                $(COMMON_SRCS)
+
+ECHO_SRCS     = echo_chamber_test.c \
+                ../echo_chamber.c \
+                $(COMMON_SRCS)
+
+TARGETS = test_runner echo_chamber_test_runner
 
 .PHONY: all test clean
 
 all: test
 
-test: $(TARGET)
-	./$(TARGET)
+test: $(TARGETS)
+	./test_runner
+	./echo_chamber_test_runner
 
-$(TARGET): $(SRCS) unity_compat.h stubs/esp_log.h stubs/esp_err.h
-	$(CC) $(CFLAGS) -o $@ $(SRCS)
+test_runner: $(COMMANDS_SRCS) unity_compat.h stubs/esp_log.h stubs/esp_err.h
+	$(CC) $(CFLAGS) -o $@ $(COMMANDS_SRCS)
+
+echo_chamber_test_runner: $(ECHO_SRCS) unity_compat.h
+	$(CC) $(CFLAGS) -o $@ $(ECHO_SRCS)
 
 clean:
-	rm -f $(TARGET)
+	rm -f $(TARGETS)

--- a/packages/components/thinkpack-behaviors/test/echo_chamber_test.c
+++ b/packages/components/thinkpack-behaviors/test/echo_chamber_test.c
@@ -1,0 +1,202 @@
+/**
+ * @file echo_chamber_test.c
+ * @brief Host-based unit tests for the echo_chamber behaviour.
+ *
+ * Assertions cover:
+ *   - Pitch-shift distribution across slot indices (0, odd, even).
+ *   - Peer-count edge cases: 0, 1, exactly 8, > 8 (clamped).
+ *   - Payload sizing + clip_id fidelity.
+ *   - Packet construction: magic, checksum, msg_type, data_length.
+ */
+
+#include <string.h>
+
+#include "echo_chamber.h"
+#include "thinkpack_protocol.h"
+#include "unity_compat.h"
+
+static const uint8_t TEST_MAC[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+static const uint8_t TEST_SEQ = 0x7A;
+
+/* ------------------------------------------------------------------ */
+/* Pitch-table policy                                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_pitch_table_zero_peers_is_all_zero(void)
+{
+    int8_t table[8];
+    memset(table, 0x7F, sizeof(table)); /* poison */
+
+    echo_chamber_compute_pitch_table(0, table, 8);
+
+    for (uint8_t i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL(0, table[i]);
+    }
+}
+
+static void test_pitch_table_single_peer_only_slot0(void)
+{
+    int8_t table[8];
+    memset(table, 0x7F, sizeof(table));
+
+    echo_chamber_compute_pitch_table(1, table, 8);
+
+    TEST_ASSERT_EQUAL(0, table[0]);
+    for (uint8_t i = 1; i < 8; i++) {
+        TEST_ASSERT_EQUAL(0, table[i]);
+    }
+}
+
+static void test_pitch_table_full_distribution(void)
+{
+    int8_t table[8];
+    memset(table, 0x7F, sizeof(table));
+
+    echo_chamber_compute_pitch_table(8, table, 8);
+
+    /* Policy: slot 0 = 0, odd slots go negative in -2 steps,
+     * even slots (>0) go positive in +2 steps. */
+    TEST_ASSERT_EQUAL(0, table[0]);
+    TEST_ASSERT_EQUAL(-2, table[1]);
+    TEST_ASSERT_EQUAL(2, table[2]);
+    TEST_ASSERT_EQUAL(-4, table[3]);
+    TEST_ASSERT_EQUAL(4, table[4]);
+    TEST_ASSERT_EQUAL(-6, table[5]);
+    TEST_ASSERT_EQUAL(6, table[6]);
+    TEST_ASSERT_EQUAL(-8, table[7]);
+}
+
+static void test_pitch_table_peer_count_exceeds_table(void)
+{
+    int8_t table[8];
+    memset(table, 0x7F, sizeof(table));
+
+    /* peer_count > table len should clamp to table len */
+    echo_chamber_compute_pitch_table(200, table, 8);
+
+    TEST_ASSERT_EQUAL(0, table[0]);
+    TEST_ASSERT_EQUAL(-2, table[1]);
+    TEST_ASSERT_EQUAL(6, table[6]);
+    TEST_ASSERT_EQUAL(-8, table[7]);
+}
+
+static void test_pitch_table_null_guard(void)
+{
+    /* Must not crash */
+    echo_chamber_compute_pitch_table(3, NULL, 0);
+    echo_chamber_compute_pitch_table(3, NULL, 8);
+    TEST_ASSERT_TRUE(1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Payload builder                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_build_payload_basic(void)
+{
+    audio_clip_broadcast_payload_t p;
+    memset(&p, 0xAA, sizeof(p));
+
+    echo_chamber_build_payload(&p, 0x2A, 12345, 4);
+
+    TEST_ASSERT_EQUAL(0x2A, p.clip_id);
+    TEST_ASSERT_EQUAL(12345, p.sample_count);
+    TEST_ASSERT_EQUAL(0, p.flags);
+
+    /* First four slots populated per policy; remainder zero. */
+    TEST_ASSERT_EQUAL(0, p.per_peer_semitone_shift[0]);
+    TEST_ASSERT_EQUAL(-2, p.per_peer_semitone_shift[1]);
+    TEST_ASSERT_EQUAL(2, p.per_peer_semitone_shift[2]);
+    TEST_ASSERT_EQUAL(-4, p.per_peer_semitone_shift[3]);
+    TEST_ASSERT_EQUAL(0, p.per_peer_semitone_shift[4]);
+    TEST_ASSERT_EQUAL(0, p.per_peer_semitone_shift[7]);
+}
+
+static void test_build_payload_clamps_sample_count(void)
+{
+    audio_clip_broadcast_payload_t p;
+    echo_chamber_build_payload(&p, 0, 65535, 1);
+
+    /* Max samples = 2 s @ 16 kHz = 32000 */
+    TEST_ASSERT_EQUAL(32000, p.sample_count);
+}
+
+static void test_build_payload_null_guard(void)
+{
+    echo_chamber_build_payload(NULL, 0, 0, 0);
+    TEST_ASSERT_TRUE(1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Packet builder                                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_build_packet_stamps_magic_and_checksum(void)
+{
+    thinkpack_packet_t pkt;
+    memset(&pkt, 0xFF, sizeof(pkt));
+
+    echo_chamber_build_packet(&pkt, TEST_SEQ, TEST_MAC, 0x03, 8000, 3);
+
+    TEST_ASSERT_EQUAL(THINKPACK_MAGIC_0, pkt.magic[0]);
+    TEST_ASSERT_EQUAL(THINKPACK_MAGIC_VERSION, pkt.magic[1]);
+    TEST_ASSERT_EQUAL(MSG_AUDIO_CLIP_BROADCAST, pkt.msg_type);
+    TEST_ASSERT_EQUAL(TEST_SEQ, pkt.sequence_number);
+    TEST_ASSERT_EQUAL_MEMORY(TEST_MAC, pkt.src_mac, 6);
+    TEST_ASSERT_EQUAL((uint8_t)sizeof(audio_clip_broadcast_payload_t), pkt.data_length);
+    TEST_ASSERT_TRUE(thinkpack_verify_checksum(&pkt));
+
+    /* Payload round-trip */
+    audio_clip_broadcast_payload_t out;
+    memcpy(&out, pkt.data, sizeof(out));
+    TEST_ASSERT_EQUAL(0x03, out.clip_id);
+    TEST_ASSERT_EQUAL(8000, out.sample_count);
+    TEST_ASSERT_EQUAL(0, out.per_peer_semitone_shift[0]);
+    TEST_ASSERT_EQUAL(-2, out.per_peer_semitone_shift[1]);
+    TEST_ASSERT_EQUAL(2, out.per_peer_semitone_shift[2]);
+}
+
+static void test_build_packet_zero_peers(void)
+{
+    thinkpack_packet_t pkt;
+    echo_chamber_build_packet(&pkt, 0, TEST_MAC, 0, 0, 0);
+
+    TEST_ASSERT_TRUE(thinkpack_verify_checksum(&pkt));
+    audio_clip_broadcast_payload_t out;
+    memcpy(&out, pkt.data, sizeof(out));
+    for (int i = 0; i < 8; i++) {
+        TEST_ASSERT_EQUAL(0, out.per_peer_semitone_shift[i]);
+    }
+}
+
+static void test_build_packet_null_guard(void)
+{
+    echo_chamber_build_packet(NULL, 0, TEST_MAC, 0, 0, 0);
+    TEST_ASSERT_TRUE(1);
+}
+
+/* ------------------------------------------------------------------ */
+/* Entry point                                                         */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_pitch_table_zero_peers_is_all_zero);
+    RUN_TEST(test_pitch_table_single_peer_only_slot0);
+    RUN_TEST(test_pitch_table_full_distribution);
+    RUN_TEST(test_pitch_table_peer_count_exceeds_table);
+    RUN_TEST(test_pitch_table_null_guard);
+
+    RUN_TEST(test_build_payload_basic);
+    RUN_TEST(test_build_payload_clamps_sample_count);
+    RUN_TEST(test_build_payload_null_guard);
+
+    RUN_TEST(test_build_packet_stamps_magic_and_checksum);
+    RUN_TEST(test_build_packet_zero_peers);
+    RUN_TEST(test_build_packet_null_guard);
+
+    int failures = UNITY_END();
+    return failures == 0 ? 0 : 1;
+}

--- a/packages/components/thinkpack-protocol/include/thinkpack_protocol.h
+++ b/packages/components/thinkpack-protocol/include/thinkpack_protocol.h
@@ -60,7 +60,9 @@ typedef enum {
     MSG_LLM_RESPONSE = 0x09,
     MSG_SYNC_PULSE = 0x0A,
     MSG_COLLECTIVE_TRIGGER = 0x0B,
-    MSG_FRAGMENT = 0x0C /**< Fragment of a large message */
+    MSG_FRAGMENT = 0x0C,             /**< Fragment of a large message         */
+    MSG_AUDIO_CLIP_BROADCAST = 0x0D, /**< Leader-driven echo-chamber clip ref */
+    /* 0x0E reserved for future audio use */
 } thinkpack_msg_type_t;
 
 /* ------------------------------------------------------------------ */
@@ -196,6 +198,27 @@ typedef struct __attribute__((packed)) {
     uint8_t data_length;                       /**< Bytes of data[] populated in this fragment  */
     uint8_t data[THINKPACK_MAX_FRAGMENT_DATA]; /**< Fragment payload bytes     */
 } thinkpack_fragment_data_t;
+
+/**
+ * @brief Payload for MSG_AUDIO_CLIP_BROADCAST — echo-chamber clip metadata.
+ *
+ * Chatterbox leader announces a just-recorded clip; each follower applies the
+ * semitone shift in @p per_peer_semitone_shift at its own slot index (0-based,
+ * wraps mod THINKPACK_MAX_PEERS).  The actual PCM is streamed separately via
+ * the fragmented-send path (thinkpack_mesh_send_large with MSG_LLM_RESPONSE-
+ * style transport); this payload is a lightweight metadata header carried in
+ * a normal-size packet so every box learns about the clip quickly.
+ *
+ * Slot mapping convention: the slot index is the follower's position in the
+ * leader's peer table at send time (0-based).  Followers that don't know
+ * their own slot default to slot 0.  Unused slots are clamped to 0 semitones.
+ */
+typedef struct __attribute__((packed)) {
+    uint8_t clip_id;                   /**< Unique per broadcast (wraps mod 256) */
+    uint16_t sample_count;             /**< PCM samples (<= THINKPACK_AUDIO_CLIP_MAX_SAMPLES) */
+    int8_t per_peer_semitone_shift[8]; /**< Per-slot pitch offset, clamped to ±12 */
+    uint8_t flags;                     /**< Reserved — must be 0 */
+} audio_clip_broadcast_payload_t;
 
 /* ------------------------------------------------------------------ */
 /* Helper function prototypes                                          */

--- a/packages/thinkpack/chatterbox/CMakeLists.txt
+++ b/packages/thinkpack/chatterbox/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.16)
+
+# Read version from release-please managed version.txt
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/version.txt")
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/version.txt" PROJECT_VER)
+    string(STRIP "${PROJECT_VER}" PROJECT_VER)
+else()
+    set(PROJECT_VER "0.1.0")
+endif()
+
+# Pick up shared ThinkPack components from packages/components/.
+list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(thinkpack-chatterbox)

--- a/packages/thinkpack/chatterbox/README.md
+++ b/packages/thinkpack/chatterbox/README.md
@@ -1,0 +1,37 @@
+# ThinkPack Chatterbox
+
+Touch-driven audio record / playback box in the ThinkPack modular-toy mesh.
+Runs on an ESP32-S3 SuperMini with:
+
+- **INMP441** I2S MEMS microphone (capture)
+- **MAX98357A** I2S DAC + speaker (playback)
+- A single native **capacitive touch pad** as the record trigger
+
+Standalone behaviour is press-to-record, release-to-play.  When the mesh
+sees other boxes, the Chatterbox acts as the leader of an **Echo Chamber**:
+each peer plays the captured clip back at a different pitch, producing a
+chorus of voices.  See [`docs/requirements/PRD-010`](../../../docs/requirements)
+and issue [#197](https://github.com/laurigates/mcu-tinkering-lab/issues/197)
+for the full feature description.
+
+## Status
+
+Firmware builds via the shared ESP-IDF container pipeline.  The audio path
+(I2S RX, I2S TX, native touch, PSRAM clip storage) is **not yet verified on
+hardware**; host tests exercise the dispatch logic only.
+
+## Build & flash
+
+```bash
+just thinkpack-chatterbox::build
+PORT=/dev/cu.usbmodemXXXX just thinkpack-chatterbox::flash-monitor
+```
+
+All ESP-IDF tooling runs inside `espressif/idf:v5.4`; no local install is
+required.  See [`WIRING.md`](WIRING.md) for the pinout.
+
+## Testing
+
+Host-testable logic lives in `packages/components/thinkpack-behaviors`
+(Echo Chamber dispatch) and `packages/components/thinkpack-audio` (state
+machine, ring buffer, pitch-shift).  Run `make test` in either directory.

--- a/packages/thinkpack/chatterbox/WIRING.md
+++ b/packages/thinkpack/chatterbox/WIRING.md
@@ -1,0 +1,63 @@
+# Chatterbox Wiring
+
+Target board: **ESP32-S3 SuperMini** (4 MB flash, octal PSRAM).
+
+All pins listed below match `main/audio_engine.c` and `main/touch_driver.c`.
+Update both files when moving a pin — the driver sources are the source of
+truth.
+
+## I2S TX — MAX98357A speaker amplifier
+
+| Signal | ESP32-S3 GPIO | MAX98357A pin | Notes |
+|--------|---------------|---------------|-------|
+| BCLK   | 4             | BCLK          | Bit clock |
+| LRCLK  | 5             | LRC           | Word-select (LRC) |
+| DOUT   | 6             | DIN           | PCM data out |
+| GND    | GND           | GND           | Common ground |
+| Vcc    | 3V3 or 5V     | Vin           | 3V3 is fine for low volume; use 5V for full output |
+
+The driver writes mono samples duplicated into stereo frames (standard for
+the MAX98357A breakout).
+
+## I2S RX — INMP441 MEMS microphone
+
+| Signal | ESP32-S3 GPIO | INMP441 pin | Notes |
+|--------|---------------|-------------|-------|
+| BCLK   | 10            | SCK         | Bit clock |
+| LRCLK  | 11            | WS          | Word-select |
+| DIN    | 12            | SD          | Serial data (mic → ESP32) |
+| GND    | GND           | GND         | Common ground |
+| Vcc    | 3V3           | VDD         | 3V3 only — do not tie to 5V |
+| L/R    | GND           | L/R         | Select left channel (mono capture) |
+
+RX runs on I2S peripheral `I2S_NUM_1` to keep it independent from the TX
+channel on `I2S_NUM_0`.
+
+## Touch pad
+
+| Signal   | ESP32-S3 GPIO | Notes |
+|----------|---------------|-------|
+| Touch    | 14            | Touch channel 14.  Connect to a small conductive pad; no external components required. |
+
+The driver calibrates against the untouched baseline on boot; avoid
+touching the pad during the first 250 ms after power-on.
+
+## Status LED (optional)
+
+| Signal | ESP32-S3 GPIO | Notes |
+|--------|---------------|-------|
+| LED    | 15            | Reserved for a single status LED.  Not yet wired in firmware. |
+
+## Pin conflicts to avoid
+
+- GPIO19/20 are the native USB D+/D- lines.  Do not repurpose them.
+- GPIO35/36/37 are internal (octal PSRAM) on the SuperMini and unusable.
+- GPIO0 is the strapping / boot-mode pin — leave floating or weakly
+  pulled up.
+
+## Power
+
+The SuperMini draws < 200 mA during record/playback at moderate volume;
+USB power is sufficient for bench testing.  For battery operation, use a
+3.7 V Li-Po through the VBAT input and keep Vcc on the MAX98357A at 3V3 to
+stay within the amp's headroom.

--- a/packages/thinkpack/chatterbox/justfile
+++ b/packages/thinkpack/chatterbox/justfile
@@ -1,0 +1,80 @@
+# ThinkPack chatterbox — audio record/playback box on ESP32-S3 SuperMini
+# Run `just` or `just --list` to see available recipes
+
+set positional-arguments
+
+import '../../../tools/esp32-idf.just'
+
+project_dir := "packages/thinkpack/chatterbox"
+port := env("PORT", _detected_s3)
+baud := env("BAUD", "460800")
+target := "esp32s3"
+
+default:
+    @just --list
+
+##########
+# Build
+##########
+
+# Build firmware in Docker container
+[group: "build"]
+build:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "Building thinkpack-chatterbox..."
+    {{container_cmd}} compose -f {{compose_file}} run --rm \
+        -w /workspace/{{project_dir}} \
+        esp-idf \
+        bash -c "idf.py set-target {{target}} && idf.py build" 2>&1 \
+        | grep -E "warning:|error:|ninja: build stopped|binary size|Build complete" \
+        || true
+    if [ ! -f build/thinkpack-chatterbox.bin ]; then
+        echo "FAILED — rerun with verbose output:" >&2
+        echo "  {{container_cmd}} compose -f {{compose_file}} run --rm -w /workspace/{{project_dir}} esp-idf bash -c 'idf.py build'" >&2
+        exit 1
+    fi
+    echo "Build OK"
+
+# Clean build artifacts (containerized)
+[group: "build"]
+clean: _idf-clean
+
+# Open configuration menu (containerized)
+[group: "build"]
+menuconfig: _idf-menuconfig
+
+# Interactive shell in ESP-IDF container
+[group: "build"]
+shell: _idf-shell
+
+##########
+# Flash & Monitor
+##########
+
+# Flash firmware to device
+[group: "device"]
+flash: require-port
+    #!/usr/bin/env bash
+    set -euo pipefail
+    esptool -s --chip esp32s3 -p {{port}} -b {{baud}} \
+        --before default-reset --after hard-reset \
+        write-flash --flash-mode dio --flash-size 4MB --flash-freq 80m \
+        0x0 build/bootloader/bootloader.bin \
+        0x8000 build/partition_table/partition-table.bin \
+        0x10000 build/thinkpack-chatterbox.bin
+    echo "Flashed OK"
+
+# Reset board via USB-Serial-JTAG CDC control signals
+[group: "device"]
+reset: require-port
+    "{{tools_dir}}/esp32s3-reset.sh" "{{port}}"
+
+# Serial monitor with reset (Ctrl-C to stop)
+[group: "device"]
+monitor: require-port
+    "{{tools_dir}}/esp32s3-monitor.sh" "{{port}}"
+
+# Flash and monitor
+[group: "device"]
+flash-monitor: flash monitor

--- a/packages/thinkpack/chatterbox/main/CMakeLists.txt
+++ b/packages/thinkpack/chatterbox/main/CMakeLists.txt
@@ -1,0 +1,23 @@
+idf_component_register(
+    SRCS
+        "main.c"
+        "audio_engine.c"
+        "touch_driver.c"
+        "standalone_mode.c"
+        "group_mode.c"
+    INCLUDE_DIRS "."
+    REQUIRES
+        driver
+        nvs_flash
+        esp_netif
+        esp_event
+        esp_wifi
+        thinkpack-protocol
+        thinkpack-mesh
+        thinkpack-behaviors
+        thinkpack-audio
+    PRIV_REQUIRES
+        esp_timer
+        freertos
+        esp_system
+)

--- a/packages/thinkpack/chatterbox/main/audio_engine.c
+++ b/packages/thinkpack/chatterbox/main/audio_engine.c
@@ -1,0 +1,284 @@
+/**
+ * @file audio_engine.c
+ * @brief I2S RX (INMP441) + TX (MAX98357A) driver implementation.
+ *
+ * Hardware-unverified — the configuration is modelled after the
+ * nfc-scavenger-hunt I2S playback path (MAX98357A mono-to-stereo duplication)
+ * and a standard I2S PDM/Philips INMP441 capture channel.
+ */
+
+#include "audio_engine.h"
+
+#include <string.h>
+
+#include "driver/i2s_std.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "thinkpack_audio.h"
+
+static const char *TAG = "audio_engine";
+
+/* ------------------------------------------------------------------ */
+/* Pin map — ESP32-S3 SuperMini. See WIRING.md.                        */
+/* ------------------------------------------------------------------ */
+
+#define PIN_TX_BCLK 4
+#define PIN_TX_LRCLK 5
+#define PIN_TX_DOUT 6
+
+#define PIN_RX_BCLK 10
+#define PIN_RX_LRCLK 11
+#define PIN_RX_DIN 12
+
+/* ------------------------------------------------------------------ */
+/* I2S DMA parameters                                                  */
+/* ------------------------------------------------------------------ */
+
+#define I2S_DMA_DESC_NUM 4
+#define I2S_DMA_FRAME_NUM 512
+#define TX_CHUNK_SAMPLES 256
+#define RX_CHUNK_SAMPLES 256
+
+/* ------------------------------------------------------------------ */
+/* Module state                                                        */
+/* ------------------------------------------------------------------ */
+
+static bool s_initialised;
+static bool s_recording;
+
+static i2s_chan_handle_t s_rx_chan;
+static i2s_chan_handle_t s_tx_chan;
+
+static int16_t *s_clip_buf; /* PSRAM */
+static size_t s_clip_samples;
+
+static int16_t *s_shifted_buf; /* PSRAM scratch for pitch-shift playback */
+
+/* ------------------------------------------------------------------ */
+/* I2S channel configuration helpers                                   */
+/* ------------------------------------------------------------------ */
+
+static esp_err_t configure_tx_channel(void)
+{
+    i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_0, I2S_ROLE_MASTER);
+    chan_cfg.dma_desc_num = I2S_DMA_DESC_NUM;
+    chan_cfg.dma_frame_num = I2S_DMA_FRAME_NUM;
+    esp_err_t err = i2s_new_channel(&chan_cfg, &s_tx_chan, NULL);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    i2s_std_config_t std_cfg = {
+        .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(THINKPACK_AUDIO_SAMPLE_RATE),
+        .slot_cfg =
+            I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_STEREO),
+        .gpio_cfg =
+            {
+                .mclk = I2S_GPIO_UNUSED,
+                .bclk = PIN_TX_BCLK,
+                .ws = PIN_TX_LRCLK,
+                .dout = PIN_TX_DOUT,
+                .din = I2S_GPIO_UNUSED,
+                .invert_flags = {0},
+            },
+    };
+    return i2s_channel_init_std_mode(s_tx_chan, &std_cfg);
+}
+
+static esp_err_t configure_rx_channel(void)
+{
+    i2s_chan_config_t chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG(I2S_NUM_1, I2S_ROLE_MASTER);
+    chan_cfg.dma_desc_num = I2S_DMA_DESC_NUM;
+    chan_cfg.dma_frame_num = I2S_DMA_FRAME_NUM;
+    esp_err_t err = i2s_new_channel(&chan_cfg, NULL, &s_rx_chan);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    i2s_std_config_t std_cfg = {
+        .clk_cfg = I2S_STD_CLK_DEFAULT_CONFIG(THINKPACK_AUDIO_SAMPLE_RATE),
+        .slot_cfg =
+            I2S_STD_PHILIPS_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
+        .gpio_cfg =
+            {
+                .mclk = I2S_GPIO_UNUSED,
+                .bclk = PIN_RX_BCLK,
+                .ws = PIN_RX_LRCLK,
+                .dout = I2S_GPIO_UNUSED,
+                .din = PIN_RX_DIN,
+                .invert_flags = {0},
+            },
+    };
+    return i2s_channel_init_std_mode(s_rx_chan, &std_cfg);
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+esp_err_t audio_engine_init(void)
+{
+    if (s_initialised) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    esp_err_t err = configure_tx_channel();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "TX channel init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = configure_rx_channel();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "RX channel init failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    s_clip_buf = heap_caps_malloc(THINKPACK_AUDIO_CLIP_MAX_SAMPLES * sizeof(int16_t),
+                                  MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    s_shifted_buf = heap_caps_malloc(THINKPACK_AUDIO_CLIP_MAX_SAMPLES * sizeof(int16_t),
+                                     MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (s_clip_buf == NULL || s_shifted_buf == NULL) {
+        ESP_LOGE(TAG, "PSRAM clip alloc failed");
+        return ESP_ERR_NO_MEM;
+    }
+
+    s_clip_samples = 0;
+    s_initialised = true;
+
+    ESP_LOGI(TAG, "audio_engine ready: %d samples of PSRAM reserved",
+             (int)THINKPACK_AUDIO_CLIP_MAX_SAMPLES);
+    return ESP_OK;
+}
+
+esp_err_t audio_engine_record_start(void)
+{
+    if (!s_initialised) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (s_recording) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    s_clip_samples = 0;
+    esp_err_t err = i2s_channel_enable(s_rx_chan);
+    if (err != ESP_OK) {
+        return err;
+    }
+    s_recording = true;
+    return ESP_OK;
+}
+
+esp_err_t audio_engine_record_tick(bool *reached_limit)
+{
+    if (!s_recording) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (reached_limit != NULL) {
+        *reached_limit = false;
+    }
+
+    size_t remaining = THINKPACK_AUDIO_CLIP_MAX_SAMPLES - s_clip_samples;
+    if (remaining == 0) {
+        if (reached_limit != NULL) {
+            *reached_limit = true;
+        }
+        return ESP_OK;
+    }
+
+    size_t chunk = remaining < RX_CHUNK_SAMPLES ? remaining : RX_CHUNK_SAMPLES;
+    size_t bytes_read = 0;
+    esp_err_t err = i2s_channel_read(s_rx_chan, &s_clip_buf[s_clip_samples],
+                                     chunk * sizeof(int16_t), &bytes_read, pdMS_TO_TICKS(10));
+    if (err != ESP_OK && err != ESP_ERR_TIMEOUT) {
+        return err;
+    }
+
+    s_clip_samples += bytes_read / sizeof(int16_t);
+    if (s_clip_samples >= THINKPACK_AUDIO_CLIP_MAX_SAMPLES && reached_limit != NULL) {
+        *reached_limit = true;
+    }
+    return ESP_OK;
+}
+
+esp_err_t audio_engine_record_stop(size_t *out_samples)
+{
+    if (!s_recording) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    esp_err_t err = i2s_channel_disable(s_rx_chan);
+    s_recording = false;
+    if (out_samples != NULL) {
+        *out_samples = s_clip_samples;
+    }
+    /* Apply toddler-safe volume cap once, at the end of capture. */
+    thinkpack_audio_apply_volume_cap(s_clip_buf, s_clip_samples);
+    return err;
+}
+
+/** Blocking mono-to-stereo write helper for MAX98357A. */
+static esp_err_t play_mono(const int16_t *mono, size_t mono_samples)
+{
+    if (mono == NULL || mono_samples == 0) {
+        return ESP_OK;
+    }
+
+    int16_t stereo[TX_CHUNK_SAMPLES * 2];
+    esp_err_t err = i2s_channel_enable(s_tx_chan);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    size_t offset = 0;
+    while (offset < mono_samples) {
+        size_t chunk = mono_samples - offset;
+        if (chunk > TX_CHUNK_SAMPLES) {
+            chunk = TX_CHUNK_SAMPLES;
+        }
+        for (size_t i = 0; i < chunk; i++) {
+            stereo[i * 2] = mono[offset + i];
+            stereo[i * 2 + 1] = mono[offset + i];
+        }
+        size_t written = 0;
+        err = i2s_channel_write(s_tx_chan, stereo, chunk * 2 * sizeof(int16_t), &written,
+                                pdMS_TO_TICKS(1000));
+        if (err != ESP_OK) {
+            break;
+        }
+        offset += chunk;
+    }
+
+    i2s_channel_disable(s_tx_chan);
+    return err;
+}
+
+esp_err_t audio_engine_playback(void)
+{
+    if (!s_initialised) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    return play_mono(s_clip_buf, s_clip_samples);
+}
+
+esp_err_t audio_engine_playback_with_pitch_shift(int8_t semitone_shift)
+{
+    if (!s_initialised) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (semitone_shift == 0) {
+        return audio_engine_playback();
+    }
+    size_t produced = thinkpack_audio_pitch_shift(s_clip_buf, s_clip_samples, semitone_shift,
+                                                  s_shifted_buf, THINKPACK_AUDIO_CLIP_MAX_SAMPLES);
+    return play_mono(s_shifted_buf, produced);
+}
+
+const int16_t *audio_engine_clip_samples(void)
+{
+    return s_clip_buf;
+}
+
+size_t audio_engine_clip_sample_count(void)
+{
+    return s_clip_samples;
+}

--- a/packages/thinkpack/chatterbox/main/audio_engine.h
+++ b/packages/thinkpack/chatterbox/main/audio_engine.h
@@ -1,0 +1,87 @@
+/**
+ * @file audio_engine.h
+ * @brief I2S record (INMP441) + playback (MAX98357A) driver for Chatterbox.
+ *
+ * Owns two i2s_chan handles (RX + TX) and a single PSRAM-backed clip buffer
+ * sized for THINKPACK_AUDIO_CLIP_MAX_SAMPLES.  The API is intentionally small:
+ * start recording, stop recording, play a captured clip, play a clip at a
+ * semitone offset.  All playback happens on the calling task (no internal
+ * task/queue) — callers that need deferred playback should wrap these calls.
+ *
+ * Hardware-unverified.  See WIRING.md for the pin table.
+ */
+
+#ifndef AUDIO_ENGINE_H
+#define AUDIO_ENGINE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialise the I2S RX + TX channels and allocate the PSRAM clip
+ *        buffer.
+ *
+ * Safe to call once at boot.  Idempotent calls return ESP_ERR_INVALID_STATE.
+ */
+esp_err_t audio_engine_init(void);
+
+/**
+ * @brief Begin capturing samples into the PSRAM clip buffer.
+ *
+ * Samples drain into the buffer until audio_engine_record_stop() is called
+ * or the clip-length cap is reached.  The function blocks briefly on I2S RX
+ * enable but does not block for the full clip duration — the caller must
+ * poll audio_engine_record_samples() and stop explicitly.
+ */
+esp_err_t audio_engine_record_start(void);
+
+/**
+ * @brief Pull samples from the I2S RX channel into the clip buffer.
+ *
+ * Call this from a task loop until @p reached_limit is set or the user
+ * releases the touch pad.  Non-blocking (uses pdMS_TO_TICKS(10) timeout
+ * internally).
+ *
+ * @param[out] reached_limit  Set to true when the clip-length cap is hit.
+ * @return     ESP_OK on success.
+ */
+esp_err_t audio_engine_record_tick(bool *reached_limit);
+
+/**
+ * @brief Stop the RX channel and return the captured sample count.
+ */
+esp_err_t audio_engine_record_stop(size_t *out_samples);
+
+/**
+ * @brief Play the currently captured clip via I2S TX (blocking).
+ */
+esp_err_t audio_engine_playback(void);
+
+/**
+ * @brief Play the captured clip, pitch-shifted by @p semitone_shift.
+ *
+ * Uses thinkpack_audio_pitch_shift() and a scratch buffer.  Blocks until
+ * playback completes.
+ */
+esp_err_t audio_engine_playback_with_pitch_shift(int8_t semitone_shift);
+
+/**
+ * @brief Pointer + length accessors for callers that need to forward the
+ *        clip over the mesh (fragmented send).
+ *
+ * The pointer remains valid until the next record_start().
+ */
+const int16_t *audio_engine_clip_samples(void);
+size_t audio_engine_clip_sample_count(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AUDIO_ENGINE_H */

--- a/packages/thinkpack/chatterbox/main/group_mode.c
+++ b/packages/thinkpack/chatterbox/main/group_mode.c
@@ -1,0 +1,119 @@
+/**
+ * @file group_mode.c
+ * @brief Echo Chamber group behaviour on incoming + outgoing broadcasts.
+ *
+ * Broadcasts are sent via thinkpack_mesh_send_large() with
+ * MSG_AUDIO_CLIP_BROADCAST as the logical type.  The mesh wraps the payload
+ * in MSG_FRAGMENT packets (since our payload is small, this is a single
+ * fragment in practice) and fires THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED on
+ * receipt with @p original_msg_type == MSG_AUDIO_CLIP_BROADCAST.  This is
+ * the agreed transport for new message types until a follow-up PR extends
+ * the mesh event dispatcher with a generic "packet received" hook.
+ */
+
+#include "group_mode.h"
+
+#include <string.h>
+
+#include "audio_engine.h"
+#include "echo_chamber.h"
+#include "esp_log.h"
+#include "esp_mac.h"
+#include "thinkpack_protocol.h"
+
+static const char *TAG = "chat_group";
+
+/* ------------------------------------------------------------------ */
+/* Module state                                                        */
+/* ------------------------------------------------------------------ */
+
+static uint8_t s_next_clip_id;
+static uint8_t s_local_slot; /**< Cached slot index (leader = 0). */
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+void group_mode_init(void)
+{
+    s_next_clip_id = 0;
+    s_local_slot = 0;
+}
+
+bool group_mode_broadcast_clip(uint16_t sample_count)
+{
+    size_t peer_count = thinkpack_mesh_peer_count();
+
+    audio_clip_broadcast_payload_t payload;
+    echo_chamber_build_payload(&payload, s_next_clip_id, sample_count, (uint8_t)peer_count);
+
+    esp_err_t err = thinkpack_mesh_send_large(NULL, (uint8_t)MSG_AUDIO_CLIP_BROADCAST,
+                                              (const uint8_t *)&payload, sizeof(payload));
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "broadcast failed: %s", esp_err_to_name(err));
+        return false;
+    }
+
+    ESP_LOGI(TAG, "broadcast clip_id=%u samples=%u peers=%u", s_next_clip_id, sample_count,
+             (unsigned)peer_count);
+    s_next_clip_id++;
+    return true;
+}
+
+static void handle_clip_broadcast(const uint8_t *data, size_t length)
+{
+    if (length < sizeof(audio_clip_broadcast_payload_t)) {
+        ESP_LOGW(TAG, "broadcast payload too small (%u bytes)", (unsigned)length);
+        return;
+    }
+    audio_clip_broadcast_payload_t payload;
+    memcpy(&payload, data, sizeof(payload));
+
+    uint8_t slot = s_local_slot;
+    if (slot >= (uint8_t)sizeof(payload.per_peer_semitone_shift)) {
+        slot = 0;
+    }
+    int8_t shift = payload.per_peer_semitone_shift[slot];
+
+    ESP_LOGI(TAG, "play clip_id=%u slot=%u shift=%d samples=%u", payload.clip_id, slot, shift,
+             payload.sample_count);
+    /* The PCM itself is streamed separately via a follow-up PR; for now we
+     * pitch-shift and replay the locally captured clip (if any) as a
+     * visible/audible stand-in. */
+    audio_engine_playback_with_pitch_shift(shift);
+}
+
+void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ctx)
+{
+    (void)user_ctx;
+    if (event == NULL) {
+        return;
+    }
+
+    switch (event->type) {
+        case THINKPACK_EVENT_PEER_DISCOVERED:
+            ESP_LOGI(TAG, "peer discovered: " MACSTR, MAC2STR(event->peer_mac));
+            break;
+        case THINKPACK_EVENT_PEER_LOST:
+            ESP_LOGI(TAG, "peer lost: " MACSTR, MAC2STR(event->peer_mac));
+            break;
+        case THINKPACK_EVENT_BECAME_LEADER:
+            s_local_slot = 0;
+            ESP_LOGI(TAG, "became leader — slot 0");
+            break;
+        case THINKPACK_EVENT_BECAME_FOLLOWER:
+            /* Leaders currently don't broadcast slot assignments — followers
+             * default to slot 1.  A later PR can thread slot info through
+             * MSG_LEADER_CLAIM. */
+            s_local_slot = 1;
+            ESP_LOGI(TAG, "became follower — slot %u", s_local_slot);
+            break;
+        case THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED:
+            if (event->original_msg_type == (uint8_t)MSG_AUDIO_CLIP_BROADCAST) {
+                handle_clip_broadcast(event->large_data, event->large_length);
+            }
+            break;
+        default:
+            break;
+    }
+}

--- a/packages/thinkpack/chatterbox/main/group_mode.h
+++ b/packages/thinkpack/chatterbox/main/group_mode.h
@@ -1,0 +1,55 @@
+/**
+ * @file group_mode.h
+ * @brief Mesh event handler for the Chatterbox echo-chamber group behaviour.
+ *
+ * When local touch captures a clip and the mesh has peers, the leader
+ * invokes group_mode_broadcast_clip() to assemble an
+ * audio_clip_broadcast_payload_t and send it out via the mesh.  Incoming
+ * MSG_AUDIO_CLIP_BROADCAST packets trigger a pitch-shifted local playback
+ * at the slot index corresponding to this node.
+ */
+
+#ifndef GROUP_MODE_H
+#define GROUP_MODE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "espnow_mesh.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialise group-mode state.
+ *
+ * Must be called once before thinkpack_mesh_start().  This currently only
+ * clears module-local state; command_executor handlers are not registered
+ * because echo-chamber traffic uses MSG_AUDIO_CLIP_BROADCAST directly rather
+ * than MSG_COMMAND.
+ */
+void group_mode_init(void);
+
+/**
+ * @brief Mesh event callback — dispatch MSG_AUDIO_CLIP_BROADCAST.
+ */
+void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ctx);
+
+/**
+ * @brief Announce a just-captured clip to the mesh.
+ *
+ * Assembles the audio_clip_broadcast_payload_t via echo_chamber, stamps
+ * a fresh clip id, and broadcasts the metadata packet.  The PCM itself is
+ * streamed separately via thinkpack_mesh_send_large() when a receiver
+ * requests it (not implemented here).
+ *
+ * @return true on success.
+ */
+bool group_mode_broadcast_clip(uint16_t sample_count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GROUP_MODE_H */

--- a/packages/thinkpack/chatterbox/main/idf_component.yml
+++ b/packages/thinkpack/chatterbox/main/idf_component.yml
@@ -1,0 +1,3 @@
+dependencies:
+  idf:
+    version: ">=5.4"

--- a/packages/thinkpack/chatterbox/main/main.c
+++ b/packages/thinkpack/chatterbox/main/main.c
@@ -1,0 +1,112 @@
+/**
+ * @file main.c
+ * @brief ThinkPack chatterbox — touch-driven audio box on ESP32-S3 SuperMini.
+ *
+ * Initialises NVS, the netif event loop, WiFi (STA mode for ESP-NOW), the
+ * I2S audio engine, touch peripheral, and joins the ThinkPack mesh.  The
+ * touch driver drives a thinkpack_audio_sm_t via standalone_mode; group_mode
+ * handles MSG_AUDIO_CLIP_BROADCAST.
+ *
+ * Hardware:
+ *   MAX98357A speaker — I2S0 (BCLK 4, LRCLK 5, DOUT 6)
+ *   INMP441 mic       — I2S1 (BCLK 10, LRCLK 11, DIN 12)
+ *   Touch pad         — GPIO14 (touch channel 14)
+ *
+ * See https://github.com/laurigates/mcu-tinkering-lab/issues/197
+ */
+
+#include <string.h>
+
+#include "audio_engine.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "esp_mac.h"
+#include "esp_netif.h"
+#include "esp_timer.h"
+#include "espnow_mesh.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "group_mode.h"
+#include "nvs_flash.h"
+#include "standalone_mode.h"
+#include "thinkpack_protocol.h"
+#include "touch_driver.h"
+
+static const char *TAG = "chatterbox";
+
+/* ------------------------------------------------------------------ */
+/* Touch edge callback                                                 */
+/* ------------------------------------------------------------------ */
+
+static void on_touch_edge(bool pressed)
+{
+    ESP_LOGD(TAG, "touch %s", pressed ? "PRESS" : "RELEASE");
+    standalone_mode_on_touch(pressed);
+
+    /* When the release transition yields a captured clip and we're in a
+     * mesh with peers, broadcast it so followers can echo. */
+    if (!pressed) {
+        size_t n = audio_engine_clip_sample_count();
+        if (n > 0 && thinkpack_mesh_peer_count() > 0) {
+            group_mode_broadcast_clip((uint16_t)n);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Audio tick task — services the record loop at 50 Hz                 */
+/* ------------------------------------------------------------------ */
+
+static void audio_task(void *arg)
+{
+    (void)arg;
+    for (;;) {
+        standalone_mode_tick();
+        vTaskDelay(pdMS_TO_TICKS(20));
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* app_main                                                            */
+/* ------------------------------------------------------------------ */
+
+void app_main(void)
+{
+    ESP_ERROR_CHECK(nvs_flash_init());
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    uint8_t mac[6];
+    ESP_ERROR_CHECK(esp_read_mac(mac, ESP_MAC_WIFI_STA));
+    ESP_LOGI(TAG, "chatterbox starting — MAC: " MACSTR, MAC2STR(mac));
+
+    /* Peripherals */
+    ESP_ERROR_CHECK(audio_engine_init());
+    standalone_mode_init();
+    group_mode_init();
+
+    ESP_ERROR_CHECK(touch_driver_init(on_touch_edge));
+
+    /* Mesh */
+    thinkpack_mesh_config_t cfg;
+    memset(&cfg, 0, sizeof(cfg));
+    cfg.box_type = BOX_CHATTERBOX;
+    cfg.capabilities = CAP_AUDIO_OUT | CAP_AUDIO_IN | CAP_TOUCH;
+    cfg.channel = 1;
+    cfg.battery_level = 100;
+    cfg.beacon_interval_ms = 500;
+    strncpy(cfg.name, "chatterbox", THINKPACK_BOX_NAME_LEN - 1);
+
+    ESP_ERROR_CHECK(thinkpack_mesh_init(&cfg));
+    thinkpack_mesh_set_event_callback(group_mode_on_event, NULL);
+    ESP_ERROR_CHECK(thinkpack_mesh_start());
+
+    ESP_LOGI(TAG, "mesh started — spawning audio task");
+    xTaskCreate(audio_task, "chat_audio", 4096, NULL, 5, NULL);
+
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(10000));
+        ESP_LOGI(TAG, "peers=%u clip=%u samples", (unsigned)thinkpack_mesh_peer_count(),
+                 (unsigned)audio_engine_clip_sample_count());
+    }
+}

--- a/packages/thinkpack/chatterbox/main/standalone_mode.c
+++ b/packages/thinkpack/chatterbox/main/standalone_mode.c
@@ -1,0 +1,62 @@
+/**
+ * @file standalone_mode.c
+ * @brief Touch-to-record / touch-to-playback loop (no peers).
+ */
+
+#include "standalone_mode.h"
+
+#include "audio_engine.h"
+#include "esp_log.h"
+#include "thinkpack_audio.h"
+
+static const char *TAG = "standalone";
+
+static thinkpack_audio_sm_t s_sm;
+
+void standalone_mode_init(void)
+{
+    thinkpack_audio_sm_init(&s_sm);
+}
+
+static void handle_post_touch_state(thinkpack_audio_state_t st)
+{
+    switch (st) {
+        case THINKPACK_AUDIO_STATE_RECORDING:
+            ESP_LOGI(TAG, "recording...");
+            audio_engine_record_start();
+            break;
+        case THINKPACK_AUDIO_STATE_PLAYING: {
+            size_t n = 0;
+            audio_engine_record_stop(&n);
+            ESP_LOGI(TAG, "playback %u samples", (unsigned)n);
+            audio_engine_playback();
+            thinkpack_audio_sm_handle(&s_sm, THINKPACK_AUDIO_EVENT_CLIP_DONE);
+            break;
+        }
+        case THINKPACK_AUDIO_STATE_IDLE:
+            /* Nothing to do. */
+            break;
+    }
+}
+
+void standalone_mode_on_touch(bool pressed)
+{
+    thinkpack_audio_event_t ev =
+        pressed ? THINKPACK_AUDIO_EVENT_TOUCH_START : THINKPACK_AUDIO_EVENT_TOUCH_END;
+    thinkpack_audio_state_t st = thinkpack_audio_sm_handle(&s_sm, ev);
+    handle_post_touch_state(st);
+}
+
+void standalone_mode_tick(void)
+{
+    if (s_sm.state != THINKPACK_AUDIO_STATE_RECORDING) {
+        return;
+    }
+    bool limit = false;
+    audio_engine_record_tick(&limit);
+    if (limit) {
+        thinkpack_audio_state_t st =
+            thinkpack_audio_sm_handle(&s_sm, THINKPACK_AUDIO_EVENT_LIMIT_REACHED);
+        handle_post_touch_state(st);
+    }
+}

--- a/packages/thinkpack/chatterbox/main/standalone_mode.h
+++ b/packages/thinkpack/chatterbox/main/standalone_mode.h
@@ -1,0 +1,40 @@
+/**
+ * @file standalone_mode.h
+ * @brief Touch-to-record / touch-to-playback loop when no peers are around.
+ *
+ * Owns a thinkpack_audio_sm_t and drives the audio engine from touch edge
+ * events.  Call standalone_mode_init() once at boot.  Touch edge callbacks
+ * arrive via standalone_mode_on_touch() which posts the corresponding
+ * THINKPACK_AUDIO_EVENT_* to the state machine and triggers the audio
+ * engine accordingly.
+ */
+
+#ifndef STANDALONE_MODE_H
+#define STANDALONE_MODE_H
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Initialise the state machine and internal state. */
+void standalone_mode_init(void);
+
+/** Feed a touch edge event (true=pressed, false=released). */
+void standalone_mode_on_touch(bool pressed);
+
+/**
+ * @brief Tick the recorder while a touch is held.
+ *
+ * Called every TOUCH poll interval from the application task.  Pulls
+ * samples from the audio engine and forces playback if the clip-length
+ * cap is reached.
+ */
+void standalone_mode_tick(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STANDALONE_MODE_H */

--- a/packages/thinkpack/chatterbox/main/touch_driver.c
+++ b/packages/thinkpack/chatterbox/main/touch_driver.c
@@ -1,0 +1,103 @@
+/**
+ * @file touch_driver.c
+ * @brief Minimal touch_pad polling driver — one pad, edge callbacks.
+ *
+ * Calibrates on boot by sampling the untouched baseline for 200 ms, then
+ * polls at 50 Hz.  A reading below (baseline × TOUCH_THRESHOLD_RATIO) is
+ * treated as a press.
+ *
+ * Hardware-unverified.  Uses the legacy touch_pad API which is still the
+ * supported path on S3 as of ESP-IDF 5.4; migrate to touch_element if/when
+ * the legacy API is deprecated.
+ */
+
+#include "touch_driver.h"
+
+#include "driver/touch_pad.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+static const char *TAG = "touch";
+
+/* Single pad — GPIO14 on ESP32-S3 is touch channel 14. Update pin + channel
+ * together if you move the pad.  See WIRING.md. */
+#define TOUCH_CHANNEL TOUCH_PAD_NUM14
+
+#define TOUCH_BASELINE_SAMPLES 10
+#define TOUCH_BASELINE_DELAY_MS 20
+#define TOUCH_POLL_PERIOD_MS 20
+/* Press threshold — a touched pad reads ~40 % of the untouched baseline. */
+#define TOUCH_THRESHOLD_NUM 60
+#define TOUCH_THRESHOLD_DEN 100
+
+static touch_driver_cb_t s_cb;
+static uint32_t s_baseline;
+static bool s_pressed;
+
+static uint32_t sample_pad(void)
+{
+    uint32_t v = 0;
+    touch_pad_read_raw_data(TOUCH_CHANNEL, &v);
+    return v;
+}
+
+static void calibrate_baseline(void)
+{
+    uint64_t sum = 0;
+    for (int i = 0; i < TOUCH_BASELINE_SAMPLES; i++) {
+        sum += sample_pad();
+        vTaskDelay(pdMS_TO_TICKS(TOUCH_BASELINE_DELAY_MS));
+    }
+    s_baseline = (uint32_t)(sum / TOUCH_BASELINE_SAMPLES);
+    ESP_LOGI(TAG, "touch baseline = %u", (unsigned)s_baseline);
+}
+
+static void touch_task(void *arg)
+{
+    (void)arg;
+    calibrate_baseline();
+    uint32_t threshold =
+        (uint32_t)((uint64_t)s_baseline * TOUCH_THRESHOLD_NUM / TOUCH_THRESHOLD_DEN);
+
+    for (;;) {
+        uint32_t v = sample_pad();
+        bool now_pressed = (v != 0 && v < threshold);
+        if (now_pressed != s_pressed) {
+            s_pressed = now_pressed;
+            if (s_cb != NULL) {
+                s_cb(now_pressed);
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(TOUCH_POLL_PERIOD_MS));
+    }
+}
+
+esp_err_t touch_driver_init(touch_driver_cb_t cb)
+{
+    s_cb = cb;
+
+    esp_err_t err = touch_pad_init();
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = touch_pad_config(TOUCH_CHANNEL);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = touch_pad_fsm_start();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    BaseType_t rc = xTaskCreate(touch_task, "touch", 3072, NULL, 4, NULL);
+    if (rc != pdPASS) {
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+
+bool touch_driver_is_pressed(void)
+{
+    return s_pressed;
+}

--- a/packages/thinkpack/chatterbox/main/touch_driver.h
+++ b/packages/thinkpack/chatterbox/main/touch_driver.h
@@ -1,0 +1,38 @@
+/**
+ * @file touch_driver.h
+ * @brief ESP32-S3 native capacitive touch wrapper for Chatterbox.
+ *
+ * Wraps the touch_pad driver in a small callback-based API.  Emits edge
+ * events (press / release) that feed a thinkpack_audio_sm_t via the mode
+ * modules.  Hardware-unverified.
+ */
+
+#ifndef TOUCH_DRIVER_H
+#define TOUCH_DRIVER_H
+
+#include <stdbool.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*touch_driver_cb_t)(bool pressed);
+
+/**
+ * @brief Initialise the touch peripheral and start the polling task.
+ *
+ * @param cb  Callback invoked on every edge (pressed=true / pressed=false).
+ *            Called from the polling task — must not block.
+ */
+esp_err_t touch_driver_init(touch_driver_cb_t cb);
+
+/** Return the last cached pressed state (for diagnostics). */
+bool touch_driver_is_pressed(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TOUCH_DRIVER_H */

--- a/packages/thinkpack/chatterbox/sdkconfig.defaults
+++ b/packages/thinkpack/chatterbox/sdkconfig.defaults
@@ -1,0 +1,46 @@
+# ESP32-S3 target (SuperMini variant — DIO flash / octal PSRAM)
+CONFIG_IDF_TARGET="esp32s3"
+
+# USB-Serial-JTAG for monitoring / flashing
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+
+# WiFi — required by ESP-NOW
+CONFIG_ESP_WIFI_ENABLED=y
+CONFIG_ESP_WIFI_ESPNOW_ENABLED=y
+
+# Disable WiFi AMPDU (S3 AP visibility workaround also applies to ESP-NOW peering)
+CONFIG_ESP_WIFI_AMPDU_RX_ENABLED=n
+CONFIG_ESP_WIFI_AMPDU_TX_ENABLED=n
+
+# Chatterbox is ESP-NOW only — no STA credentials persisted
+CONFIG_ESP_WIFI_NVS_ENABLED=n
+
+# Reduce WiFi buffers to make room for audio in RAM
+CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=4
+CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM=8
+CONFIG_ESP_WIFI_DYNAMIC_TX_BUFFER_NUM=8
+CONFIG_ESP_WIFI_11KV_SUPPORT=n
+
+# No Bluetooth
+CONFIG_BT_ENABLED=n
+
+# PSRAM — required for the 2 s clip buffer (32000 samples × 2 bytes = 64 KB)
+#
+# SuperMini ESP32-S3 boards ship with octal PSRAM; swap to _MODE_QUAD if you
+# are using a QIO variant.
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_OCT=y
+CONFIG_SPIRAM_SPEED_80M=y
+CONFIG_SPIRAM_USE_CAPS_ALLOC=y
+
+# Partition table — default single factory app is fine for now
+CONFIG_PARTITION_TABLE_SINGLE_APP=y
+
+# Logging level
+CONFIG_LOG_DEFAULT_LEVEL_INFO=y
+
+# Larger main task stack for WiFi + ESP-NOW + I2S init in a single task
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# Flash size (SuperMini 4 MB)
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y


### PR DESCRIPTION
## Summary
- Closes #197 — Chatterbox firmware and Echo Chamber mesh behaviour.
- New pure-logic consumer of `thinkpack-audio` (no PCM handled by the behaviour layer).
- Pre-reserved message ID `MSG_AUDIO_CLIP_BROADCAST = 0x0D` added to protocol; `0x0E` left reserved with an explanatory comment.

## Hardware verification status
**Not yet tested on hardware.** I2S TX (MAX98357A), I2S RX (INMP441), ESP32-S3 native touch peripheral, and PSRAM clip storage are implementation-only; tracked for hardware verification after the merged firmware bundle is flashed to physical boxes.

## Transport note
`MSG_AUDIO_CLIP_BROADCAST` is sent via `thinkpack_mesh_send_large()` so it traverses the existing fragmentation / reassembly path. Followers observe it through `THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED` with `original_msg_type == MSG_AUDIO_CLIP_BROADCAST`. No mesh core changes were needed.

## Test plan
- [ ] `make test` in `packages/components/thinkpack-behaviors/test/` — all assertions pass (62 new + 142 existing).
- [ ] `make test` in `packages/components/thinkpack-audio/test/` — no regressions (74 passing).
- [ ] `clang-format --dry-run --Werror` clean on all new sources.
- [ ] `just --list` shows `thinkpack-chatterbox` module.
- [ ] CI green (conventional-commits, format, C/C++ lint, host tests, secret scan, detect changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)