### PR TITLE
feat(thinkpack): PR E — Finderbox group mode (Hot-Cold + NFC Story Sounds)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !.claude/skills/build/
 # Host test binaries (produced by make test in test/ directories)
 test_runner
+*_test_runner
 target/
 *.o
 *.a

--- a/packages/components/thinkpack-behaviors/CMakeLists.txt
+++ b/packages/components/thinkpack-behaviors/CMakeLists.txt
@@ -1,6 +1,8 @@
 idf_component_register(SRCS "command_dispatcher.c"
                             "command_executor.c"
                             "echo_chamber.c"
+                            "hot_cold.c"
+                            "nfc_story_sounds.c"
                     INCLUDE_DIRS "include"
                     REQUIRES thinkpack-protocol log esp_common
                     PRIV_REQUIRES freertos)

--- a/packages/components/thinkpack-behaviors/hot_cold.c
+++ b/packages/components/thinkpack-behaviors/hot_cold.c
@@ -1,0 +1,121 @@
+/**
+ * @file hot_cold.c
+ * @brief RSSI smoothing + blue→red colour mapping for Finderbox seek mode.
+ *
+ * Pure integer math; no ESP-IDF or hardware dependencies — fully host
+ * testable.  See hot_cold.h for API documentation.
+ */
+
+#include "hot_cold.h"
+
+#include <limits.h>
+#include <stddef.h>
+
+/* Exponential moving average factor: α = 1/4.
+ * new_q8 = old_q8 + (sample_q8 - old_q8) >> 2. */
+#define HOT_COLD_EMA_SHIFT 2
+
+/* Q8.8 helpers — keep one bit of headroom for signed right-shift of
+ * the difference (absolute value well below 2^15 for realistic RSSI). */
+#define HOT_COLD_Q8(x) ((int16_t)((int32_t)(x) * 256))
+#define HOT_COLD_FROM_Q8(x) ((int16_t)((x) / 256))
+
+/* ------------------------------------------------------------------ */
+/* State                                                               */
+/* ------------------------------------------------------------------ */
+
+void hot_cold_reset(hot_cold_state_t *state)
+{
+    if (state == NULL) {
+        return;
+    }
+    state->smoothed_q8 = 0;
+    state->primed = false;
+}
+
+void hot_cold_update(hot_cold_state_t *state, int8_t rssi_dbm)
+{
+    if (state == NULL) {
+        return;
+    }
+
+    int16_t sample_q8 = HOT_COLD_Q8(rssi_dbm);
+
+    if (!state->primed) {
+        state->smoothed_q8 = sample_q8;
+        state->primed = true;
+        return;
+    }
+
+    /* new = old + (sample - old) / 4  — integer EMA. */
+    int32_t diff = (int32_t)sample_q8 - (int32_t)state->smoothed_q8;
+    int32_t next = (int32_t)state->smoothed_q8 + (diff >> HOT_COLD_EMA_SHIFT);
+
+    /* Clamp to int16_t range before storing; real RSSI values keep this
+     * comfortably inside bounds but be defensive. */
+    if (next > INT16_MAX) {
+        next = INT16_MAX;
+    } else if (next < INT16_MIN) {
+        next = INT16_MIN;
+    }
+    state->smoothed_q8 = (int16_t)next;
+}
+
+int8_t hot_cold_smoothed_dbm(const hot_cold_state_t *state)
+{
+    if (state == NULL || !state->primed) {
+        return INT8_MIN;
+    }
+    int16_t dbm = HOT_COLD_FROM_Q8(state->smoothed_q8);
+    if (dbm > INT8_MAX) {
+        return INT8_MAX;
+    }
+    if (dbm < INT8_MIN) {
+        return INT8_MIN;
+    }
+    return (int8_t)dbm;
+}
+
+/* ------------------------------------------------------------------ */
+/* Colour mapping                                                      */
+/* ------------------------------------------------------------------ */
+
+/* Map a smoothed dBm value to a 0..255 "heat" intensity.  Values at or
+ * below HOT_COLD_RSSI_MIN produce 0 (cold / blue); values at or above
+ * HOT_COLD_RSSI_MAX produce 255 (hot / red). */
+static uint8_t heat_intensity(int dbm)
+{
+    if (dbm <= HOT_COLD_RSSI_MIN) {
+        return 0;
+    }
+    if (dbm >= HOT_COLD_RSSI_MAX) {
+        return 255;
+    }
+    int span = HOT_COLD_RSSI_MAX - HOT_COLD_RSSI_MIN;
+    int numer = (dbm - HOT_COLD_RSSI_MIN) * 255;
+    return (uint8_t)(numer / span);
+}
+
+void hot_cold_get_color(const hot_cold_state_t *state, uint8_t *r, uint8_t *g, uint8_t *b)
+{
+    uint8_t red = 0;
+    uint8_t green = 0;
+    uint8_t blue = 255;
+
+    if (state != NULL && state->primed) {
+        int dbm = HOT_COLD_FROM_Q8(state->smoothed_q8);
+        uint8_t heat = heat_intensity(dbm);
+        red = heat;
+        blue = (uint8_t)(255 - heat);
+    }
+
+    if (r != NULL) {
+        *r = red;
+    }
+    if (g != NULL) {
+        *g = green;
+    }
+    if (b != NULL) {
+        *b = blue;
+    }
+}

--- a/packages/components/thinkpack-behaviors/include/hot_cold.h
+++ b/packages/components/thinkpack-behaviors/include/hot_cold.h
@@ -1,0 +1,94 @@
+/**
+ * @file hot_cold.h
+ * @brief RSSI-driven "hot-cold" indicator logic for Finderbox group mode.
+ *
+ * Maintains an exponential moving average of RSSI samples (α = 1/4, pure
+ * integer math — no floating point or ESP-IDF dependencies) and converts
+ * the smoothed value into an RGB gradient running from cold blue
+ * (weak signal, distant target) to hot red (strong signal, target close).
+ *
+ * All logic lives in the `thinkpack-behaviors` component so the math is
+ * host-testable; Finderbox's group_mode.c is the only caller under ESP-IDF.
+ *
+ * Typical usage:
+ * @code
+ *   hot_cold_state_t state;
+ *   hot_cold_reset(&state);
+ *   hot_cold_update(&state, -60);
+ *   uint8_t r, g, b;
+ *   hot_cold_get_color(&state, &r, &g, &b);
+ *   led_ring_fill(r, g, b);
+ *   led_ring_show();
+ * @endcode
+ */
+
+#ifndef HOT_COLD_H
+#define HOT_COLD_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Lower bound (weakest signal, coldest) of the mapped RSSI range, dBm. */
+#define HOT_COLD_RSSI_MIN (-90)
+
+/** Upper bound (strongest signal, hottest) of the mapped RSSI range, dBm. */
+#define HOT_COLD_RSSI_MAX (-30)
+
+/**
+ * @brief Running hot-cold filter state.
+ *
+ * Store one instance per target.  Use ::hot_cold_reset before the first
+ * ::hot_cold_update call so the filter warms up from the first sample
+ * instead of jumping toward zero.
+ */
+typedef struct {
+    int16_t smoothed_q8; /**< Smoothed RSSI scaled ×256 (Q8.8 fixed point) */
+    bool primed;         /**< true once at least one sample has been taken */
+} hot_cold_state_t;
+
+/**
+ * @brief Reset @p state so the next sample seeds the filter directly.
+ *
+ * Safe to call on a NULL pointer.
+ */
+void hot_cold_reset(hot_cold_state_t *state);
+
+/**
+ * @brief Fold @p rssi_dbm into the running EMA.
+ *
+ * On the first (primed=false) call the value is adopted verbatim so the
+ * indicator doesn't need multiple samples to leave the -128 dBm default.
+ * Subsequent calls apply an α = 1/4 EMA: new = old + (sample - old) / 4.
+ *
+ * @p state must not be NULL.
+ */
+void hot_cold_update(hot_cold_state_t *state, int8_t rssi_dbm);
+
+/**
+ * @brief Current smoothed RSSI in dBm (integer), or INT8_MIN if never primed.
+ */
+int8_t hot_cold_smoothed_dbm(const hot_cold_state_t *state);
+
+/**
+ * @brief Map the current smoothed RSSI to an RGB gradient.
+ *
+ * The gradient is a straight linear blend from blue (r=0, g=0, b=255) at
+ * HOT_COLD_RSSI_MIN to red (r=255, g=0, b=0) at HOT_COLD_RSSI_MAX.  The
+ * green channel stays at 0 to keep the "cool→warm" semantic obvious.
+ * Output is safe to drop into led_ring_fill() directly — the Finderbox
+ * LED ring applies its own brightness cap.
+ *
+ * If @p state has never been primed the function outputs pure blue.
+ * Any of @p r/@p g/@p b may be NULL to skip that channel.
+ */
+void hot_cold_get_color(const hot_cold_state_t *state, uint8_t *r, uint8_t *g, uint8_t *b);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HOT_COLD_H */

