### PR TITLE
feat(gamepad-synth): add piezo accent voices for Drone mode

### DIFF
--- a/.claude/rules/esp-idf-sdkconfig.md
+++ b/.claude/rules/esp-idf-sdkconfig.md
@@ -45,3 +45,16 @@ Later files override earlier ones. Each overlay should only contain the settings
 ## Stack Sizing
 
 The default main task stack (`CONFIG_ESP_MAIN_TASK_STACK_SIZE=3584`) is often too small when initializing WiFi + BLE + USB. Set 8192 or higher for projects that initialize multiple subsystems in `app_main()`. Use `uxTaskGetStackHighWaterMark()` to verify headroom at runtime.
+
+## Bluepad32 Requires UART as Primary Console
+
+Bluepad32 v3.10.x (and its vendored btstack) unconditionally reference UART-console symbols in `uni_console.c` and `btstack_stdio_esp32.c` (`CONFIG_ESP_CONSOLE_UART_BAUDRATE`, `esp_console_dev_uart_config_t`, `esp_console_new_repl_uart`). ESP-IDF 5.4 only defines these when `CONFIG_ESP_CONSOLE_UART_DEFAULT` or `CONFIG_ESP_CONSOLE_UART_CUSTOM` is set, so `CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y` as primary breaks the build.
+
+Keep UART as primary and select USB_SERIAL_JTAG as the secondary — ESP-IDF duplicates log output to both channels, so USB-C logging still works:
+
+```
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
+```
+
+Upstream issue: https://github.com/ricardoquesada/bluepad32/issues/209

--- a/packages/audio/gamepad-synth/WIRING.md
+++ b/packages/audio/gamepad-synth/WIRING.md
@@ -17,8 +17,12 @@ The firmware runs at 240 MHz on one core (audio) while Bluepad32 uses the other 
 | 6 | I2S LRCLK (WS) | Output | MAX98357A LRC |
 | 7 | I2S DOUT | Output | MAX98357A DIN |
 | 2 | Status LED | Output | LED anode (via 220-330 Ω resistor) |
+| 8 | Piezo A (LEDC) | Output | Piezo disc (+) — used in Drone mode |
+| 9 | Piezo B (LEDC) | Output | Piezo disc (+) — used in Drone mode |
 
 All three I2S pins are plain GPIOs on the ESP32-S3 (no special strapping roles), so any other trio works too — just update `I2S_BCLK_PIN` / `I2S_WS_PIN` / `I2S_DOUT_PIN` in `main/main.c`.
+
+The piezos are optional accent voices that only sound in Drone mode. Skip them entirely if you just want the DAC synth.
 
 ## Wiring Diagram
 
@@ -66,6 +70,7 @@ Optional:
 
 - 100 µF electrolytic between MAX98357A VIN and GND if you hear USB-related whine or the amp resets under peak load
 - 4.7 kΩ pull-up on the MAX98357A `SD` pin if you want to use the left-channel-only mode (tying SD directly to VIN gives mono sum; leaving it floating also gives mono sum on most breakouts)
+- 2× piezo disc transducers (any 27-35 mm disc) — one leg to GPIO8/9, other leg to GND. Drive is GPIO-direct via LEDC square wave; piezos are high-impedance capacitive, so no transistor needed for a bench test. Add a small MOSFET half-bridge later if you want more volume.
 
 ## MAX98357A Gain Selection
 
