### PR TITLE
ci(scan-secrets): raise max_turns from 5 to 15

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -11,5 +11,6 @@ jobs:
     uses: laurigates/.github/.github/workflows/reusable-security-secrets.yml@main
     with:
       file-patterns: '**/*.c **/*.h **/*.cpp **/*.hpp **/*.py **/*.yml **/*.yaml **/*.json **/*.toml'
+      max-turns: 15
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- Bumps \`max-turns\` input on the reusable \`scan-secrets\` workflow from the default 5 to 15 so large PRs don't exhaust the turn budget before the AI scanner finishes.
- Resolves the failure mode tracked in #241.

Gitleaks (pattern-based) continues to run as the primary detector; the AI scan is an extra layer and should now finish cleanly on diffs up to the \`file-limit\` cap (50 files) in the reusable workflow.

## Test plan
- [ ] Confirm \`scan-secrets\` check passes on this PR (trivial diff, so not a stress test — real validation will be on the next large PR).

Closes #241.