--- a/packages/components/thinkpack-behaviors/include/nfc_story_sounds.h
+++ b/packages/components/thinkpack-behaviors/include/nfc_story_sounds.h
@@ -1,0 +1,95 @@
+/**
+ * @file nfc_story_sounds.h
+ * @brief Parser + dispatcher for LLM-generated NFC "story sound" sequences.
+ *
+ * Brainbox returns a short JSON document describing a sequence of audio
+ * actions for a tagged story fragment; Finderbox parses it offline and
+ * walks the sequence, invoking an application-supplied dispatch callback
+ * for each step.  The parser is intentionally tiny and hand-rolled — no
+ * cJSON dependency, safe on the host for unit tests.
+ *
+ * Supported JSON shape:
+ * @code
+ *   {"sequence":[
+ *     {"kind":"tone","param":440},
+ *     {"kind":"wait","param":120},
+ *     {"kind":"clip","param":3}
+ *   ]}
+ * @endcode
+ *
+ * Grammar (whitespace between tokens is permitted):
+ *   root       = '{' '"sequence"' ':' '[' step (',' step)* ']' '}'
+ *   step       = '{' '"kind"' ':' '"' KIND '"' ',' '"param"' ':' INT '}'
+ *   KIND       = "tone" | "clip" | "wait"
+ *   INT        = signed decimal integer, fits in int32_t
+ *
+ * Any deviation (bad keys, unexpected token, overflow, too many steps)
+ * fails the parse cleanly and leaves @p out zero-initialised.
+ */
+
+#ifndef NFC_STORY_SOUNDS_H
+#define NFC_STORY_SOUNDS_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum steps in a parsed story sequence. */
+#define NFC_STORY_SOUNDS_MAX_STEPS 16
+
+/** Step kinds understood by the dispatcher. */
+typedef enum {
+    NFC_STORY_KIND_TONE = 0, /**< param = frequency in Hz (e.g. 440) */
+    NFC_STORY_KIND_CLIP = 1, /**< param = chatterbox clip_id to broadcast */
+    NFC_STORY_KIND_WAIT = 2, /**< param = delay in milliseconds */
+} nfc_story_kind_t;
+
+/** One parsed step. */
+typedef struct {
+    uint8_t kind;  /**< @ref nfc_story_kind_t */
+    int32_t param; /**< kind-specific integer parameter */
+} story_step_t;
+
+/** Parsed sequence. */
+typedef struct {
+    story_step_t steps[NFC_STORY_SOUNDS_MAX_STEPS];
+    uint8_t count; /**< Valid entries in steps[] */
+} story_sequence_t;
+
+/**
+ * @brief Dispatch callback invoked once per step during execute.
+ *
+ * The callback is called synchronously from @ref nfc_story_sounds_execute
+ * and is free to block (e.g. for WAIT steps).  Return a non-zero value to
+ * abort the remaining sequence.
+ */
+typedef int (*audio_dispatch_fn)(uint8_t kind, int32_t param, void *user_ctx);
+
+/**
+ * @brief Parse @p json into @p out.
+ *
+ * @param json  JSON text (not required to be NUL-terminated).
+ * @param len   Number of bytes in @p json.
+ * @param out   Destination.  Zeroed on entry and left zeroed on failure.
+ * @return true if the sequence was fully parsed, false on any error.
+ */
+bool nfc_story_sounds_parse(const char *json, size_t len, story_sequence_t *out);
+
+/**
+ * @brief Invoke @p dispatch once for each step in @p seq.
+ *
+ * Stops early and returns the dispatcher's non-zero return value if any
+ * step rejects the dispatch; otherwise returns 0 once all steps have fired.
+ */
+int nfc_story_sounds_execute(const story_sequence_t *seq, audio_dispatch_fn dispatch,
+                             void *user_ctx);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NFC_STORY_SOUNDS_H */