@@ -119,4 +124,4 @@ Oscillator A ──┐
 Oscillator B ──┘
 ```
 
-All DSP runs at 44.1 kHz, 16-bit, mono (duplicated to both I2S slots to satisfy the MAX98357A's stereo I2S expectation).
+All DSP runs at 44.1 kHz, 16-bit, mono. The I2S bus carries two slots (L/R) per frame; we write the same sample to both, and the MAX98357A sums them to its mono speaker output.

--- a/packages/audio/gamepad-synth/main/CMakeLists.txt
+++ b/packages/audio/gamepad-synth/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "main.c"
+idf_component_register(SRCS "main.c" "piezo_voice.c"
                        INCLUDE_DIRS "."
                        REQUIRES driver nvs_flash esp_timer
                        PRIV_REQUIRES bluepad32)

--- a/packages/audio/gamepad-synth/main/main.c
+++ b/packages/audio/gamepad-synth/main/main.c
@@ -36,6 +36,8 @@
 #include "uni_hid_device.h"
 #include "uni_platform.h"
 
+#include "piezo_voice.h"
+
 static const char *TAG = "gamepad_synth";
 
 /* ── Pin Definitions ─────────────────────────────────────── */
@@ -44,6 +46,13 @@ static const char *TAG = "gamepad_synth";
 #define I2S_WS_PIN GPIO_NUM_6
 #define I2S_DOUT_PIN GPIO_NUM_7
 #define LED_PIN GPIO_NUM_2
+
+#define PIEZO_A_PIN GPIO_NUM_8
+#define PIEZO_B_PIN GPIO_NUM_9
+
+/* Detune between the two piezos in Drone mode. Fixed ratio so beating rate
+ * scales with pitch: ~4 Hz beat at 200 Hz → ~40 Hz warble at 2 kHz. */
+#define PIEZO_DETUNE_RATIO 1.02f
 
 /* ── I2S / Audio Configuration ───────────────────────────── */
 
@@ -571,7 +580,10 @@ static void mode_drone(const gamepad_state_t *gp)
     synth_set_filter(true, 3000.0f, 1.5f);
 
     tone_play((uint32_t)pitch_a);
-    synth_set_osc_b(true, pitch_b, WAVE_TRIANGLE);
+    /* Route osc B onto the two piezos with a fixed detune so the beating
+     * happens acoustically in air rather than inside the DAC mix. */
+    piezo_voice_note_on(PIEZO_A, pitch_b);
+    piezo_voice_note_on(PIEZO_B, pitch_b * PIEZO_DETUNE_RATIO);
     led_on();
 }
 
@@ -1101,6 +1113,8 @@ static void control_task(void *arg)
 
         if (!gp.connected) {
             tone_stop();
+            piezo_voice_note_off(PIEZO_A);
+            piezo_voice_note_off(PIEZO_B);
             led_off();
             vTaskDelayUntil(&last_wake, pdMS_TO_TICKS(CONTROL_TASK_PERIOD_MS));
             continue;
@@ -1112,6 +1126,8 @@ static void control_task(void *arg)
 
         if (misc_pressed & MISC_BACK) {
             tone_stop();
+            piezo_voice_note_off(PIEZO_A);
+            piezo_voice_note_off(PIEZO_B);
             s_mode = (s_mode + 1) % MODE_COUNT;
             s_arp_running = false;
             s_sfx.ticks_left = 0;
@@ -1221,6 +1237,8 @@ void app_main(void)
     init_sine_table();
     init_i2s();
     init_led();
+    piezo_voice_init(PIEZO_A, PIEZO_A_PIN);
+    piezo_voice_init(PIEZO_B, PIEZO_B_PIN);
     synth_set_waveform(WAVE_SAWTOOTH);
     synth_set_filter(true, 6000.0f, 1.5f);
     synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);

--- a/packages/audio/gamepad-synth/main/piezo_voice.c
+++ b/packages/audio/gamepad-synth/main/piezo_voice.c
@@ -1,0 +1,108 @@
+/**
+ * @file piezo_voice.c
+ * @brief LEDC-backed square-wave driver for piezo accent voices.
+ */
+
+#include "piezo_voice.h"
+
+#include <stdbool.h>
+
+#include "driver/ledc.h"
+#include "esp_err.h"
+#include "esp_log.h"
+
+static const char *TAG = "piezo_voice";
+
+#define PIEZO_LEDC_MODE LEDC_LOW_SPEED_MODE
+#define PIEZO_LEDC_RES LEDC_TIMER_8_BIT
+#define PIEZO_LEDC_DUTY_ON 128 /* 50% of 2^8 */
+#define PIEZO_LEDC_DUTY_OFF 0
+#define PIEZO_INIT_FREQ_HZ 1000
+#define PIEZO_MIN_FREQ_HZ 30.0f
+#define PIEZO_MAX_FREQ_HZ 20000.0f
+
+typedef struct {
+    gpio_num_t gpio;
+    ledc_channel_t channel;
+    ledc_timer_t timer;
+    bool initialized;
+    bool on;
+} piezo_voice_t;
+
+static piezo_voice_t s_voices[PIEZO_COUNT];
+
+void piezo_voice_init(piezo_id_t id, gpio_num_t gpio)
+{
+    if (id >= PIEZO_COUNT) {
+        ESP_LOGE(TAG, "invalid piezo id %d", (int)id);
+        return;
+    }
+
+    ledc_channel_t channel = (id == PIEZO_A) ? LEDC_CHANNEL_0 : LEDC_CHANNEL_1;
+    ledc_timer_t timer = (id == PIEZO_A) ? LEDC_TIMER_0 : LEDC_TIMER_1;
+
+    ledc_timer_config_t timer_cfg = {
+        .speed_mode = PIEZO_LEDC_MODE,
+        .timer_num = timer,
+        .duty_resolution = PIEZO_LEDC_RES,
+        .freq_hz = PIEZO_INIT_FREQ_HZ,
+        .clk_cfg = LEDC_AUTO_CLK,
+    };
+    ESP_ERROR_CHECK(ledc_timer_config(&timer_cfg));
+
+    ledc_channel_config_t ch_cfg = {
+        .gpio_num = gpio,
+        .speed_mode = PIEZO_LEDC_MODE,
+        .channel = channel,
+        .timer_sel = timer,
+        .duty = PIEZO_LEDC_DUTY_OFF,
+        .hpoint = 0,
+        .intr_type = LEDC_INTR_DISABLE,
+    };
+    ESP_ERROR_CHECK(ledc_channel_config(&ch_cfg));
+
+    s_voices[id] = (piezo_voice_t){
+        .gpio = gpio,
+        .channel = channel,
+        .timer = timer,
+        .initialized = true,
+        .on = false,
+    };
+
+    ESP_LOGI(TAG, "piezo %d on GPIO%d (timer %d, channel %d)", (int)id, (int)gpio, (int)timer,
+             (int)channel);
+}
+
+void piezo_voice_note_on(piezo_id_t id, float freq_hz)
+{
+    if (id >= PIEZO_COUNT || !s_voices[id].initialized)
+        return;
+
+    if (freq_hz < PIEZO_MIN_FREQ_HZ)
+        freq_hz = PIEZO_MIN_FREQ_HZ;
+    if (freq_hz > PIEZO_MAX_FREQ_HZ)
+        freq_hz = PIEZO_MAX_FREQ_HZ;
+
+    esp_err_t err = ledc_set_freq(PIEZO_LEDC_MODE, s_voices[id].timer, (uint32_t)freq_hz);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "piezo %d: ledc_set_freq(%u) failed: %s", (int)id, (unsigned)freq_hz,
+                 esp_err_to_name(err));
+        return;
+    }
+
+    if (!s_voices[id].on) {
+        ESP_ERROR_CHECK(ledc_set_duty(PIEZO_LEDC_MODE, s_voices[id].channel, PIEZO_LEDC_DUTY_ON));
+        ESP_ERROR_CHECK(ledc_update_duty(PIEZO_LEDC_MODE, s_voices[id].channel));
+        s_voices[id].on = true;
+    }
+}
+
+void piezo_voice_note_off(piezo_id_t id)
+{
+    if (id >= PIEZO_COUNT || !s_voices[id].initialized || !s_voices[id].on)
+        return;
+
+    ESP_ERROR_CHECK(ledc_set_duty(PIEZO_LEDC_MODE, s_voices[id].channel, PIEZO_LEDC_DUTY_OFF));
+    ESP_ERROR_CHECK(ledc_update_duty(PIEZO_LEDC_MODE, s_voices[id].channel));
+    s_voices[id].on = false;
+}

--- a/packages/audio/gamepad-synth/main/piezo_voice.h
+++ b/packages/audio/gamepad-synth/main/piezo_voice.h
@@ -1,0 +1,34 @@
+/**
+ * @file piezo_voice.h
+ * @brief GPIO-driven piezo voices using LEDC square-wave generation.
+ *
+ * Each voice owns its own LEDC timer so frequencies are independent.
+ * Suitable as an accent layer alongside the main I2S DAC output.
+ */
+
+#pragma once
+
+#include "driver/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIEZO_A = 0,
+    PIEZO_B,
+    PIEZO_COUNT,
+} piezo_id_t;
+
+/** Initialize one piezo voice on the given GPIO. Safe to call once per id. */
+void piezo_voice_init(piezo_id_t id, gpio_num_t gpio);
+
+/** Start (or retune) the voice at freq_hz. Clamped to the LEDC-reachable range. */
+void piezo_voice_note_on(piezo_id_t id, float freq_hz);
+
+/** Silence the voice. Idempotent. */
+void piezo_voice_note_off(piezo_id_t id);
+
+#ifdef __cplusplus
+}
+#endif

--- a/packages/audio/gamepad-synth/sdkconfig.defaults
+++ b/packages/audio/gamepad-synth/sdkconfig.defaults
@@ -17,8 +17,12 @@ CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 # --- Flash ---
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
 
-# --- Console (USB-Serial-JTAG for logging) ---
-CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+# --- Console ---
+# UART is the primary console so the vendored Bluepad32/btstack code
+# (which references CONFIG_ESP_CONSOLE_UART_BAUDRATE unconditionally) compiles.
+# USB-Serial-JTAG is kept as the secondary output so USB-C logging still works.
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
 
 # --- Compiler (suppress GCC 13+ warnings in vendored btstack) ---
 CONFIG_COMPILER_DISABLE_GCC13_WARNINGS=y


### PR DESCRIPTION
## Summary

- Route oscillator B to two GPIO-driven piezos (GPIO8/9) in Drone mode with a fixed 1.02 detune ratio so beating happens acoustically in air rather than inside the DAC mix. Each piezo owns its own LEDC timer for independent pitch.
- Switch console from USB-Serial-JTAG primary to UART primary (USB-JTAG kept as secondary output). Bluepad32 v3.10.x unconditionally references UART console symbols, so USB-JTAG primary breaks the build.
- Document the Bluepad32 UART-console constraint in `.claude/rules/esp-idf-sdkconfig.md`.

## Test plan

- [ ] Build passes in the containerized ESP-IDF v5.4 flow
- [ ] Firmware flashes to ESP32-S3 and logs appear on USB-C via secondary USB-JTAG
- [ ] Drone mode: moving left stick plays osc A via I2S DAC, piezos emit detuned square at osc B frequency
- [ ] Switching out of Drone mode silences both piezos
- [ ] Disconnecting the gamepad silences both piezos and the DAC

🤖 Generated with [Claude Code](https://claude.com/claude-code)