### PR TITLE
docs(gamepad-synth): refresh WIRING.md for v1.0.0 hardware build

### DIFF
--- a/packages/audio/gamepad-synth/WIRING.md
+++ b/packages/audio/gamepad-synth/WIRING.md
@@ -2,7 +2,12 @@
 
 ## Board
 
-Any ESP32-S3 development board with USB-Serial-JTAG (e.g., Waveshare ESP32-S3-Zero, ESP32-S3-DevKitC-1). No PSRAM or WiFi required.
+Any ESP32-S3 development board with USB-Serial-JTAG. No PSRAM, no WiFi, no SD card required. Verified with:
+
+- Waveshare ESP32-S3-Zero (recommended — compact, castellated pads)
+- Espressif ESP32-S3-DevKitC-1
+
+The firmware runs at 240 MHz on one core (audio) while Bluepad32 uses the other (Bluetooth), so any ESP32-S3 variant with standard specs works.
 
 ## Pin Assignments
 
@@ -11,7 +16,9 @@ Any ESP32-S3 development board with USB-Serial-JTAG (e.g., Waveshare ESP32-S3-Ze
 | 5 | I2S BCLK | Output | MAX98357A BCLK |
 | 6 | I2S LRCLK (WS) | Output | MAX98357A LRC |
 | 7 | I2S DOUT | Output | MAX98357A DIN |
-| 2 | Status LED | Output | LED anode (via resistor) |
+| 2 | Status LED | Output | LED anode (via 220-330 Ω resistor) |
+
+All three I2S pins are plain GPIOs on the ESP32-S3 (no special strapping roles), so any other trio works too — just update `I2S_BCLK_PIN` / `I2S_WS_PIN` / `I2S_DOUT_PIN` in `main/main.c`.
 
 ## Wiring Diagram
 
@@ -24,32 +31,88 @@ ESP32-S3                MAX98357A
 |  GPIO7 |──── DOUT ────| DIN    |
 |        |              |        |
 |   3V3  |──── VIN ─────| VIN    |    Speaker
-|   GND  |──── GND ─────| GND    |   ┌──────┐
-|        |              | + OUT ──|───| (+)  |
-|        |              | - OUT ──|───| (-)  |
-|        |              |________|   └──────┘
-|        |
-|  GPIO2 |──── 220R ──── LED (+)
-|    GND |────────────── LED (-)
+|   GND  |──┬─── GND ───| GND    |   ┌──────┐
+|        |  │           | + OUT ─|───│ (+)  │
+|        |  │           | - OUT ─|───│ (-)  │
+|        |  │           | GAIN   |   └──────┘
+|        |  │           |        |
+|        |  │           | SD  ───| (leave floating or tie to VIN for mono sum)
+|        |  │           |________|
+|        |  │
+|  GPIO2 |──│── 220Ω ── LED (+)
+|        |  │            │
+|    GND |──┴─────────── LED (-)
 |        |
 |    USB |──── USB-C cable (power + serial monitor)
 |________|
 ```
 
-## Components
+## Parts List
 
-| Component | Specification | Notes |
-|-----------|--------------|-------|
-| MAX98357A | I2S 3W Class D amplifier breakout | Adafruit or generic; mono output. Connect GAIN to GND for 9 dB or leave floating for 12 dB. |
-| Speaker | 4-8 ohm, 2-3W | Any small speaker; 40 mm recommended for breadboard projects |
-| LED | Standard 3mm/5mm | Any color; 220-330 ohm series resistor |
-| BLE controller | Xbox Series X/S (fw v5.15+), PS5 DualSense, Switch Pro, Joy-Cons, 8BitDo (BLE mode) | Connects via BLE (no wiring). PS4 DualShock 4, Xbox One, and Wii remotes are **not** compatible (require Bluetooth Classic / BR/EDR). |
+| Qty | Component | Notes |
+|-----|-----------|-------|
+| 1 | ESP32-S3 dev board | Waveshare ESP32-S3-Zero or ESP32-S3-DevKitC-1 |
+| 1 | MAX98357A I2S amplifier breakout | Adafruit #3006 or generic — mono 3.2 W Class D |
+| 1 | Speaker, 4-8 Ω, 2-3 W | 40 mm is a good breadboard size; panel mount for enclosures |
+| 1 | LED (3mm or 5mm) | Any color |
+| 1 | Resistor, 220-330 Ω | LED current limiter |
+| — | Jumper wires, breadboard | Standard |
 
-## Notes
+Optional:
 
-- **I2S audio**: The ESP32-S3 drives a MAX98357A I2S DAC at 44.1 kHz, 16-bit stereo (mono samples duplicated to both channels). The DAC handles amplification — no external amp needed.
-- **GAIN pin**: The MAX98357A GAIN pin sets amplifier gain. Leave floating for 12 dB (default), connect to GND for 9 dB (quieter), or connect to VIN for 15 dB (louder).
-- **Power**: USB-C provides both power and serial console via USB-Serial-JTAG. The MAX98357A draws power from 3V3.
-- **Bluetooth pairing**: Put your BLE controller in pairing mode — Xbox: hold the pair button on top; PS5: hold Share + PS; Switch Pro: hold the sync button on top. No physical connection needed.
-- **Mode cycle button**: View (Xbox) / Share (PS) / `-` (Switch) cycles through the four sound modes.
-- **LED behavior**: Lights when a tone is playing; blinks N times when switching sound modes (1-4 blinks).
+- 100 µF electrolytic between MAX98357A VIN and GND if you hear USB-related whine or the amp resets under peak load
+- 4.7 kΩ pull-up on the MAX98357A `SD` pin if you want to use the left-channel-only mode (tying SD directly to VIN gives mono sum; leaving it floating also gives mono sum on most breakouts)
+
+## MAX98357A Gain Selection
+
+The `GAIN` pin on the MAX98357A sets amplifier gain:
+
+| GAIN connection | Gain | Use when |
+|-----------------|------|----------|
+| Tied to GND | 9 dB | Quiet listening, small speaker |
+| Floating (default) | 12 dB | General use (start here) |
+| 100 kΩ to GND | 6 dB | Very quiet — avoid if possible |
+| Tied to VIN | 15 dB | Loud / outdoor |
+| 100 kΩ to VIN | 3 dB | — |
+
+Start with `GAIN` floating; adjust only if it's too quiet or clipping.
+
+## Controllers
+
+The ESP32-S3 only supports **BLE** (no Bluetooth Classic). Compatible controllers:
+
+- Xbox Series X/S (firmware v5.15+; update via Xbox Accessories app on Windows)
+- PS5 DualSense
+- Nintendo Switch Pro
+- Nintendo Joy-Cons (individually)
+- 8BitDo controllers in BLE mode
+
+**Not compatible** — these need Bluetooth Classic / BR/EDR:
+
+- PS4 DualShock 4
+- Xbox One (older models, pre-Series)
+- Wii remotes
+
+## Build Notes
+
+1. **Power**: USB-C provides both 5 V (to VBUS/VIN on the board) and a serial console via USB-Serial-JTAG. No external PSU needed for low volumes; for a loud speaker, consider powering VIN from 5 V directly to avoid brown-outs.
+2. **Bluetooth pairing**: Put the controller in pairing mode:
+   - Xbox: hold the small pair button on top of the controller until the Xbox button flashes rapidly
+   - PS5: hold Share + PS button until the light bar flashes
+   - Switch Pro: hold the sync button on top of the controller
+   After initial pairing, the controller auto-reconnects on boot (just press Home / Xbox / PS).
+3. **Startup jingle**: The board plays a C5-E5-G5-C6 arpeggio on boot to confirm audio is working.
+4. **Mode cycle**: View (Xbox) / Share (PS) / `-` (Switch) cycles through the **seven** sound modes.
+5. **LED behavior**: Lights during active notes; blinks 1-7 times when switching modes to indicate the new mode number.
+
+## Signal Chain
+
+For reference, the audio path inside the ESP32-S3 is:
+
+```
+Oscillator A ──┐
+               ├──► 50/50 mix ──► SVF filter ──► LFO mod ──► Delay line ──► I2S ──► MAX98357A ──► Speaker
+Oscillator B ──┘
+```
+
+All DSP runs at 44.1 kHz, 16-bit, mono (duplicated to both I2S slots to satisfy the MAX98357A's stereo I2S expectation).


### PR DESCRIPTION
## Summary

Brings WIRING.md in line with the v1.0.0 firmware so a hardware build matches what the code expects.

- Mode cycle text now reflects 7 modes (was 4): Mono Synth, Dual Osc, Delay Synth, Scale, Arpeggio, Retro SFX, Drone
- LED mode blink count updated to 1-7
- Added concrete parts list (Adafruit #3006 for MAX98357A, 40 mm 4-8 Ω speaker, 220-330 Ω LED resistor)
- Added GAIN-pin selection table for the MAX98357A (tie GND / float / VIN for 9 / 12 / 15 dB)
- Added signal-chain diagram showing the full DSP path inside the ESP32-S3
- Notes on optional 100 µF decoupling, SD-pin behavior, and brown-out mitigation

## Test plan

- [ ] Wire up per the diagram and confirm audio on first boot (startup jingle plays)
- [ ] Cycle all 7 modes and verify LED blinks 1-7 correspondingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)