--- a/packages/components/thinkpack-behaviors/nfc_story_sounds.c
+++ b/packages/components/thinkpack-behaviors/nfc_story_sounds.c
@@ -1,0 +1,312 @@
+/**
+ * @file nfc_story_sounds.c
+ * @brief Hand-rolled JSON parser + dispatcher for NFC story sound sequences.
+ *
+ * See nfc_story_sounds.h for the accepted grammar.  The parser walks the
+ * input character-by-character, keeping a small cursor; no allocations and
+ * no external JSON library.
+ */
+
+#include "nfc_story_sounds.h"
+
+#include <string.h>
+
+/* ------------------------------------------------------------------ */
+/* Parser state                                                        */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    const char *buf;
+    size_t len;
+    size_t pos;
+} parser_t;
+
+static bool at_end(const parser_t *p)
+{
+    return p->pos >= p->len;
+}
+
+static void skip_ws(parser_t *p)
+{
+    while (!at_end(p)) {
+        char c = p->buf[p->pos];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') {
+            p->pos++;
+            continue;
+        }
+        break;
+    }
+}
+
+static bool consume_char(parser_t *p, char expected)
+{
+    skip_ws(p);
+    if (at_end(p) || p->buf[p->pos] != expected) {
+        return false;
+    }
+    p->pos++;
+    return true;
+}
+
+/* Match a double-quoted literal — e.g. consume_literal_string(p, "sequence")
+ * matches `"sequence"` exactly.  Leading whitespace is skipped.  No escape
+ * processing; we only compare ASCII runs. */
+static bool consume_literal_string(parser_t *p, const char *literal)
+{
+    skip_ws(p);
+    size_t lit_len = strlen(literal);
+    if (p->len - p->pos < lit_len + 2) {
+        return false;
+    }
+    if (p->buf[p->pos] != '"') {
+        return false;
+    }
+    if (memcmp(p->buf + p->pos + 1, literal, lit_len) != 0) {
+        return false;
+    }
+    if (p->buf[p->pos + 1 + lit_len] != '"') {
+        return false;
+    }
+    p->pos += lit_len + 2;
+    return true;
+}
+
+/* Read a quoted string into out_buf (NUL-terminated, at most out_cap bytes
+ * including terminator).  No escape handling — rejects backslashes outright
+ * to keep the parser strict and short. */
+static bool consume_quoted_string(parser_t *p, char *out_buf, size_t out_cap)
+{
+    skip_ws(p);
+    if (at_end(p) || p->buf[p->pos] != '"') {
+        return false;
+    }
+    p->pos++;
+    size_t written = 0;
+    while (!at_end(p) && p->buf[p->pos] != '"') {
+        char c = p->buf[p->pos];
+        if (c == '\\') {
+            return false;
+        }
+        if (written + 1 >= out_cap) {
+            return false;
+        }
+        out_buf[written++] = c;
+        p->pos++;
+    }
+    if (at_end(p)) {
+        return false;
+    }
+    p->pos++; /* closing quote */
+    out_buf[written] = '\0';
+    return true;
+}
+
+/* Parse a signed decimal integer into *out.  Rejects overflow beyond int32. */
+static bool consume_integer(parser_t *p, int32_t *out)
+{
+    skip_ws(p);
+    if (at_end(p)) {
+        return false;
+    }
+    size_t start = p->pos;
+    int sign = 1;
+    if (p->buf[p->pos] == '-') {
+        sign = -1;
+        p->pos++;
+    } else if (p->buf[p->pos] == '+') {
+        p->pos++;
+    }
+    if (at_end(p) || p->buf[p->pos] < '0' || p->buf[p->pos] > '9') {
+        p->pos = start;
+        return false;
+    }
+    int64_t acc = 0;
+    while (!at_end(p) && p->buf[p->pos] >= '0' && p->buf[p->pos] <= '9') {
+        acc = acc * 10 + (p->buf[p->pos] - '0');
+        if (acc > (int64_t)2147483647LL + 1) {
+            return false;
+        }
+        p->pos++;
+    }
+    acc *= sign;
+    if (acc > 2147483647LL || acc < -2147483648LL) {
+        return false;
+    }
+    *out = (int32_t)acc;
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Higher-level parse helpers                                          */
+/* ------------------------------------------------------------------ */
+
+static bool kind_from_string(const char *s, uint8_t *out)
+{
+    if (strcmp(s, "tone") == 0) {
+        *out = (uint8_t)NFC_STORY_KIND_TONE;
+        return true;
+    }
+    if (strcmp(s, "clip") == 0) {
+        *out = (uint8_t)NFC_STORY_KIND_CLIP;
+        return true;
+    }
+    if (strcmp(s, "wait") == 0) {
+        *out = (uint8_t)NFC_STORY_KIND_WAIT;
+        return true;
+    }
+    return false;
+}
+
+static bool parse_step(parser_t *p, story_step_t *step)
+{
+    if (!consume_char(p, '{')) {
+        return false;
+    }
+
+    bool have_kind = false;
+    bool have_param = false;
+    uint8_t kind = 0;
+    int32_t param = 0;
+
+    for (int field = 0; field < 2; field++) {
+        if (field > 0 && !consume_char(p, ',')) {
+            return false;
+        }
+
+        /* Key name — we accept "kind" or "param" in any order. */
+        skip_ws(p);
+        if (at_end(p) || p->buf[p->pos] != '"') {
+            return false;
+        }
+        char key[16];
+        if (!consume_quoted_string(p, key, sizeof(key))) {
+            return false;
+        }
+        if (!consume_char(p, ':')) {
+            return false;
+        }
+
+        if (strcmp(key, "kind") == 0) {
+            char kind_str[16];
+            if (!consume_quoted_string(p, kind_str, sizeof(kind_str))) {
+                return false;
+            }
+            if (!kind_from_string(kind_str, &kind)) {
+                return false;
+            }
+            have_kind = true;
+        } else if (strcmp(key, "param") == 0) {
+            if (!consume_integer(p, &param)) {
+                return false;
+            }
+            have_param = true;
+        } else {
+            return false;
+        }
+    }
+
+    if (!consume_char(p, '}')) {
+        return false;
+    }
+    if (!have_kind || !have_param) {
+        return false;
+    }
+
+    step->kind = kind;
+    step->param = param;
+    return true;
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+bool nfc_story_sounds_parse(const char *json, size_t len, story_sequence_t *out)
+{
+    if (out == NULL) {
+        return false;
+    }
+    memset(out, 0, sizeof(*out));
+
+    if (json == NULL || len == 0) {
+        return false;
+    }
+
+    parser_t p = {.buf = json, .len = len, .pos = 0};
+
+    if (!consume_char(&p, '{')) {
+        return false;
+    }
+    if (!consume_literal_string(&p, "sequence")) {
+        return false;
+    }
+    if (!consume_char(&p, ':')) {
+        return false;
+    }
+    if (!consume_char(&p, '[')) {
+        return false;
+    }
+
+    skip_ws(&p);
+    if (!at_end(&p) && p.buf[p.pos] == ']') {
+        /* Empty sequence — reject to keep the LLM contract simple. */
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+
+    uint8_t count = 0;
+    for (;;) {
+        if (count >= NFC_STORY_SOUNDS_MAX_STEPS) {
+            memset(out, 0, sizeof(*out));
+            return false;
+        }
+        story_step_t step;
+        if (!parse_step(&p, &step)) {
+            memset(out, 0, sizeof(*out));
+            return false;
+        }
+        out->steps[count++] = step;
+
+        skip_ws(&p);
+        if (!at_end(&p) && p.buf[p.pos] == ',') {
+            p.pos++;
+            continue;
+        }
+        break;
+    }
+
+    if (!consume_char(&p, ']')) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+    if (!consume_char(&p, '}')) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+
+    /* Trailing whitespace after the close-brace is permitted; anything
+     * else indicates malformed input. */
+    skip_ws(&p);
+    if (!at_end(&p)) {
+        memset(out, 0, sizeof(*out));
+        return false;
+    }
+
+    out->count = count;
+    return true;
+}
+
+int nfc_story_sounds_execute(const story_sequence_t *seq, audio_dispatch_fn dispatch,
+                             void *user_ctx)
+{
+    if (seq == NULL || dispatch == NULL) {
+        return -1;
+    }
+    for (uint8_t i = 0; i < seq->count; i++) {
+        int rc = dispatch(seq->steps[i].kind, seq->steps[i].param, user_ctx);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+    return 0;
+}

--- a/packages/components/thinkpack-behaviors/test/Makefile
+++ b/packages/components/thinkpack-behaviors/test/Makefile
@@ -1,13 +1,16 @@
 # Makefile for thinkpack-behaviors host-based unit tests
 #
-# Compiles command_dispatcher.c, command_executor.c, and echo_chamber.c for
-# Linux/macOS using gcc and runs Unity-compatible tests without ESP-IDF or
-# hardware.  Suitable for CI and local development.
+# Compiles command_dispatcher.c, command_executor.c, echo_chamber.c,
+# hot_cold.c and nfc_story_sounds.c for Linux/macOS using gcc and runs
+# Unity-compatible tests without ESP-IDF or hardware.  Suitable for CI
+# and local development.
 #
 # Usage:
 #   make test         — build and run all test binaries (default)
 #   make test_runner  — build/run the commands test binary
 #   make echo_chamber_test_runner — build/run the echo-chamber test binary
+#   make hot_cold_test_runner     — build/run the hot-cold test binary
+#   make nfc_story_sounds_test_runner — build/run the story-sounds test binary
 #   make clean        — remove build artefacts
 
 CC     = gcc
@@ -29,7 +32,14 @@ ECHO_SRCS     = echo_chamber_test.c \
                 ../echo_chamber.c \
                 $(COMMON_SRCS)
 
-TARGETS = test_runner echo_chamber_test_runner
+HOT_COLD_SRCS = test_hot_cold.c \
+                ../hot_cold.c
+
+STORY_SRCS    = test_nfc_story_sounds.c \
+                ../nfc_story_sounds.c
+
+TARGETS = test_runner echo_chamber_test_runner \
+          hot_cold_test_runner nfc_story_sounds_test_runner
 
 .PHONY: all test clean
 
@@ -38,12 +48,20 @@ all: test
 test: $(TARGETS)
 	./test_runner
 	./echo_chamber_test_runner
+	./hot_cold_test_runner
+	./nfc_story_sounds_test_runner
 
 test_runner: $(COMMANDS_SRCS) unity_compat.h stubs/esp_log.h stubs/esp_err.h
 	$(CC) $(CFLAGS) -o $@ $(COMMANDS_SRCS)
 
 echo_chamber_test_runner: $(ECHO_SRCS) unity_compat.h
 	$(CC) $(CFLAGS) -o $@ $(ECHO_SRCS)
+
+hot_cold_test_runner: $(HOT_COLD_SRCS) unity_compat.h
+	$(CC) $(CFLAGS) -o $@ $(HOT_COLD_SRCS)
+
+nfc_story_sounds_test_runner: $(STORY_SRCS) unity_compat.h
+	$(CC) $(CFLAGS) -o $@ $(STORY_SRCS)
 
 clean:
 	rm -f $(TARGETS)

--- a/packages/components/thinkpack-behaviors/test/test_hot_cold.c
+++ b/packages/components/thinkpack-behaviors/test/test_hot_cold.c
@@ -1,0 +1,193 @@
+/**
+ * @file test_hot_cold.c
+ * @brief Host-based unit tests for the hot_cold RSSI indicator.
+ */
+
+#include "hot_cold.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* Reset + priming                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_reset_marks_unprimed(void)
+{
+    hot_cold_state_t s = {.smoothed_q8 = 999, .primed = true};
+    hot_cold_reset(&s);
+    TEST_ASSERT_FALSE(s.primed);
+    TEST_ASSERT_EQUAL(0, s.smoothed_q8);
+}
+
+static void test_first_sample_adopted_verbatim(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, -60);
+    TEST_ASSERT_TRUE(s.primed);
+    TEST_ASSERT_EQUAL(-60, hot_cold_smoothed_dbm(&s));
+}
+
+static void test_unprimed_smoothed_reports_int8_min(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    TEST_ASSERT_EQUAL(-128, hot_cold_smoothed_dbm(&s));
+}
+
+/* ------------------------------------------------------------------ */
+/* EMA convergence                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_ema_converges_toward_sample(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, -80);
+    /* Feed -40 repeatedly; should approach -40 monotonically. */
+    int8_t prev = -80;
+    for (int i = 0; i < 30; i++) {
+        hot_cold_update(&s, -40);
+        int8_t now = hot_cold_smoothed_dbm(&s);
+        /* Non-increasing distance to -40. */
+        int dist_prev = prev < -40 ? (-40 - prev) : (prev + 40);
+        int dist_now = now < -40 ? (-40 - now) : (now + 40);
+        TEST_ASSERT_TRUE(dist_now <= dist_prev);
+        prev = now;
+    }
+    TEST_ASSERT_EQUAL(-40, hot_cold_smoothed_dbm(&s));
+}
+
+static void test_ema_step_is_quarter_of_delta(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, -80);
+    hot_cold_update(&s, -40); /* delta = +40, expected step = +10 */
+    TEST_ASSERT_EQUAL(-70, hot_cold_smoothed_dbm(&s));
+}
+
+/* ------------------------------------------------------------------ */
+/* Colour gradient                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_color_unprimed_is_pure_blue(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    uint8_t r = 42, g = 42, b = 42;
+    hot_cold_get_color(&s, &r, &g, &b);
+    TEST_ASSERT_EQUAL(0, r);
+    TEST_ASSERT_EQUAL(0, g);
+    TEST_ASSERT_EQUAL(255, b);
+}
+
+static void test_color_at_rssi_min_is_blue(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, (int8_t)HOT_COLD_RSSI_MIN);
+    uint8_t r, g, b;
+    hot_cold_get_color(&s, &r, &g, &b);
+    TEST_ASSERT_EQUAL(0, r);
+    TEST_ASSERT_EQUAL(0, g);
+    TEST_ASSERT_EQUAL(255, b);
+}
+
+static void test_color_at_rssi_max_is_red(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, (int8_t)HOT_COLD_RSSI_MAX);
+    uint8_t r, g, b;
+    hot_cold_get_color(&s, &r, &g, &b);
+    TEST_ASSERT_EQUAL(255, r);
+    TEST_ASSERT_EQUAL(0, g);
+    TEST_ASSERT_EQUAL(0, b);
+}
+
+static void test_color_clamps_above_max(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, -20); /* above RSSI_MAX */
+    uint8_t r, g, b;
+    hot_cold_get_color(&s, &r, &g, &b);
+    TEST_ASSERT_EQUAL(255, r);
+    TEST_ASSERT_EQUAL(0, b);
+}
+
+static void test_color_clamps_below_min(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, -110); /* below RSSI_MIN, but stored as int8 */
+    uint8_t r, g, b;
+    hot_cold_get_color(&s, &r, &g, &b);
+    TEST_ASSERT_EQUAL(0, r);
+    TEST_ASSERT_EQUAL(255, b);
+}
+
+static void test_color_midpoint_is_purple(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    /* Midpoint between -90 and -30 is -60. */
+    hot_cold_update(&s, -60);
+    uint8_t r, g, b;
+    hot_cold_get_color(&s, &r, &g, &b);
+    TEST_ASSERT_TRUE(r > 120 && r < 136);
+    TEST_ASSERT_EQUAL(0, g);
+    TEST_ASSERT_TRUE(b > 120 && b < 136);
+}
+
+static void test_color_accepts_null_channels(void)
+{
+    hot_cold_state_t s;
+    hot_cold_reset(&s);
+    hot_cold_update(&s, -30);
+    /* Should not crash. */
+    hot_cold_get_color(&s, NULL, NULL, NULL);
+    uint8_t r = 0;
+    hot_cold_get_color(&s, &r, NULL, NULL);
+    TEST_ASSERT_EQUAL(255, r);
+}
+
+/* ------------------------------------------------------------------ */
+/* Null-safety                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_null_state_noops(void)
+{
+    hot_cold_reset(NULL);
+    hot_cold_update(NULL, -50);
+    TEST_ASSERT_EQUAL(-128, hot_cold_smoothed_dbm(NULL));
+    uint8_t r = 5, g = 5, b = 5;
+    hot_cold_get_color(NULL, &r, &g, &b);
+    /* NULL state treated as unprimed → pure blue */
+    TEST_ASSERT_EQUAL(0, r);
+    TEST_ASSERT_EQUAL(0, g);
+    TEST_ASSERT_EQUAL(255, b);
+}
+
+/* ------------------------------------------------------------------ */
+/* Main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_reset_marks_unprimed);
+    RUN_TEST(test_first_sample_adopted_verbatim);
+    RUN_TEST(test_unprimed_smoothed_reports_int8_min);
+    RUN_TEST(test_ema_converges_toward_sample);
+    RUN_TEST(test_ema_step_is_quarter_of_delta);
+    RUN_TEST(test_color_unprimed_is_pure_blue);
+    RUN_TEST(test_color_at_rssi_min_is_blue);
+    RUN_TEST(test_color_at_rssi_max_is_red);
+    RUN_TEST(test_color_clamps_above_max);
+    RUN_TEST(test_color_clamps_below_min);
+    RUN_TEST(test_color_midpoint_is_purple);
+    RUN_TEST(test_color_accepts_null_channels);
+    RUN_TEST(test_null_state_noops);
+    return UNITY_END();
+}

--- a/packages/components/thinkpack-behaviors/test/test_nfc_story_sounds.c
+++ b/packages/components/thinkpack-behaviors/test/test_nfc_story_sounds.c
@@ -1,0 +1,244 @@
+/**
+ * @file test_nfc_story_sounds.c
+ * @brief Host-based unit tests for the NFC story sounds parser + dispatcher.
+ */
+
+#include <string.h>
+
+#include "nfc_story_sounds.h"
+#include "unity_compat.h"
+
+/* ------------------------------------------------------------------ */
+/* Parser — happy path                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_single_tone(void)
+{
+    const char *j = "{\"sequence\":[{\"kind\":\"tone\",\"param\":440}]}";
+    story_sequence_t out;
+    TEST_ASSERT_TRUE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(1, out.count);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_TONE, out.steps[0].kind);
+    TEST_ASSERT_EQUAL(440, out.steps[0].param);
+}
+
+static void test_parse_all_kinds(void)
+{
+    const char *j = "{\"sequence\":["
+                    "{\"kind\":\"tone\",\"param\":440},"
+                    "{\"kind\":\"wait\",\"param\":120},"
+                    "{\"kind\":\"clip\",\"param\":3}"
+                    "]}";
+    story_sequence_t out;
+    TEST_ASSERT_TRUE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(3, out.count);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_TONE, out.steps[0].kind);
+    TEST_ASSERT_EQUAL(440, out.steps[0].param);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_WAIT, out.steps[1].kind);
+    TEST_ASSERT_EQUAL(120, out.steps[1].param);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_CLIP, out.steps[2].kind);
+    TEST_ASSERT_EQUAL(3, out.steps[2].param);
+}
+
+static void test_parse_whitespace_and_negative_param(void)
+{
+    const char *j = "{ \"sequence\" : [ {\n"
+                    "  \"kind\" : \"wait\" , \"param\" : -10\n"
+                    "} ] }";
+    story_sequence_t out;
+    TEST_ASSERT_TRUE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(1, out.count);
+    TEST_ASSERT_EQUAL(-10, out.steps[0].param);
+}
+
+static void test_parse_param_before_kind(void)
+{
+    const char *j = "{\"sequence\":[{\"param\":880,\"kind\":\"tone\"}]}";
+    story_sequence_t out;
+    TEST_ASSERT_TRUE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(1, out.count);
+    TEST_ASSERT_EQUAL(880, out.steps[0].param);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_TONE, out.steps[0].kind);
+}
+
+/* ------------------------------------------------------------------ */
+/* Parser — failure modes                                              */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_rejects_null_inputs(void)
+{
+    story_sequence_t out;
+    memset(&out, 0xCC, sizeof(out));
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(NULL, 0, &out));
+    TEST_ASSERT_EQUAL(0, out.count);
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse("anything", 0, &out));
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse("{", 1, NULL));
+}
+
+static void test_parse_rejects_malformed_brace(void)
+{
+    const char *j = "{\"sequence\":[{\"kind\":\"tone\",\"param\":440}";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(0, out.count);
+}
+
+static void test_parse_rejects_truncated(void)
+{
+    const char *j = "{\"sequence\":[{\"kind\":\"ton";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(0, out.count);
+}
+
+static void test_parse_rejects_wrong_root_key(void)
+{
+    const char *j = "{\"seq\":[{\"kind\":\"tone\",\"param\":440}]}";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(0, out.count);
+}
+
+static void test_parse_rejects_unknown_kind(void)
+{
+    const char *j = "{\"sequence\":[{\"kind\":\"screech\",\"param\":1}]}";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+}
+
+static void test_parse_rejects_missing_param(void)
+{
+    const char *j = "{\"sequence\":[{\"kind\":\"tone\"}]}";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+}
+
+static void test_parse_rejects_empty_sequence(void)
+{
+    const char *j = "{\"sequence\":[]}";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+    TEST_ASSERT_EQUAL(0, out.count);
+}
+
+static void test_parse_rejects_too_many_steps(void)
+{
+    /* Build a sequence with MAX+1 steps. */
+    char j[1024];
+    size_t pos = 0;
+    pos += (size_t)snprintf(j + pos, sizeof(j) - pos, "{\"sequence\":[");
+    for (int i = 0; i < NFC_STORY_SOUNDS_MAX_STEPS + 1; i++) {
+        pos += (size_t)snprintf(j + pos, sizeof(j) - pos, "%s{\"kind\":\"wait\",\"param\":%d}",
+                                i == 0 ? "" : ",", i);
+    }
+    pos += (size_t)snprintf(j + pos, sizeof(j) - pos, "]}");
+
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, pos, &out));
+    TEST_ASSERT_EQUAL(0, out.count);
+}
+
+static void test_parse_rejects_trailing_garbage(void)
+{
+    const char *j = "{\"sequence\":[{\"kind\":\"tone\",\"param\":440}]}XYZ";
+    story_sequence_t out;
+    TEST_ASSERT_FALSE(nfc_story_sounds_parse(j, strlen(j), &out));
+}
+
+/* ------------------------------------------------------------------ */
+/* Execute                                                             */
+/* ------------------------------------------------------------------ */
+
+typedef struct {
+    int call_count;
+    uint8_t kinds[NFC_STORY_SOUNDS_MAX_STEPS];
+    int32_t params[NFC_STORY_SOUNDS_MAX_STEPS];
+    int abort_after; /**< -1 = never abort */
+} exec_ctx_t;
+
+static int mock_dispatch(uint8_t kind, int32_t param, void *user_ctx)
+{
+    exec_ctx_t *c = (exec_ctx_t *)user_ctx;
+    c->kinds[c->call_count] = kind;
+    c->params[c->call_count] = param;
+    c->call_count++;
+    if (c->abort_after >= 0 && c->call_count > c->abort_after) {
+        return 42;
+    }
+    return 0;
+}
+
+static void test_execute_invokes_each_step_in_order(void)
+{
+    const char *j = "{\"sequence\":["
+                    "{\"kind\":\"tone\",\"param\":100},"
+                    "{\"kind\":\"wait\",\"param\":200},"
+                    "{\"kind\":\"clip\",\"param\":300}"
+                    "]}";
+    story_sequence_t seq;
+    TEST_ASSERT_TRUE(nfc_story_sounds_parse(j, strlen(j), &seq));
+
+    exec_ctx_t ctx = {0};
+    ctx.abort_after = -1;
+    int rc = nfc_story_sounds_execute(&seq, mock_dispatch, &ctx);
+    TEST_ASSERT_EQUAL(0, rc);
+    TEST_ASSERT_EQUAL(3, ctx.call_count);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_TONE, ctx.kinds[0]);
+    TEST_ASSERT_EQUAL(100, ctx.params[0]);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_WAIT, ctx.kinds[1]);
+    TEST_ASSERT_EQUAL(200, ctx.params[1]);
+    TEST_ASSERT_EQUAL((int)NFC_STORY_KIND_CLIP, ctx.kinds[2]);
+    TEST_ASSERT_EQUAL(300, ctx.params[2]);
+}
+
+static void test_execute_stops_on_dispatch_error(void)
+{
+    const char *j = "{\"sequence\":["
+                    "{\"kind\":\"tone\",\"param\":1},"
+                    "{\"kind\":\"tone\",\"param\":2},"
+                    "{\"kind\":\"tone\",\"param\":3}"
+                    "]}";
+    story_sequence_t seq;
+    TEST_ASSERT_TRUE(nfc_story_sounds_parse(j, strlen(j), &seq));
+
+    exec_ctx_t ctx = {0};
+    ctx.abort_after = 1; /* dispatcher rejects after the first call */
+    int rc = nfc_story_sounds_execute(&seq, mock_dispatch, &ctx);
+    TEST_ASSERT_EQUAL(42, rc);
+    TEST_ASSERT_EQUAL(2, ctx.call_count);
+}
+
+static void test_execute_rejects_null_args(void)
+{
+    exec_ctx_t ctx = {0};
+    ctx.abort_after = -1;
+    TEST_ASSERT_EQUAL(-1, nfc_story_sounds_execute(NULL, mock_dispatch, &ctx));
+    story_sequence_t seq = {0};
+    TEST_ASSERT_EQUAL(-1, nfc_story_sounds_execute(&seq, NULL, &ctx));
+}
+
+/* ------------------------------------------------------------------ */
+/* Main                                                                */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_parse_single_tone);
+    RUN_TEST(test_parse_all_kinds);
+    RUN_TEST(test_parse_whitespace_and_negative_param);
+    RUN_TEST(test_parse_param_before_kind);
+    RUN_TEST(test_parse_rejects_null_inputs);
+    RUN_TEST(test_parse_rejects_malformed_brace);
+    RUN_TEST(test_parse_rejects_truncated);
+    RUN_TEST(test_parse_rejects_wrong_root_key);
+    RUN_TEST(test_parse_rejects_unknown_kind);
+    RUN_TEST(test_parse_rejects_missing_param);
+    RUN_TEST(test_parse_rejects_empty_sequence);
+    RUN_TEST(test_parse_rejects_too_many_steps);
+    RUN_TEST(test_parse_rejects_trailing_garbage);
+    RUN_TEST(test_execute_invokes_each_step_in_order);
+    RUN_TEST(test_execute_stops_on_dispatch_error);
+    RUN_TEST(test_execute_rejects_null_args);
+    return UNITY_END();
+}

