### PR TITLE
docs(rules): require relative symlinks for vendored deps

### DIFF
--- a/.claude/rules/containerized-builds.md
+++ b/.claude/rules/containerized-builds.md
@@ -96,3 +96,4 @@ ESP32-S3 projects with native USB-Serial-JTAG override `monitor` with their own 
 - Define `container_cmd`, `require-port`, `_monitor_baud`, or `_serial-monitor` locally — they come from the import
 - Define `build`, `clean`, `menuconfig`, or `shell` with inline container commands — use `esp32-idf.just` shared recipes
 - Copy the pyserial monitor block inline — use `_serial-monitor` instead
+- Use absolute symlinks for vendored dependencies (`external/<name>`) — absolute targets like `/Users/...` don't resolve inside the container's `/workspace` bind mount. Use relative symlinks that stay under the repo root, e.g. `ln -sfn ../../../input-gaming/xbox-switch-bridge/external/bluepad32 external/bluepad32`.


### PR DESCRIPTION
## Summary

- Add a rule to `.claude/rules/containerized-builds.md` warning against absolute symlink targets for vendored dependencies under `external/<name>`.
- Absolute paths like `/Users/...` don't resolve inside the ESP-IDF container's `/workspace` bind mount. Relative symlinks that stay under the repo root work in both host and container contexts.

## Test plan

- [ ] Doc-only change — no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)