--- a/packages/thinkpack/brainbox/main/prompt_builder.c
+++ b/packages/thinkpack/brainbox/main/prompt_builder.c
@@ -169,3 +169,89 @@ int prompt_builder_collective(const char *trigger, const group_manifest_t *manif
      * have been written (matches snprintf convention). */
     return pos;
 }
+
+/* ------------------------------------------------------------------ */
+/* NFC sound-story prompt (Finderbox STORY scan)                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @brief Human-readable difficulty label for the LLM prompt.
+ *
+ * Kept intentionally short — the LLM associates the adjective with the
+ * pacing and density of the generated sequence.
+ */
+static const char *difficulty_label(story_difficulty_t d)
+{
+    switch (d) {
+        case STORY_DIFFICULTY_EASY:
+            return "easy";
+        case STORY_DIFFICULTY_MEDIUM:
+            return "medium";
+        case STORY_DIFFICULTY_HARD:
+            return "hard";
+        default:
+            return "easy";
+    }
+}
+
+story_difficulty_t prompt_builder_difficulty_from_param(uint8_t param)
+{
+    if (param == 0) {
+        return STORY_DIFFICULTY_EASY;
+    }
+    if (param < 10) {
+        return STORY_DIFFICULTY_MEDIUM;
+    }
+    return STORY_DIFFICULTY_HARD;
+}
+
+int prompt_builder_nfc_story(const char *uid_hex, const char *label, story_difficulty_t difficulty,
+                             char *out, size_t out_size)
+{
+    if (!uid_hex || !label || !out || out_size == 0) {
+        return -1;
+    }
+
+    int pos = 0;
+
+    append(out, out_size, &pos,
+           "You are the Brainbox narrator for a ThinkPack NFC sound-story.  "
+           "A Finderbox just scanned a tagged object and is asking for a "
+           "short musical sequence to play back for a toddler aged 2-4.\n"
+           "\n"
+           "TAG UID: %s\n"
+           "TAG LABEL: \"%s\"\n"
+           "DIFFICULTY: %s\n"
+           "\n",
+           uid_hex, label, difficulty_label(difficulty));
+
+    append(out, out_size, &pos,
+           "DIFFICULTY GUIDELINES:\n"
+           "  easy   — 2 to 3 steps, gentle tones (300-800 Hz), generous waits\n"
+           "  medium — 4 to 6 steps, wider range (200-1500 Hz), mix tones + waits\n"
+           "  hard   — 7 to 10 steps, quicker pacing, up to 2000 Hz, may layer clips\n"
+           "\n");
+
+    append(out, out_size, &pos,
+           "SAFETY CONSTRAINTS (mandatory):\n"
+           "  - Max 16 steps total.\n"
+           "  - Tone frequency: 200..2000 Hz (integer Hz).\n"
+           "  - Wait duration: 30..2000 ms.\n"
+           "  - Clip IDs: 0..15.\n"
+           "  - No strobe / rapid alternation patterns.\n"
+           "\n");
+
+    append(out, out_size, &pos,
+           "OUTPUT FORMAT: Respond with ONLY a valid JSON object — no explanation, "
+           "no markdown fences. Schema:\n"
+           "{\n"
+           "  \"sequence\": [\n"
+           "    {\"kind\": \"tone\", \"param\": <freq_hz>},\n"
+           "    {\"kind\": \"wait\", \"param\": <ms>},\n"
+           "    {\"kind\": \"clip\", \"param\": <clip_id>}\n"
+           "  ]\n"
+           "}\n"
+           "Respond ONLY with the JSON object matching this schema.\n");
+
+    return pos;
+}

--- a/packages/thinkpack/brainbox/main/prompt_builder.h
+++ b/packages/thinkpack/brainbox/main/prompt_builder.h
@@ -56,4 +56,49 @@ typedef struct {
 int prompt_builder_collective(const char *trigger, const group_manifest_t *manifest, char *out,
                               size_t out_size);
 
+/**
+ * @brief Difficulty tier for NFC sound-story prompts.
+ *
+ * Mapped from the tag registry's @c param byte so the same physical tag
+ * can be re-used for toddler, preschool, and kindergarten sessions
+ * without changing firmware:
+ *   param == 0        → STORY_DIFFICULTY_EASY    — short, playful
+ *   param 1..9        → STORY_DIFFICULTY_MEDIUM  — slightly more varied
+ *   param 10..255     → STORY_DIFFICULTY_HARD    — quicker pace, layered
+ */
+typedef enum {
+    STORY_DIFFICULTY_EASY = 0,
+    STORY_DIFFICULTY_MEDIUM = 1,
+    STORY_DIFFICULTY_HARD = 2,
+} story_difficulty_t;
+
+/**
+ * @brief Build a per-tag "sound story" prompt for a Finderbox STORY scan.
+ *
+ * The resulting prompt asks the LLM to respond with a strict JSON
+ * document of the form @c {"sequence":[...]} matching the grammar
+ * accepted by @ref nfc_story_sounds_parse.  The prompt is intentionally
+ * small (<1 kB for typical inputs) so the Brainbox can send it to the
+ * cloud LLM without hitting token ceilings.
+ *
+ * @param uid_hex     ASCII hex string of the tag UID (e.g. "04A1F2…").
+ *                    Must not be NULL.
+ * @param label       Registry label for the tag (NUL-terminated).  May
+ *                    be an empty string.  Must not be NULL.
+ * @param difficulty  Difficulty tier derived from the tag param byte.
+ * @param out         Output buffer.  Must not be NULL.
+ * @param out_size    Size of @p out in bytes.
+ * @return Number of bytes that would have been written (snprintf
+ *         convention), or a negative value on encoding error.
+ */
+int prompt_builder_nfc_story(const char *uid_hex, const char *label, story_difficulty_t difficulty,
+                             char *out, size_t out_size);
+
+/**
+ * @brief Map a tag param byte to a story difficulty tier.
+ *
+ * Pure helper — see @ref story_difficulty_t for the mapping contract.
+ */
+story_difficulty_t prompt_builder_difficulty_from_param(uint8_t param);
+
 #endif  // PROMPT_BUILDER_H

--- a/packages/thinkpack/finderbox/main/CMakeLists.txt
+++ b/packages/thinkpack/finderbox/main/CMakeLists.txt
@@ -3,6 +3,7 @@ idf_component_register(
         "main.c"
         "tag_registry.c"
         "standalone_mode.c"
+        "group_mode.c"
         "piezo.c"
         "led_ring.c"
     INCLUDE_DIRS "."

--- a/packages/thinkpack/finderbox/main/group_mode.c
+++ b/packages/thinkpack/finderbox/main/group_mode.c
@@ -1,0 +1,365 @@
+/**
+ * @file group_mode.c
+ * @brief Mesh-aware group behaviour for Finderbox.
+ *
+ * SEEK (Hot-Cold):
+ *   When a SEEK tag is scanned locally, all subsequent peer beacons are
+ *   sampled for RSSI (via group_manager_find) at ~10 Hz by a small task
+ *   that feeds hot_cold_update and repaints the LED ring.  A partner
+ *   Glowbug (if any) mirrors the current colour via CMD_LED_PATTERN.
+ *
+ * STORY (NFC Story Sounds):
+ *   When a STORY tag is scanned, Finderbox unicasts an MSG_LLM_REQUEST to
+ *   the mesh leader (or broadcasts if none known) carrying the tag UID
+ *   and label as the prompt hint.  The Brainbox replies with a short JSON
+ *   sound sequence via MSG_LLM_RESPONSE (possibly fragmented); on receipt
+ *   we parse it and dispatch via piezo + MSG_AUDIO_CLIP_BROADCAST relays
+ *   to Chatterbox peers.
+ *
+ * All mesh sends happen off the receive-task critical path — either on
+ * the SEEK polling task or on the standalone scan task (via
+ * group_mode_on_local_scan).
+ */
+
+#include "group_mode.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "command_dispatcher.h"
+#include "esp_log.h"
+#include "esp_mac.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "group_manager.h"
+#include "hot_cold.h"
+#include "led_ring.h"
+#include "nfc_story_sounds.h"
+#include "piezo.h"
+#include "thinkpack_commands.h"
+#include "thinkpack_protocol.h"
+
+static const char *TAG = "group_mode";
+
+/* ------------------------------------------------------------------ */
+/* Tunables                                                            */
+/* ------------------------------------------------------------------ */
+
+/** LED repaint cadence while SEEK is active. */
+#define SEEK_POLL_INTERVAL_MS 100
+/** Stale threshold after which SEEK reverts to "cold" if no beacon. */
+#define SEEK_STALE_MS 3000
+/** Piezo frequency for STORY-sequence tone steps. */
+#define STORY_TONE_DEFAULT_HZ 880
+/** Minimum param clamp for tone steps (Hz). */
+#define STORY_TONE_MIN_HZ 200
+/** Maximum param clamp for tone steps (Hz). */
+#define STORY_TONE_MAX_HZ 6000
+/** Duration of a single story tone step (ms). */
+#define STORY_TONE_DURATION_MS 150
+
+/* ------------------------------------------------------------------ */
+/* State                                                               */
+/* ------------------------------------------------------------------ */
+
+static thinkpack_nfc_registry_t *s_registry = NULL;
+static hot_cold_state_t s_hot_cold;
+static bool s_seek_active = false;
+static TaskHandle_t s_seek_task = NULL;
+static uint8_t s_leader_mac[6];
+static bool s_have_leader = false;
+static uint8_t s_seq = 0;
+
+/* Most-recently scanned STORY tag context — retained for the LLM reply. */
+static uint8_t s_story_uid[THINKPACK_NFC_UID_MAX_LEN];
+static uint8_t s_story_uid_len = 0;
+static bool s_story_pending = false;
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+static uint32_t now_ms(void)
+{
+    return (uint32_t)(xTaskGetTickCount() * portTICK_PERIOD_MS);
+}
+
+/* Fill out_mac with local WiFi MAC; used as src for our own packets. */
+static void fill_own_mac(uint8_t out_mac[6])
+{
+    if (esp_read_mac(out_mac, ESP_MAC_WIFI_STA) != ESP_OK) {
+        memset(out_mac, 0, 6);
+    }
+}
+
+/* Mirror the current hot-cold colour to any partner Glowbug.  Sent as
+ * CMD_LED_PATTERN SOLID so the standard command_executor handles it. */
+static void broadcast_color_mirror(uint8_t r, uint8_t g, uint8_t b)
+{
+    cmd_led_pattern_payload_t p = {
+        .r = r,
+        .g = g,
+        .b = b,
+        .pattern = (uint8_t)LED_PATTERN_SOLID,
+    };
+    uint8_t own_mac[6];
+    fill_own_mac(own_mac);
+
+    thinkpack_packet_t pkt;
+    command_build_led_pattern(&pkt, s_seq++, own_mac, &p);
+    (void)thinkpack_mesh_send(NULL, &pkt); /* broadcast */
+}
+
+/* ------------------------------------------------------------------ */
+/* SEEK polling task                                                   */
+/* ------------------------------------------------------------------ */
+
+static void seek_task(void *arg)
+{
+    (void)arg;
+
+    uint32_t last_beacon_ms = 0;
+
+    for (;;) {
+        if (!s_seek_active) {
+            /* Task parks itself when SEEK is cleared. */
+            vTaskDelay(pdMS_TO_TICKS(SEEK_POLL_INTERVAL_MS));
+            continue;
+        }
+
+        /* Pick the "nearest-looking" peer: highest RSSI among current peers. */
+        size_t pc = group_manager_count();
+        int8_t best_rssi = INT8_MIN;
+        bool have_any = false;
+
+        for (size_t i = 0; i < pc; i++) {
+            const thinkpack_peer_t *peer = group_manager_get(i);
+            if (peer == NULL) {
+                continue;
+            }
+            if (!have_any || peer->rssi > best_rssi) {
+                best_rssi = peer->rssi;
+                have_any = true;
+                last_beacon_ms = peer->last_seen_ms;
+            }
+        }
+
+        uint32_t t = now_ms();
+        if (have_any && (t - last_beacon_ms) < SEEK_STALE_MS) {
+            hot_cold_update(&s_hot_cold, best_rssi);
+        } else {
+            /* Stale — fade toward cold by pushing the minimum RSSI in. */
+            hot_cold_update(&s_hot_cold, (int8_t)HOT_COLD_RSSI_MIN);
+        }
+
+        uint8_t r, g, b;
+        hot_cold_get_color(&s_hot_cold, &r, &g, &b);
+        led_ring_fill(r, g, b);
+        led_ring_show();
+        broadcast_color_mirror(r, g, b);
+
+        vTaskDelay(pdMS_TO_TICKS(SEEK_POLL_INTERVAL_MS));
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* STORY sequence dispatch                                             */
+/* ------------------------------------------------------------------ */
+
+/* clamp helper for tone frequencies. */
+static uint32_t clamp_freq(int32_t hz)
+{
+    if (hz < STORY_TONE_MIN_HZ) {
+        return (uint32_t)STORY_TONE_MIN_HZ;
+    }
+    if (hz > STORY_TONE_MAX_HZ) {
+        return (uint32_t)STORY_TONE_MAX_HZ;
+    }
+    return (uint32_t)hz;
+}
+
+/* Relay a clip broadcast to any Chatterbox peers that might be in-mesh.
+ * This is a metadata-only packet — the Chatterbox leader streams the PCM
+ * separately (outside PR E's scope). */
+static void relay_clip(uint8_t clip_id)
+{
+    audio_clip_broadcast_payload_t payload = {
+        .clip_id = clip_id,
+        .sample_count = 0,
+        .flags = 0,
+    };
+    memset(payload.per_peer_semitone_shift, 0, sizeof(payload.per_peer_semitone_shift));
+
+    uint8_t own_mac[6];
+    fill_own_mac(own_mac);
+
+    thinkpack_packet_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    pkt.msg_type = (uint8_t)MSG_AUDIO_CLIP_BROADCAST;
+    pkt.sequence_number = s_seq++;
+    memcpy(pkt.src_mac, own_mac, 6);
+    pkt.data_length = (uint8_t)sizeof(payload);
+    memcpy(pkt.data, &payload, sizeof(payload));
+    thinkpack_finalize(&pkt);
+    (void)thinkpack_mesh_send(NULL, &pkt);
+}
+
+/* Dispatcher passed to nfc_story_sounds_execute. */
+static int story_step_dispatch(uint8_t kind, int32_t param, void *user_ctx)
+{
+    (void)user_ctx;
+
+    switch ((nfc_story_kind_t)kind) {
+        case NFC_STORY_KIND_TONE:
+            piezo_play_tone(clamp_freq(param), STORY_TONE_DURATION_MS);
+            vTaskDelay(pdMS_TO_TICKS(STORY_TONE_DURATION_MS));
+            break;
+        case NFC_STORY_KIND_WAIT:
+            if (param > 0 && param < 10000) {
+                vTaskDelay(pdMS_TO_TICKS((uint32_t)param));
+            }
+            break;
+        case NFC_STORY_KIND_CLIP:
+            if (param >= 0 && param < 256) {
+                relay_clip((uint8_t)param);
+            }
+            break;
+        default:
+            ESP_LOGW(TAG, "Story: unknown kind %u — skipping", (unsigned)kind);
+            break;
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* LLM request / reply                                                 */
+/* ------------------------------------------------------------------ */
+
+/* Build a small ASCII prompt hint from the tag's UID + label and unicast
+ * it to the leader.  If we haven't seen a leader yet, broadcast it. */
+static void send_story_request(const thinkpack_nfc_entry_t *entry)
+{
+    char hint[96];
+    int n = snprintf(hint, sizeof(hint), "story:uid=");
+    for (uint8_t i = 0; i < entry->uid_len && n > 0 && (size_t)n + 3 < sizeof(hint); i++) {
+        n += snprintf(hint + n, sizeof(hint) - (size_t)n, "%02X", entry->uid[i]);
+    }
+    if (n > 0 && (size_t)n + 1 < sizeof(hint)) {
+        n += snprintf(hint + n, sizeof(hint) - (size_t)n, " label=\"%s\" param=%u", entry->label,
+                      (unsigned)entry->param);
+    }
+    if (n < 0) {
+        n = 0;
+    }
+    size_t hint_len = (size_t)n;
+    if (hint_len > sizeof(hint)) {
+        hint_len = sizeof(hint);
+    }
+
+    uint8_t own_mac[6];
+    fill_own_mac(own_mac);
+
+    thinkpack_packet_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    pkt.msg_type = (uint8_t)MSG_LLM_REQUEST;
+    pkt.sequence_number = s_seq++;
+    memcpy(pkt.src_mac, own_mac, 6);
+    pkt.data_length =
+        (uint8_t)(hint_len > THINKPACK_MAX_DATA_LEN ? THINKPACK_MAX_DATA_LEN : hint_len);
+    memcpy(pkt.data, hint, pkt.data_length);
+    thinkpack_finalize(&pkt);
+
+    const uint8_t *dest = s_have_leader ? s_leader_mac : NULL;
+    (void)thinkpack_mesh_send(dest, &pkt);
+    ESP_LOGI(TAG, "STORY request sent (%u bytes, leader=%s)", (unsigned)pkt.data_length,
+             s_have_leader ? "unicast" : "broadcast");
+}
+
+/* ------------------------------------------------------------------ */
+/* Public API                                                          */
+/* ------------------------------------------------------------------ */
+
+void group_mode_init(thinkpack_nfc_registry_t *registry)
+{
+    s_registry = registry;
+    hot_cold_reset(&s_hot_cold);
+    s_seek_active = false;
+    s_have_leader = false;
+    s_story_pending = false;
+
+    BaseType_t ok = xTaskCreate(seek_task, "seek_poll", 4096, NULL, 4, &s_seek_task);
+    if (ok != pdPASS) {
+        ESP_LOGE(TAG, "SEEK polling task creation failed");
+    } else {
+        ESP_LOGI(TAG, "group_mode initialised — seek task running at %d ms", SEEK_POLL_INTERVAL_MS);
+    }
+}
+
+void group_mode_on_local_scan(const thinkpack_nfc_entry_t *entry)
+{
+    if (entry == NULL) {
+        return;
+    }
+    switch ((thinkpack_nfc_behavior_t)entry->behavior) {
+        case THINKPACK_NFC_BEHAVIOR_SEEK:
+            ESP_LOGI(TAG, "SEEK armed — label='%s'", entry->label);
+            hot_cold_reset(&s_hot_cold);
+            s_seek_active = true;
+            break;
+        case THINKPACK_NFC_BEHAVIOR_STORY:
+            ESP_LOGI(TAG, "STORY scan — label='%s' param=%u", entry->label, (unsigned)entry->param);
+            memcpy(s_story_uid, entry->uid, entry->uid_len);
+            s_story_uid_len = entry->uid_len;
+            s_story_pending = true;
+            send_story_request(entry);
+            break;
+        default:
+            /* CHIME / COLOR / NONE: no group-mode action — standalone handles them. */
+            break;
+    }
+}
+
+void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ctx)
+{
+    (void)user_ctx;
+    if (event == NULL) {
+        return;
+    }
+
+    switch (event->type) {
+        case THINKPACK_EVENT_LEADER_ELECTED:
+        case THINKPACK_EVENT_BECAME_FOLLOWER:
+            memcpy(s_leader_mac, event->peer_mac, 6);
+            s_have_leader = true;
+            ESP_LOGI(TAG, "Leader known: " MACSTR, MAC2STR(event->peer_mac));
+            break;
+
+        case THINKPACK_EVENT_LEADER_LOST:
+            s_have_leader = false;
+            break;
+
+        case THINKPACK_EVENT_PEER_DISCOVERED:
+            ESP_LOGD(TAG, "Peer discovered: " MACSTR, MAC2STR(event->peer_mac));
+            break;
+
+        case THINKPACK_EVENT_LARGE_MESSAGE_RECEIVED:
+            if (event->original_msg_type == (uint8_t)MSG_LLM_RESPONSE && s_story_pending &&
+                event->large_data != NULL && event->large_length > 0) {
+                story_sequence_t seq;
+                if (nfc_story_sounds_parse((const char *)event->large_data, event->large_length,
+                                           &seq)) {
+                    ESP_LOGI(TAG, "STORY reply parsed — %u steps", (unsigned)seq.count);
+                    nfc_story_sounds_execute(&seq, story_step_dispatch, NULL);
+                } else {
+                    ESP_LOGW(TAG, "STORY reply rejected by parser (%zu bytes)",
+                             event->large_length);
+                }
+                s_story_pending = false;
+            }
+            break;
+
+        default:
+            break;
+    }
+}

--- a/packages/thinkpack/finderbox/main/group_mode.h
+++ b/packages/thinkpack/finderbox/main/group_mode.h
@@ -1,0 +1,61 @@
+/**
+ * @file group_mode.h
+ * @brief Mesh-aware group behaviour for Finderbox — SEEK Hot-Cold +
+ *        NFC Story Sounds dispatch.
+ *
+ * Register @ref group_mode_on_event as the thinkpack_mesh event
+ * callback.  The module watches for peer beacons (used to update RSSI
+ * samples for the current SEEK target) and large-message events
+ * carrying a Brainbox reply for an earlier STORY request.
+ *
+ * See https://github.com/laurigates/mcu-tinkering-lab/issues/198
+ */
+
+#ifndef FINDERBOX_GROUP_MODE_H
+#define FINDERBOX_GROUP_MODE_H
+
+#include "espnow_mesh.h"
+#include "thinkpack_nfc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialise the group-mode state machine.
+ *
+ * Must be called once after standalone_mode_start() and before
+ * thinkpack_mesh_set_event_callback().  Safe to call with or without
+ * a populated registry; behaviour lookups dereference the registry
+ * each time a tag is scanned.
+ *
+ * @param registry  Non-NULL pointer to the live tag registry used by
+ *                  standalone_mode; must outlive the mesh.
+ */
+void group_mode_init(thinkpack_nfc_registry_t *registry);
+
+/**
+ * @brief Mesh event handler — forward every event to this function.
+ *
+ * The handler is intentionally a thin router: PEER_DISCOVERED and
+ * LARGE_MESSAGE_RECEIVED drive the visible behaviour; all other event
+ * types are logged and otherwise ignored.
+ */
+void group_mode_on_event(const thinkpack_mesh_event_data_t *event, void *user_ctx);
+
+/**
+ * @brief Notify group mode that a tag was just scanned locally.
+ *
+ * Called by standalone_mode after a successful UID lookup.  Behaviour:
+ *   - SEEK      → capture target UID so subsequent beacons drive
+ *                 Hot-Cold.
+ *   - STORY     → emit MSG_LLM_REQUEST to the mesh leader (if known).
+ *   - CHIME/COLOR/NONE → no additional group-mode action.
+ */
+void group_mode_on_local_scan(const thinkpack_nfc_entry_t *entry);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FINDERBOX_GROUP_MODE_H */

--- a/packages/thinkpack/finderbox/main/main.c
+++ b/packages/thinkpack/finderbox/main/main.c
@@ -24,6 +24,7 @@
 #include "espnow_mesh.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "group_mode.h"
 #include "led_ring.h"
 #include "nvs_flash.h"
 #include "piezo.h"
@@ -100,6 +101,12 @@ void app_main(void)
     strncpy(cfg.name, "finderbox", THINKPACK_BOX_NAME_LEN - 1);
 
     ESP_ERROR_CHECK(thinkpack_mesh_init(&cfg));
+
+    /* Wire the group-mode event handler before starting the mesh so
+     * LEADER_ELECTED events fire through us from the very first tick. */
+    group_mode_init(&s_registry);
+    ESP_ERROR_CHECK(thinkpack_mesh_set_event_callback(group_mode_on_event, NULL));
+
     ESP_ERROR_CHECK(thinkpack_mesh_start());
 
     ESP_LOGI(TAG, "Mesh started — starting scan task");

--- a/packages/thinkpack/finderbox/main/standalone_mode.c
+++ b/packages/thinkpack/finderbox/main/standalone_mode.c
@@ -10,6 +10,7 @@
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "group_mode.h"
 #include "led_ring.h"
 #include "piezo.h"
 #include "tag_registry.h"
@@ -127,6 +128,8 @@ static void scan_task(void *arg)
                     memcpy(&s_last_entry, entry, sizeof(s_last_entry));
                     s_have_last = true;
                     dispatch_behavior(entry);
+                    /* Group-mode hook (PR E): SEEK / STORY dispatch over mesh. */
+                    group_mode_on_local_scan(entry);
                 } else {
                     ESP_LOGI(TAG, "Unknown UID — no registry entry");
                 }
@@ -169,4 +172,5 @@ void standalone_mode_replay_last(void)
     ESP_LOGI(TAG, "Replay — behaviour=%u label='%s'", (unsigned)s_last_entry.behavior,
              s_last_entry.label);
     dispatch_behavior(&s_last_entry);
+    group_mode_on_local_scan(&s_last_entry);
 }


### PR DESCRIPTION
## Summary
- Closes #198 — completes Finderbox with mesh-aware group mode.
- New host-testable behaviours: `hot_cold` (RSSI smoothing + gradient) and `nfc_story_sounds` (JSON sequence parser + dispatcher).
- Brainbox prompt gets a per-tag sound-story template with adaptive-difficulty tuning.

## Hardware verification status
Group-mode behaviours tested at the logic level (RSSI smoothing, JSON parsing, color gradient). Real-world RSSI smoothing curve and LLM-driven story playback are pending hardware verification after PR F's OTA relay lands.

## Test plan
- [ ] \`make test\` in \`packages/components/thinkpack-behaviors/test/\` — all green.
- [ ] \`make test\` in \`packages/components/thinkpack-nfc/test/\` + \`thinkpack-audio/test/\` — no regressions.
- [ ] \`clang-format --dry-run --Werror\` clean.
- [ ] CI green (conventional-commits, format, C/C++ lint, host tests, secret scan, detect changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)