### PR TITLE
feat(gamepad-synth): unified controls phase 1 + voicing refactor

### DIFF
--- a/packages/audio/gamepad-synth/CLAUDE.md
+++ b/packages/audio/gamepad-synth/CLAUDE.md
@@ -6,9 +6,9 @@ For monorepo-wide conventions, see the root [CLAUDE.md](../../../CLAUDE.md).
 
 ## Project Overview
 
-Gamepad Synth turns a BLE Bluetooth controller (Xbox Series X/S, PS5 DualSense, Switch Pro) into a Korg Monotron-inspired synthesizer. An ESP32-S3 reads gamepad input via Bluepad32 and produces audio through an I2S DAC (MAX98357A) in seven sound modes.
+Gamepad Synth turns a BLE Bluetooth controller (Xbox Series X/S, PS5 DualSense, Switch Pro) into a Korg Monotron-inspired synthesizer. An ESP32-S3 reads gamepad input via Bluepad32 and produces audio through an I2S DAC (MAX98357A). Three top-level voicings (Continuous, Discrete, One-shot) with orthogonal toggles (DUAL_OSC, DRONE_HOLD, DELAY, ARP, WAVEFORM) set via RB-held + face button.
 
-**Status**: v1.0.0 — All PRD-008 phases complete. Mono Synth, Dual Osc, Delay Synth, Scale, Arpeggio, Retro SFX, Drone modes. Full signal chain: dual DDS oscillators → resonant SVF filter → LFO modulation → 0.5 s delay → I2S DAC.
+**Status**: Phase 2 — voicing-based control model. Full signal chain: dual DDS oscillators → resonant TPT SVF filter → LFO modulation → 0.5 s delay → I2S DAC. Per-voicing config persists across voicing switches.
 
 ## Tech Stack
 
@@ -70,36 +70,41 @@ Port is auto-detected for ESP32-S3. Override with `PORT=/dev/ttyUSB0 just flash`
 
 ### Control Paradigm
 
-Tweak sticks (RY, RX, plus LX/LY in Drone) use **rate control**: stick displacement = rate of change of the parameter, not absolute position. Holding off-center changes the value over time; releasing to center holds the last value. This makes it possible to find a sweet spot and release, rather than having to hold the stick still. A short "bump" blip fires when a parameter reaches its min/max limit.
+Tweak sticks (typically RY/RX) use **rate control**: stick displacement = rate of change of the parameter, not absolute position. Holding off-center changes the value over time; releasing to center holds the last value. This makes it possible to find a sweet spot and release, rather than having to hold the stick still. A short "bump" blip fires when a parameter reaches its min/max limit.
 
-Primary pitch sticks (LY in Mono/Dual/Delay) stay **absolute** for theremin-style muscle memory — stick up = high note.
+Primary pitch sticks (LY in Continuous/Discrete) stay **absolute** for theremin-style muscle memory — stick up = high note. Under `DRONE_HOLD`, LY becomes integrating too (slow drift).
 
-Tweak parameter state (cutoff, resonance, delay time, feedback, detune, pitch offset) persists across ticks within a mode, resets on mode switch, and resets on LS-click.
+Tweak parameter state (cutoff, resonance, delay time, feedback, detune, pitch offset) persists across ticks within a voicing, resets on voicing switch, and resets on LS-click.
 
-### Global Buttons (every mode)
+Per-voicing configuration (`DUAL_OSC`, `DRONE_HOLD`, `DELAY`, `ARP`, `WAVEFORM`, interval semitones) persists **across** voicing switches, so you can tune up a Continuous setup, switch to Discrete for a chord bridge, and come back with the Continuous toggles still on.
+
+### Global Buttons (every voicing)
 
 | Button | Action |
 |---|---|
 | D-pad ↑/↓ | Master volume nudge (±0.05 per step), auto-repeats at 4 Hz |
 | D-pad ←/→ | Drum tempo nudge (±5 BPM), also drives the arp step rate |
-| Share/View/− (`MISC_BACK`) | Cycle sound mode (1-7). Brief LED flash, then a per-mode signature gesture plays. |
+| Share/View/− (`MISC_BACK`) | Cycle voicing (3 choices). Brief LED flash, then a per-voicing signature gesture plays. |
 | Home/PS/Xbox tap | Toggle drum engine on/off. Pattern/volume come from the settings page. |
 | Home/PS/Xbox held + A/B/X/Y | Select drum pattern 1/2/3/4 directly (auto-starts drums if off) |
 | Menu/Options/+ | Enter/exit settings-edit overlay. Inside, d-pad becomes field navigation (not volume/tempo). |
-| LS click (left-stick press) | Reset current mode's tweak parameters to defaults |
-| LT / RT triggers | ±7-semitone pitch bend (global in pitched modes) |
+| LS click (left-stick press) | Reset current voicing's tweak parameters to defaults |
+| LT / RT triggers | ±7-semitone pitch bend (global in pitched voicings) |
+| **RB + A** | Toggle `DUAL_OSC` (Continuous) |
+| **RB + B** | Toggle `DRONE_HOLD` (Continuous; forces DUAL_OSC on) |
+| **RB + X** | Toggle `DELAY` (Continuous + Discrete) |
+| **RB + Y** | Cycle `WAVEFORM` (global: square → saw → triangle → sine) |
+| **RB + LB** | Toggle `ARP` (Discrete) |
 
-**Settings-edit overlay**: d-pad ←/→ moves cursor between fields (drum_pattern, drum_volume, lfo_rate_hz, lfo_depth, lfo_target); ↑/↓ adjusts the selected field. Each cursor move plays a short value ladder so the user can audit the current value without a screen. Master volume and tempo moved to the global d-pad.
+While RB is held, face buttons are fully suppressed from normal voicing dispatch so the modifier-key metaphor stays clean. All toggles play a confirmation cue (two-blip up / single down / waveform-specific blip).
 
-### Sound Modes (cycled via View/Share/- button; each plays a signature gesture on entry)
+**Settings-edit overlay**: d-pad ←/→ moves cursor between fields (drum_pattern, drum_volume, lfo_rate_hz, lfo_depth, lfo_target); ↑/↓ adjusts the selected field. Each cursor move plays a short value ladder so the user can audit the current value without a screen. Master volume and tempo live on the global d-pad.
 
-1. **Mono Synth** — Monotron-style single osc. LY=pitch (absolute), LX=vibrato depth (absolute, fixed 5 Hz rate), RY=filter cutoff (integrating, log), RX=resonance (integrating). LFO target/rate/depth from settings.
-2. **Dual Osc** — Two sawtooth oscillators. LY=pitch (absolute), face buttons pick interval (A=unison, B=fifth, X=octave, Y=2 octaves), RY=cutoff (integrating), RX=resonance (integrating). Detune persists in `s_tweak_detune_cents` (phase-2 entry point for a shoulder modifier).
-3. **Delay Synth** — Single osc with dynamic delay. LY=pitch (absolute), RY=delay time (integrating, 20-500 ms, log), RX=feedback (integrating, 0-0.9). Filter fixed at 4 kHz / Q 1.2.
-4. **Scale Player** (sine + slapback) — A/B/X/Y (no LB) = Do/Re/Mi/Fa; **LB held** + A/B/X/Y = Sol/La/Ti/Do-high. LY integrates pitch offset (±12 st); RY = fine bend (±50 Hz, absolute).
-5. **Arpeggiator** (square + cosmic echo) — Face buttons = chord (A=major, B=minor, X=7th, Y=dim), LB/RB = octave, LY integrates root transpose (±12 st), LX-zones = pattern (left=down, right=up, center=up-down), RT toggles arp. Step rate is derived from the global tempo (16th notes).
-6. **Retro SFX** (filter/delay bypassed) — A/B/X/Y (no LB) = Laser/Explosion/Power-up/Coin; **LB held** + A/B/X/Y = Siren/Engine/Jump/Warp. RT = speed multiplier (0.3-1.0x on tick count).
-7. **Drone** — Two sustained oscillators. LY integrates osc A pitch, RY integrates osc B pitch (both drift slowly), LX integrates filter cutoff, RX integrates resonance. Osc B is also routed to the two piezos at a fixed detune ratio for acoustic beating. LFO from settings.
+### Voicings (cycled via View/Share/- button; each plays a signature gesture on entry)
+
+1. **Continuous** (Mono + Dual Osc + Delay Synth + Drone collapsed) — LY=pitch (absolute; integrating under DRONE_HOLD), LX=vibrato (or filter cutoff under DRONE_HOLD), RY=filter cutoff (integrating, log; osc B pitch under DRONE_HOLD), RX=filter resonance (integrating). Face buttons select dual-osc interval (unison/5th/8va/2×8va) when DUAL_OSC is on. LB+RY/RX fine-tunes delay time/feedback when DELAY is on. DRONE_HOLD routes osc B to the piezos at a fixed 1.02 detune ratio. Signature: pitch-bend chirp on sawtooth.
+2. **Discrete** (Scale + Arpeggio collapsed) — LY integrates pitch offset (±12 st). Without ARP: face buttons play scale degrees (A=Do/B=Re/X=Mi/Y=Fa; LB held → Sol/La/Ti/Do); RY=fine bend (±50 Hz, absolute); RX=filter cutoff (integrating). With ARP: face buttons pick chord (major/minor/7th/dim); LX-zones pick pattern (left=down, right=up, center=up-down); RT toggles arp running; step rate from the global tempo (16ths). Signature: Do-Mi-Sol on sine.
+3. **One-shot** (Retro SFX) — A/B/X/Y (no LB) trigger Laser/Explosion/Power-up/Coin; LB+face triggers Siren/Engine/Jump/Warp. RT = speed multiplier (0.3-1.0x). Filter and delay bypassed. Signature: laser zap.
 
 ### Dependencies
 

--- a/packages/audio/gamepad-synth/CLAUDE.md
+++ b/packages/audio/gamepad-synth/CLAUDE.md
@@ -68,15 +68,38 @@ Port is auto-detected for ESP32-S3. Override with `PORT=/dev/ttyUSB0 just flash`
 | `STICK_DEADZONE` | 50 | Analog stick dead zone (out of ±512) |
 | `MIN_FREQ` / `MAX_FREQ` | 100 / 2000 Hz | Tone frequency range |
 
-### Sound Modes (cycled via View/Share/- button, LED blinks 1-7)
+### Control Paradigm
 
-1. **Mono Synth** — Monotron-style single osc. LY=pitch, LX=vibrato depth, RY=filter cutoff, RX=resonance, LT=LFO rate, RT=LFO depth (cutoff wah)
-2. **Dual Osc** — Two sawtooth oscillators. LY=pitch, face buttons=interval (A=unison, B=fifth, X=octave, Y=two octaves), RX=detune (±50 cents), RY=cutoff
-3. **Delay Synth** — Single osc with dynamic delay. LY=pitch, RY=delay time (20-500 ms), RX=feedback, LT/RT=filter cutoff modulation
-4. **Scale Player** (sine + slapback) — Face buttons + d-pad = C major scale notes, shoulders = octave shift
-5. **Arpeggiator** (square + cosmic echo) — Face buttons = chord type, RT = toggle, LY = speed, LX = pattern
-6. **Retro SFX** (filter/delay bypassed) — Face buttons + d-pad = game SFX, RT = speed multiplier
-7. **Drone** — Two sustained oscillators with LFO. LY=osc A pitch, RY=osc B pitch, LT=LFO rate, RT=LFO depth (pitch + cutoff)
+Tweak sticks (RY, RX, plus LX/LY in Drone) use **rate control**: stick displacement = rate of change of the parameter, not absolute position. Holding off-center changes the value over time; releasing to center holds the last value. This makes it possible to find a sweet spot and release, rather than having to hold the stick still. A short "bump" blip fires when a parameter reaches its min/max limit.
+
+Primary pitch sticks (LY in Mono/Dual/Delay) stay **absolute** for theremin-style muscle memory — stick up = high note.
+
+Tweak parameter state (cutoff, resonance, delay time, feedback, detune, pitch offset) persists across ticks within a mode, resets on mode switch, and resets on LS-click.
+
+### Global Buttons (every mode)
+
+| Button | Action |
+|---|---|
+| D-pad ↑/↓ | Master volume nudge (±0.05 per step), auto-repeats at 4 Hz |
+| D-pad ←/→ | Drum tempo nudge (±5 BPM), also drives the arp step rate |
+| Share/View/− (`MISC_BACK`) | Cycle sound mode (1-7). Brief LED flash, then a per-mode signature gesture plays. |
+| Home/PS/Xbox tap | Toggle drum engine on/off. Pattern/volume come from the settings page. |
+| Home/PS/Xbox held + A/B/X/Y | Select drum pattern 1/2/3/4 directly (auto-starts drums if off) |
+| Menu/Options/+ | Enter/exit settings-edit overlay. Inside, d-pad becomes field navigation (not volume/tempo). |
+| LS click (left-stick press) | Reset current mode's tweak parameters to defaults |
+| LT / RT triggers | ±7-semitone pitch bend (global in pitched modes) |
+
+**Settings-edit overlay**: d-pad ←/→ moves cursor between fields (drum_pattern, drum_volume, lfo_rate_hz, lfo_depth, lfo_target); ↑/↓ adjusts the selected field. Each cursor move plays a short value ladder so the user can audit the current value without a screen. Master volume and tempo moved to the global d-pad.
+
+### Sound Modes (cycled via View/Share/- button; each plays a signature gesture on entry)
+
+1. **Mono Synth** — Monotron-style single osc. LY=pitch (absolute), LX=vibrato depth (absolute, fixed 5 Hz rate), RY=filter cutoff (integrating, log), RX=resonance (integrating). LFO target/rate/depth from settings.
+2. **Dual Osc** — Two sawtooth oscillators. LY=pitch (absolute), face buttons pick interval (A=unison, B=fifth, X=octave, Y=2 octaves), RY=cutoff (integrating), RX=resonance (integrating). Detune persists in `s_tweak_detune_cents` (phase-2 entry point for a shoulder modifier).
+3. **Delay Synth** — Single osc with dynamic delay. LY=pitch (absolute), RY=delay time (integrating, 20-500 ms, log), RX=feedback (integrating, 0-0.9). Filter fixed at 4 kHz / Q 1.2.
+4. **Scale Player** (sine + slapback) — A/B/X/Y (no LB) = Do/Re/Mi/Fa; **LB held** + A/B/X/Y = Sol/La/Ti/Do-high. LY integrates pitch offset (±12 st); RY = fine bend (±50 Hz, absolute).
+5. **Arpeggiator** (square + cosmic echo) — Face buttons = chord (A=major, B=minor, X=7th, Y=dim), LB/RB = octave, LY integrates root transpose (±12 st), LX-zones = pattern (left=down, right=up, center=up-down), RT toggles arp. Step rate is derived from the global tempo (16th notes).
+6. **Retro SFX** (filter/delay bypassed) — A/B/X/Y (no LB) = Laser/Explosion/Power-up/Coin; **LB held** + A/B/X/Y = Siren/Engine/Jump/Warp. RT = speed multiplier (0.3-1.0x on tick count).
+7. **Drone** — Two sustained oscillators. LY integrates osc A pitch, RY integrates osc B pitch (both drift slowly), LX integrates filter cutoff, RX integrates resonance. Osc B is also routed to the two piezos at a fixed detune ratio for acoustic beating. LFO from settings.
 
 ### Dependencies
 

--- a/packages/audio/gamepad-synth/README.md
+++ b/packages/audio/gamepad-synth/README.md
@@ -1,6 +1,6 @@
 # Gamepad Synth
 
-Turn a Bluetooth controller into a Korg Monotron-inspired synthesizer. An ESP32-S3 reads gamepad input via [Bluepad32](https://github.com/ricardoquesada/bluepad32) and produces audio through an I2S DAC (MAX98357A) in seven sound modes. Features dual DDS oscillators, resonant SVF filter, LFO modulation, and a 0.5-second delay line.
+Turn a Bluetooth controller into a Korg Monotron-inspired synthesizer. An ESP32-S3 reads gamepad input via [Bluepad32](https://github.com/ricardoquesada/bluepad32) and produces audio through an I2S DAC (MAX98357A). Three top-level voicings (Continuous, Discrete, One-shot) with orthogonal toggles for dual-osc, drone-hold, delay, arpeggiator, and waveform. Features dual DDS oscillators, resonant SVF filter, LFO modulation, and a 0.5-second delay line.
 
 ## Hardware
 
@@ -8,7 +8,7 @@ Turn a Bluetooth controller into a Korg Monotron-inspired synthesizer. An ESP32-
 - MAX98357A I2S DAC breakout (BCLK=GPIO5, WS=GPIO6, DIN=GPIO7)
 - 4-8 ohm speaker (2-3W)
 - Status LED on GPIO2
-- Optional: two piezo discs on GPIO8/GPIO9 for Drone-mode accent voices
+- Optional: two piezo discs on GPIO8/GPIO9 for Drone-hold accent voices
 
 See [WIRING.md](WIRING.md) for the full wiring guide.
 
@@ -39,115 +39,93 @@ The ESP32-S3 only supports **BLE** (no Bluetooth Classic). Compatible controller
 3. The LED blinks and the startup jingle plays when the board boots
 4. Once paired, the controller auto-reconnects on subsequent power-ups (just press the home button)
 
-## Sound Modes
-
-Press **View** (Xbox) / **Share** (PS) / **-** (Switch) to cycle through modes. The LED blinks 1-7 times to indicate the current mode.
-
-### Mode 1: Mono Synth
-
-Monotron-style single oscillator with resonant filter and LFO wah.
+## Global Controls
 
 | Control | Function |
 |---------|----------|
-| Left stick Y | Base pitch (100-2000 Hz) |
-| Left stick X | Vibrato depth (fixed 5 Hz speed) |
-| Right stick Y | Filter cutoff (40 Hz to 18 kHz, logarithmic) |
-| Right stick X | Filter resonance (self-oscillation at max) |
-| LT | LFO rate (0.1 - 20 Hz) |
-| RT | LFO depth (0 = off, max = ±2 octaves of cutoff modulation) |
+| D-pad ↑/↓ | Master volume (±0.05, auto-repeats at 4 Hz) |
+| D-pad ←/→ | Drum tempo (±5 BPM, also drives arp step rate) |
+| Share / View / − | Cycle voicing (Continuous → Discrete → One-shot) |
+| Home / PS / Xbox tap | Toggle drum engine on/off |
+| Home held + A/B/X/Y | Select drum pattern 1-4 |
+| Menu / Options / + | Enter/exit settings-edit overlay (d-pad navigates fields) |
+| LS click | Reset tweak parameters to defaults |
+| LT / RT triggers | ±7-semitone pitch bend in pitched voicings |
 
-Sweep right stick Y upward while holding RX for classic Monotron squelch. Hold RT while varying LT for filter "wah".
+## Modifier Toggles (RB-held + face button)
 
-### Mode 2: Dual Osc
+Each toggle plays a confirmation cue and persists per-voicing across voicing switches.
 
-Two sawtooth oscillators with selectable interval and detune for fat analog sound.
+| Combo | Toggle | Scope | Effect |
+|-------|--------|-------|--------|
+| RB + A | DUAL_OSC | Continuous | Enables osc B; face buttons select interval (unison/5th/8va/2×8va) |
+| RB + B | DRONE_HOLD | Continuous | LY+RY integrate pitch; osc B plays on piezos; forces DUAL_OSC on |
+| RB + X | DELAY | Continuous + Discrete | Enables delay tail; LB held + RY/RX fine-tunes time/feedback |
+| RB + Y | WAVEFORM | All | Cycles square → saw → triangle → sine |
+| RB + LB | ARP | Discrete | Overlays arpeggiator; face button picks chord, steps fire at 16ths |
 
-| Control | Function |
-|---------|----------|
-| Left stick Y | Base pitch |
-| A / B / X / Y | Interval: unison / fifth / octave / two octaves |
-| Right stick X | Detune (±50 cents) |
-| Right stick Y | Filter cutoff |
+## Voicings
 
-### Mode 3: Delay Synth
+Press **Share / View / −** to cycle. Each voicing plays a signature gesture on entry so you can identify the voicing without a screen.
 
-Single oscillator with dynamic delay-as-secondary-voice (Monotron Delay behavior).
+### Continuous
 
-| Control | Function |
-|---------|----------|
-| Left stick Y | Base pitch |
-| Right stick Y | Delay time (20 - 500 ms) |
-| Right stick X | Feedback (up to 0.9 — Karplus-Strong territory at max) |
-| LT | Filter cutoff down |
-| RT | Filter cutoff up |
-
-Short delay + high feedback produces string-like tones. Long delay + moderate feedback creates cosmic echoes.
-
-### Mode 4: Scale Player
-
-Play a C major scale with buttons and d-pad. Each button maps to a scale degree.
-
-| Control | Note |
-|---------|------|
-| A | Do (C) |
-| B | Re (D) |
-| X | Mi (E) |
-| Y | Fa (F) |
-| D-pad Up | Sol (G) |
-| D-pad Right | La (A) |
-| D-pad Down | Ti (B) |
-| D-pad Left | Do (C, high) |
-| LB | Octave down |
-| RB | Octave up |
-| Right stick Y | Pitch bend |
-
-Three octave range: C4, C5 (default), C6.
-
-### Mode 5: Arpeggiator
-
-Automatically cycles through chord notes. Select a chord, then toggle the arpeggio on.
+Monotron-style instrument: LY is the pitch stick, the right stick shapes the tone.
 
 | Control | Function |
 |---------|----------|
-| A | Major chord |
-| B | Minor chord |
-| X | Dominant 7th chord |
-| Y | Diminished chord |
-| RT | Toggle arpeggio on/off |
-| Left stick Y | Speed (50-500 ms per note) |
+| Left stick Y | Pitch (100-2000 Hz, absolute; integrating under DRONE_HOLD) |
+| Left stick X | Vibrato depth at 5 Hz (absolute; filter cutoff integrator under DRONE_HOLD) |
+| Right stick Y | Filter cutoff (40 Hz - 18 kHz, log, integrating; osc B pitch under DRONE_HOLD) |
+| Right stick X | Filter resonance (0.5 - 6.0, integrating) |
+| A/B/X/Y (no RB) | Interval: unison/5th/8va/2×8va (only when DUAL_OSC is on) |
+| LB + Right stick Y | Delay time adjust (when DELAY is on) |
+| LB + Right stick X | Delay feedback adjust (when DELAY is on) |
+| LT / RT | ±7-semitone pitch bend |
+
+Sweep RY upward while nudging RX for classic Monotron squelch. Toggle DRONE_HOLD (RB+B) for sustained drones that drift when sticks are released.
+
+### Discrete
+
+Face buttons pick scalar notes. Optional arpeggiator overlay.
+
+Without ARP:
+
+| Control | Function |
+|---------|----------|
+| A / B / X / Y (no LB) | Do / Re / Mi / Fa (lower tetrachord) |
+| LB + A / B / X / Y | Sol / La / Ti / Do (upper tetrachord) |
+| Left stick Y | Pitch offset, ±12 st (integrating) |
+| Right stick Y | Fine bend, ±50 Hz (absolute) |
+| Right stick X | Filter cutoff (integrating) |
+
+With ARP (RB+LB toggle):
+
+| Control | Function |
+|---------|----------|
+| A / B / X / Y | Chord: major / minor / 7th / diminished |
 | Left stick X | Pattern: left=down, right=up, center=up-down |
-| D-pad Up/Down | Transpose root note up/down |
-| LB | Octave down |
-| RB | Octave up |
+| Left stick Y | Root transpose, ±12 st (integrating) |
+| RT trigger rising edge | Start/stop arp running |
+| Right stick X | Filter cutoff (integrating) |
 
-### Mode 6: Retro SFX
+Step rate follows the global tempo (16th notes).
 
-Trigger classic game sound effects with button presses (filter and delay bypassed for raw effects).
+### One-shot
+
+Face buttons trigger retro SFX envelopes. Filter and delay bypassed.
 
 | Control | Sound Effect |
-|---------|-------------|
-| A | Laser (descending sweep) |
-| B | Explosion (low rumble) |
-| X | Power-up (ascending sweep) |
-| Y | Coin (high chirp) |
-| D-pad Up | Siren (oscillating) |
-| D-pad Down | Engine (low rumble) |
-| D-pad Left | Jump (ascending chirp) |
-| D-pad Right | Warp (sweep up) |
-| RT | Speed multiplier (0.5x-2x) |
-
-### Mode 7: Drone
-
-Two continuously-sustained oscillators with LFO modulation for evolving textures. Oscillator A plays through the DAC; oscillator B plays through the optional piezo pair (if wired) with a fixed 1.02 detune ratio between the two discs, so the beating happens acoustically in air.
-
-| Control | Function |
-|---------|----------|
-| Left stick Y | Oscillator A pitch (sawtooth, DAC) |
-| Right stick Y | Oscillator B pitch (square wave on piezos) |
-| LT | LFO rate |
-| RT | LFO depth (modulates both pitch and filter cutoff on the DAC voice) |
-
-No note-off — the drone plays continuously while in this mode. Dial in a static interval with the sticks, then add slow LFO modulation for a shifting ambient pad. Without the piezos wired, oscillator B is silent and only the DAC drone is heard.
+|---------|--------------|
+| A (no LB) | Laser (descending sweep) |
+| B (no LB) | Explosion (low rumble) |
+| X (no LB) | Power-up (ascending sweep) |
+| Y (no LB) | Coin (high chirp) |
+| LB + A | Siren |
+| LB + B | Engine |
+| LB + X | Jump |
+| LB + Y | Warp |
+| RT | Speed multiplier (0.3×-1.0×) |
 
 ## Building
 
@@ -159,6 +137,14 @@ just flash
 just monitor
 ```
 
+To enable verbose axis/dispatch diagnostic logging for debugging input-mapping issues:
+
+```bash
+just menuconfig
+# Navigate to "Gamepad Synth" → enable "Enable verbose axis..."
+just build && just flash && just monitor
+```
+
 ## Architecture
 
 - **Core 0**: Bluepad32 BTstack event loop (Bluetooth handling)
@@ -166,8 +152,8 @@ just monitor
   - **Control task** (50 Hz): reads gamepad state, updates synth parameters
   - **Audio render task** (continuous, priority 10): DDS phase accumulator with selectable waveform, writes 256-sample blocks to I2S DMA
 - **Audio output**: 44.1 kHz, 16-bit stereo (mono duplicated) via MAX98357A I2S DAC
-- **Piezo accents** (Drone mode only): two GPIO-driven LEDC square-wave voices on GPIO8/GPIO9 with a fixed 1.02 detune ratio, running in parallel to the DAC path
-- **Waveforms**: Square, sawtooth, triangle, sine (256-entry lookup table), noise. Per-mode defaults: Mono/Dual Osc/Delay Synth/Drone=sawtooth, Scale=sine, Arpeggio=square, SFX=square
-- **Filter**: State-variable low-pass with cutoff (40 Hz - 18 kHz) and resonance (Q 0.5 - 6.0). Chamberlin topology, coefficients recomputed once per 256-sample block. Self-oscillates at high resonance
+- **Piezo accents** (DRONE_HOLD only): two GPIO-driven LEDC square-wave voices on GPIO8/GPIO9 with a fixed 1.02 detune ratio, running in parallel to the DAC path
+- **Waveforms**: Square, sawtooth, triangle, sine (256-entry lookup table), noise. Cycle via RB+Y
+- **Filter**: Topology-preserving SVF (low-pass) with cutoff (40 Hz - 18 kHz) and resonance (Q 0.5 - 6.0). Unconditionally stable. Coefficients recomputed once per 256-sample block. Defensive NaN recovery guards against corner cases
 - **LFO**: Block-rate triangle LFO (0.1 - 20 Hz) modulating filter cutoff or oscillator pitch. Up to ±2 octaves cutoff mod or ±1 octave pitch mod at full depth
-- **Delay**: Circular-buffer delay line (0.5 s / 22050 samples, ~44 KB static RAM) with configurable delay time, feedback (up to 0.95), and wet/dry mix. Scale = slapback, Arpeggio = cosmic echo
+- **Delay**: Circular-buffer delay line (0.5 s / 22050 samples, ~44 KB static RAM) with configurable delay time, feedback (up to 0.9), and wet/dry mix

--- a/packages/audio/gamepad-synth/main/Kconfig.projbuild
+++ b/packages/audio/gamepad-synth/main/Kconfig.projbuild
@@ -1,0 +1,16 @@
+menu "Gamepad Synth"
+
+config GAMEPAD_SYNTH_DEBUG_AXES
+    bool "Enable verbose axis and dispatch diagnostic logging"
+    default n
+    help
+        When enabled, the control task periodically logs raw gamepad axis
+        values along with the current voicing, target frequency, and filter
+        state. Each voicing function also logs the reason it called
+        tone_stop (deadzone, no-face-button, arp-not-running, etc.), and
+        the audio render task logs when the active flag transitions false.
+
+        Intended to diagnose input-mapping bugs like the right-stick
+        cardinal-axis cutoff. Noisy at 5 Hz — disable for normal use.
+
+endmenu

--- a/packages/audio/gamepad-synth/main/main.c
+++ b/packages/audio/gamepad-synth/main/main.c
@@ -2,22 +2,30 @@
  * @file main.c
  * @brief ESP32-S3 Gamepad Synth — Bluetooth controller drives I2S audio
  *
- * Seven sound modes cycled via the Share/View/- button. Each announces
- * itself with a "signature gesture" played in its own voice on mode
- * switch (Tier-A audible cue).
+ * Three top-level voicings cycled via the Share/View/- button:
+ *   1. Continuous — monotron-style instrument (LY=pitch, sticks=tone)
+ *   2. Discrete   — face buttons pick notes / chord degrees
+ *   3. One-shot   — face buttons trigger retro SFX envelopes
  *
- * Unified control scheme:
- *   D-pad ↑/↓     = master volume         (global, 4 Hz auto-repeat)
- *   D-pad ←/→     = drum tempo / arp step (global, 4 Hz auto-repeat)
- *   Share/View/-  = cycle sound mode
+ * Orthogonal toggles layer on top (RB-held + face button):
+ *   RB+A = DUAL_OSC   (Continuous: face picks interval)
+ *   RB+B = DRONE_HOLD (Continuous: LY+RY integrate pitch, piezos sing)
+ *   RB+X = DELAY      (Continuous + Discrete: LB+RY/RX fine-tunes)
+ *   RB+Y = WAVEFORM   (global: cycles sq→saw→tri→sine)
+ *   RB+LB = ARP       (Discrete: arpeggiate chord at global tempo)
+ *
+ * Global controls:
+ *   D-pad ↑/↓     = master volume         (4 Hz auto-repeat)
+ *   D-pad ←/→     = drum tempo / arp step (4 Hz auto-repeat)
+ *   Share/View/-  = cycle voicing (3 choices)
  *   Home/PS/Xbox  = tap toggles drum engine, hold+face selects pattern 1-4
  *   Menu/Options  = enter settings-edit overlay (d-pad navigates fields)
- *   LT/RT         = ±7-semitone pitch bend in pitched modes
- *   LS click      = reset per-mode tweak parameters to defaults
+ *   LT/RT         = ±7-semitone pitch bend in pitched voicings
+ *   LS click      = reset per-voicing tweak parameters to defaults
  *
- * Sticks use *rate control* for tweak parameters (RY/RX, plus LX/LY in
- * Drone): holding off-center changes the value over time; releasing
- * holds. Primary pitch sticks (LY in Mono/Dual/Delay) stay absolute.
+ * Sticks use *rate control* for tweak parameters (RY/RX): holding
+ * off-center changes the value over time; releasing holds. Primary pitch
+ * sticks (LY in Continuous/Discrete) stay absolute unless DRONE_HOLD.
  *
  * Bluepad32 runs on Core 0 (BTstack event loop, blocks forever).
  * Core 1 runs two tasks:
@@ -52,6 +60,17 @@
 #include "piezo_voice.h"
 
 static const char *TAG = "gamepad_synth";
+
+/* Gated diagnostic logging for axis / dispatch debugging. Enable via
+ * `idf.py menuconfig` → "Gamepad Synth" → "Enable verbose axis..." to
+ * trace input-mapping bugs (e.g. right-stick cardinal-axis cutoff). */
+#if CONFIG_GAMEPAD_SYNTH_DEBUG_AXES
+#define DBG_AXES(fmt, ...) ESP_LOGI(TAG, "AXES: " fmt, ##__VA_ARGS__)
+#else
+#define DBG_AXES(fmt, ...) \
+    do {                   \
+    } while (0)
+#endif
 
 /* ── Pin Definitions ─────────────────────────────────────── */
 
@@ -396,22 +415,39 @@ static inline float compute_bend_mult(const gamepad_state_t *gp)
     return powf(2.0f, bend_semitones / 12.0f);
 }
 
-/* ── Sound Modes ─────────────────────────────────────────── */
+/* ── Voicings and Voicing Config ─────────────────────────
+ *
+ * Three top-level voicings cycled by Share/View/-. Orthogonal toggles
+ * layer on top (RB-held + face button). Per-voicing config persists
+ * across voicing switches — finding a sweet setup in Continuous and
+ * switching to Discrete for a chord bridge preserves the Continuous
+ * setup.
+ */
 
 typedef enum {
-    MODE_MONO = 0,    /* Monotron-style single osc + filter + LFO */
-    MODE_DUAL_OSC,    /* Two oscillators with selectable interval + detune */
-    MODE_DELAY_SYNTH, /* Single osc + dynamic delay (RY=time, RX=feedback) */
-    MODE_SCALE,
-    MODE_ARPEGGIO,
-    MODE_SFX,
-    MODE_DRONE, /* Two sustained oscillators with LFO modulation */
-    MODE_COUNT,
-} sound_mode_t;
+    VOICING_CONTINUOUS = 0, /* LY=pitch, sticks shape the tone */
+    VOICING_DISCRETE,       /* Face buttons play notes / chord degrees */
+    VOICING_ONE_SHOT,       /* Face buttons trigger SFX envelopes */
+    VOICING_COUNT,
+} voicing_t;
 
-static sound_mode_t s_mode = MODE_MONO;
+typedef struct {
+    bool dual_osc;       /* Continuous only: enable osc B */
+    bool drone_hold;     /* Continuous only: LY+RY integrate pitch, piezos sing; forces dual_osc */
+    bool delay;          /* Continuous + Discrete: delay tail */
+    bool arp;            /* Discrete only: arp overlay */
+    waveform_t waveform; /* Per-voicing timbre */
+    int interval_semitones; /* Dual-osc interval (Continuous) */
+} voicing_cfg_t;
 
-/* Arpeggiator state */
+static voicing_t s_voicing = VOICING_CONTINUOUS;
+static voicing_cfg_t s_cfg[VOICING_COUNT] = {
+    [VOICING_CONTINUOUS] = {.waveform = WAVE_SAWTOOTH, .interval_semitones = 0},
+    [VOICING_DISCRETE] = {.waveform = WAVE_SINE, .interval_semitones = 0},
+    [VOICING_ONE_SHOT] = {.waveform = WAVE_SQUARE, .interval_semitones = 0},
+};
+
+/* Arpeggiator state (used by VOICING_DISCRETE when cfg.arp is true) */
 static const uint8_t *s_arp_chord = CHORD_MAJOR;
 static int s_arp_root = 0;      /* semitone offset from C4 */
 static int s_arp_index = 0;     /* current note in chord */
@@ -419,7 +455,7 @@ static int s_arp_direction = 1; /* 1=up, -1=down */
 static bool s_arp_running = false;
 static uint32_t s_arp_last_ms = 0;
 
-/* SFX state */
+/* SFX state (used by VOICING_ONE_SHOT) */
 typedef struct {
     float freq;
     float freq_end;
@@ -428,7 +464,7 @@ typedef struct {
 } sfx_state_t;
 static sfx_state_t s_sfx = {0};
 
-/* Scale octave: 0=C4, 1=C5, 2=C6 */
+/* Scale octave for arp: 0=C4, 1=C5, 2=C6 */
 static int s_octave = 1;
 
 /* Mode switch debounce */
@@ -679,308 +715,7 @@ static void led_off(void)
     gpio_set_level(LED_PIN, 0);
 }
 
-/* ── Mode 1: Mono Synth (Monotron-style) ─────────────────── */
-
-static void mode_mono(const gamepad_state_t *gp)
-{
-    int16_t ly = gp->axis_y;
-    int16_t lx = gp->axis_x;
-
-    /* Right stick integrates filter cutoff (RY) and resonance (RX) —
-     * set-and-release semantics, value persists across ticks. */
-    integrate_right_stick_filter(gp->axis_ry, gp->axis_rx);
-    synth_set_lfo((lfo_target_t)s_settings.lfo_target, s_settings.lfo_rate_hz,
-                  s_settings.lfo_depth);
-
-    /* Playing sticks (LY pitch, LX vibrato) stay absolute for expressive
-     * real-time control — the user wants muscle memory here, not rate. */
-    if (abs(ly) < STICK_DEADZONE && abs(lx) < STICK_DEADZONE) {
-        tone_stop();
-        led_off();
-        return;
-    }
-
-    float pitch = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-    float vib_depth = map_range((float)abs(lx), 0, STICK_MAX, 0, 100);
-    static uint32_t tick = 0;
-    tick++;
-    float vib = vib_depth * sinf(2.0f * 3.14159f * 5.0f * (float)tick / CONTROL_TASK_HZ);
-    pitch += vib;
-
-    pitch *= compute_bend_mult(gp);
-    tone_play((uint32_t)pitch);
-    led_on();
-}
-
-/* ── Mode 2: Dual Osc (two oscillators, face-button interval) ── */
-
-static void mode_dual_osc(const gamepad_state_t *gp)
-{
-    /* A=unison, B=fifth, X=octave, Y=two octaves (rising-edge tap) */
-    static int s_interval_semitones = 0;
-    static uint16_t prev_buttons = 0;
-    uint16_t pressed = gp->buttons & ~prev_buttons;
-    prev_buttons = gp->buttons;
-
-    if (pressed & BTN_A) {
-        s_interval_semitones = 0;
-        synth_blip(BLIP_FREQ_DOWN);
-    }
-    if (pressed & BTN_B) {
-        s_interval_semitones = 7;
-        synth_blip(BLIP_FREQ_NEUTRAL);
-    }
-    if (pressed & BTN_X) {
-        s_interval_semitones = 12;
-        synth_blip(BLIP_FREQ_UP);
-    }
-    if (pressed & BTN_Y) {
-        s_interval_semitones = 24;
-        synth_blip(BLIP_FREQ_UP * 1.5f);
-    }
-
-    /* Right stick integrates filter. Detune moves onto an integrating
-     * axis too (driven by shoulder-held modifier in a later phase); for
-     * now it persists at 0 cents and can be nudged via RS-click + RX
-     * (see control_task). */
-    integrate_right_stick_filter(gp->axis_ry, gp->axis_rx);
-
-    /* Playing stick (LY pitch) stays absolute. */
-    int16_t ly = gp->axis_y;
-    if (abs(ly) < STICK_DEADZONE) {
-        tone_stop();
-        synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
-        led_off();
-        return;
-    }
-
-    float pitch_a = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-    float detune_mult = powf(2.0f, s_tweak_detune_cents / 1200.0f);
-    float pitch_b = pitch_a * powf(2.0f, (float)s_interval_semitones / 12.0f) * detune_mult;
-
-    float bend_mult = compute_bend_mult(gp);
-    pitch_a *= bend_mult;
-    pitch_b *= bend_mult;
-
-    tone_play((uint32_t)pitch_a);
-    synth_set_osc_b(true, pitch_b, WAVE_SAWTOOTH);
-    led_on();
-}
-
-/* ── Mode 3: Delay Synth (single osc + dynamic delay) ────── */
-
-static void mode_delay_synth(const gamepad_state_t *gp)
-{
-    /* In Delay Synth the right stick is repurposed for the delay line
-     * (the whole point of the mode), so filter stays fixed. RY integrates
-     * delay time (log, 20..500 ms). RX integrates feedback (linear). */
-    synth_set_filter(true, 4000.0f, 1.2f);
-
-    bool bumped = false;
-    bumped |= integrate_exp(&s_tweak_delay_ms, stick_rate(gp->axis_ry), 2.0f, 20.0f, 500.0f,
-                            INTEGRATION_DT);
-    bumped |=
-        integrate_lin(&s_tweak_feedback, stick_rate(gp->axis_rx), 0.5f, 0.0f, 0.9f, INTEGRATION_DT);
-    int delay_samples = (int)(SAMPLE_RATE * s_tweak_delay_ms / 1000.0f);
-    synth_set_delay(true, delay_samples, s_tweak_feedback, 0.5f);
-
-    static uint32_t last_bump_ms = 0;
-    if (bumped) {
-        uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
-        if (now - last_bump_ms > 400) {
-            synth_blip(BLIP_FREQ_NEUTRAL * 0.5f);
-            last_bump_ms = now;
-        }
-    }
-
-    /* Playing stick (LY pitch) absolute. */
-    int16_t ly = gp->axis_y;
-    if (abs(ly) < STICK_DEADZONE) {
-        tone_stop();
-        led_off();
-        return;
-    }
-
-    float pitch = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-    pitch *= compute_bend_mult(gp);
-    tone_play((uint32_t)pitch);
-    led_on();
-}
-
-/* ── Mode 7: Drone (two sustained oscillators, LFO on both) ── */
-
-static void mode_drone(const gamepad_state_t *gp)
-{
-    /* Drone integrates *both* pitch sticks — slow glides are the point,
-     * so rate-control fits better than absolute. LX integrates filter
-     * cutoff, RX integrates resonance (different axes from Mono because
-     * the right stick is the second melodic voice here). */
-    integrate_exp(&s_drone_freq_a, stick_rate(gp->axis_y), 2.0f, (float)MIN_FREQ, (float)MAX_FREQ,
-                  INTEGRATION_DT);
-    integrate_exp(&s_drone_freq_b, stick_rate(gp->axis_ry), 2.0f, (float)MIN_FREQ, (float)MAX_FREQ,
-                  INTEGRATION_DT);
-    integrate_exp(&s_tweak_cutoff_hz, stick_rate(gp->axis_x), 4.0f, FILTER_CUTOFF_MIN,
-                  FILTER_CUTOFF_MAX, INTEGRATION_DT);
-    integrate_lin(&s_tweak_resonance, stick_rate(gp->axis_rx), 3.0f, FILTER_Q_MIN, FILTER_Q_MAX,
-                  INTEGRATION_DT);
-    synth_set_filter(true, s_tweak_cutoff_hz, s_tweak_resonance);
-    synth_set_lfo((lfo_target_t)s_settings.lfo_target, s_settings.lfo_rate_hz,
-                  s_settings.lfo_depth);
-
-    float bend_mult = compute_bend_mult(gp);
-    float pitch_a = s_drone_freq_a * bend_mult;
-    float pitch_b = s_drone_freq_b * bend_mult;
-
-    tone_play((uint32_t)pitch_a);
-    /* Osc B is rendered on the piezos with a fixed detune ratio so the
-     * beating happens acoustically in air rather than inside the DAC. */
-    piezo_voice_note_on(PIEZO_A, pitch_b);
-    piezo_voice_note_on(PIEZO_B, pitch_b * PIEZO_DETUNE_RATIO);
-    led_on();
-}
-
-/* ── Mode 4: Scale Player ────────────────────────────────── */
-
-static void mode_scale(const gamepad_state_t *gp)
-{
-    /* Face buttons = scale degrees (held = sustain note):
-     *   LB-not-held + A/B/X/Y → Do  Re  Mi  Fa  (lower tetrachord)
-     *   LB-held     + A/B/X/Y → Sol La  Ti  Do  (upper tetrachord)
-     * LY integrates pitch offset (±12 semitones) to replace the previous
-     * LB/RB octave shift with smooth, rate-controlled motion. */
-    integrate_lin(&s_tweak_pitch_offset_st, stick_rate(gp->axis_y), 6.0f, -12.0f, 12.0f,
-                  INTEGRATION_DT);
-
-    bool lb_held = (gp->buttons & BTN_SHOULDER_L) != 0;
-    int note_idx = -1;
-    if (gp->buttons & BTN_A)
-        note_idx = lb_held ? 4 : 0;
-    if (gp->buttons & BTN_B)
-        note_idx = lb_held ? 5 : 1;
-    if (gp->buttons & BTN_X)
-        note_idx = lb_held ? 6 : 2;
-    if (gp->buttons & BTN_Y)
-        note_idx = lb_held ? 7 : 3;
-
-    if (note_idx < 0) {
-        tone_stop();
-        led_off();
-        return;
-    }
-
-    int semitone = (12 /* base C5 */) + SCALE_MAJOR[note_idx] + (int)s_tweak_pitch_offset_st;
-    float freq = (float)note_at(semitone);
-
-    /* RY = fine bend (absolute, expressive). Triggers = coarse bend. */
-    freq += map_range((float)gp->axis_ry, -STICK_MAX, STICK_MAX, -50, 50);
-    freq *= compute_bend_mult(gp);
-
-    tone_play((uint32_t)freq);
-    led_on();
-}
-
-/* ── Mode 5: Arpeggiator ────────────────────────────────── */
-
-static void mode_arpeggio(const gamepad_state_t *gp)
-{
-    /* Face buttons select chord (rising edge) */
-    static uint16_t prev_buttons = 0;
-    uint16_t pressed = gp->buttons & ~prev_buttons;
-    prev_buttons = gp->buttons;
-
-    if (pressed & BTN_A) {
-        s_arp_chord = CHORD_MAJOR;
-        synth_blip(BLIP_FREQ_UP);
-    }
-    if (pressed & BTN_B) {
-        s_arp_chord = CHORD_MINOR;
-        synth_blip(BLIP_FREQ_DOWN);
-    }
-    if (pressed & BTN_X) {
-        s_arp_chord = CHORD_7TH;
-        synth_blip(BLIP_FREQ_NEUTRAL);
-    }
-    if (pressed & BTN_Y) {
-        s_arp_chord = CHORD_DIM;
-        synth_blip(BLIP_FREQ_DOWN * 0.75f);
-    }
-
-    /* LB/RB still shift octave */
-    if (pressed & BTN_SHOULDER_L && s_octave > 0) {
-        s_octave--;
-        synth_blip(BLIP_FREQ_DOWN);
-    }
-    if (pressed & BTN_SHOULDER_R && s_octave < 2) {
-        s_octave++;
-        synth_blip(BLIP_FREQ_UP);
-    }
-
-    /* LY integrates the root note (±12 semitones from C). Replaces the
-     * d-pad root transpose — smooth, rate-controlled, releases at value. */
-    integrate_lin(&s_tweak_pitch_offset_st, stick_rate(gp->axis_y), 6.0f, -12.0f, 12.0f,
-                  INTEGRATION_DT);
-    s_arp_root = (int)s_tweak_pitch_offset_st;
-
-    /* RT trigger toggles arpeggio on/off (rising edge) */
-    static bool prev_r2 = false;
-    bool r2 = gp->throttle > 100;
-    if (r2 && !prev_r2) {
-        s_arp_running = !s_arp_running;
-        s_arp_index = 0;
-        s_arp_direction = 1;
-        synth_blip(s_arp_running ? BLIP_FREQ_UP : BLIP_FREQ_DOWN);
-        if (!s_arp_running)
-            tone_stop();
-    }
-    prev_r2 = r2;
-
-    if (!s_arp_running) {
-        led_off();
-        return;
-    }
-
-    /* Step rate is derived from the global tempo (16th notes). Set via
-     * d-pad ←/→ — one groove for the whole device. */
-    float speed_ms = 60000.0f / (float)s_settings.drum_tempo_bpm / 4.0f;
-
-    /* Pattern from left stick X quadrant: left = down, right = up, center = up-down */
-    int pattern = 0;
-    if (gp->axis_x < -STICK_DEADZONE)
-        pattern = 1;
-    else if (gp->axis_x > STICK_DEADZONE)
-        pattern = 0;
-    else
-        pattern = 2;
-
-    uint32_t now_ms = xTaskGetTickCount() * portTICK_PERIOD_MS;
-    if (now_ms - s_arp_last_ms >= (uint32_t)speed_ms) {
-        s_arp_last_ms = now_ms;
-
-        int semitone = (s_octave * 12) + s_arp_root + s_arp_chord[s_arp_index];
-        tone_play(note_at(semitone));
-        led_on();
-
-        /* Advance index based on pattern */
-        if (pattern == 0) {
-            s_arp_index = (s_arp_index + 1) % CHORD_LEN;
-        } else if (pattern == 1) {
-            s_arp_index--;
-            if (s_arp_index < 0)
-                s_arp_index = CHORD_LEN - 1;
-        } else {
-            s_arp_index += s_arp_direction;
-            if (s_arp_index >= CHORD_LEN) {
-                s_arp_index = CHORD_LEN - 2;
-                s_arp_direction = -1;
-            } else if (s_arp_index < 0) {
-                s_arp_index = 1;
-                s_arp_direction = 1;
-            }
-        }
-    }
-}
-
-/* ── Mode 6: Retro SFX ──────────────────────────────────── */
+/* ── SFX helpers (used by VOICING_ONE_SHOT) ──────────────── */
 
 static void sfx_start(float start, float end, int ticks)
 {
@@ -1003,7 +738,294 @@ static void sfx_tick(void)
     s_sfx.ticks_left--;
 }
 
-static void mode_sfx(const gamepad_state_t *gp)
+/* Arpeggiator core — called from VOICING_DISCRETE when cfg.arp is true.
+ * Handles chord selection on face-button rising edge and steps through
+ * the chord at global-tempo 16ths. */
+static void arp_tick(const gamepad_state_t *gp, uint16_t face_pressed)
+{
+    if (face_pressed & BTN_A) {
+        s_arp_chord = CHORD_MAJOR;
+        s_arp_running = true;
+        s_arp_index = 0;
+        s_arp_direction = 1;
+        synth_blip(BLIP_FREQ_UP);
+    } else if (face_pressed & BTN_B) {
+        s_arp_chord = CHORD_MINOR;
+        s_arp_running = true;
+        s_arp_index = 0;
+        s_arp_direction = 1;
+        synth_blip(BLIP_FREQ_DOWN);
+    } else if (face_pressed & BTN_X) {
+        s_arp_chord = CHORD_7TH;
+        s_arp_running = true;
+        s_arp_index = 0;
+        s_arp_direction = 1;
+        synth_blip(BLIP_FREQ_NEUTRAL);
+    } else if (face_pressed & BTN_Y) {
+        s_arp_chord = CHORD_DIM;
+        s_arp_running = true;
+        s_arp_index = 0;
+        s_arp_direction = 1;
+        synth_blip(BLIP_FREQ_DOWN * 0.75f);
+    }
+
+    /* LY-integrated pitch offset drives the arp root. */
+    s_arp_root = (int)s_tweak_pitch_offset_st;
+
+    /* RT rising edge still toggles arp running (off-switch without
+     * disabling the whole cfg.arp toggle). */
+    static bool prev_r2 = false;
+    bool r2 = gp->throttle > 100;
+    if (r2 && !prev_r2) {
+        s_arp_running = !s_arp_running;
+        s_arp_index = 0;
+        s_arp_direction = 1;
+        synth_blip(s_arp_running ? BLIP_FREQ_UP : BLIP_FREQ_DOWN);
+        if (!s_arp_running)
+            tone_stop();
+    }
+    prev_r2 = r2;
+
+    if (!s_arp_running) {
+        led_off();
+        DBG_AXES("voicing=discrete arp=on running=false stop_reason=arp_not_running");
+        return;
+    }
+
+    /* Step rate is derived from the global tempo (16th notes). */
+    float speed_ms = 60000.0f / (float)s_settings.drum_tempo_bpm / 4.0f;
+
+    /* Pattern from left stick X quadrant: left=down, right=up, center=up-down */
+    int pattern;
+    if (gp->axis_x < -STICK_DEADZONE)
+        pattern = 1;
+    else if (gp->axis_x > STICK_DEADZONE)
+        pattern = 0;
+    else
+        pattern = 2;
+
+    uint32_t now_ms = xTaskGetTickCount() * portTICK_PERIOD_MS;
+    if (now_ms - s_arp_last_ms >= (uint32_t)speed_ms) {
+        s_arp_last_ms = now_ms;
+
+        int semitone = (s_octave * 12) + s_arp_root + s_arp_chord[s_arp_index];
+        tone_play(note_at(semitone));
+        led_on();
+
+        if (pattern == 0) {
+            s_arp_index = (s_arp_index + 1) % CHORD_LEN;
+        } else if (pattern == 1) {
+            s_arp_index--;
+            if (s_arp_index < 0)
+                s_arp_index = CHORD_LEN - 1;
+        } else {
+            s_arp_index += s_arp_direction;
+            if (s_arp_index >= CHORD_LEN) {
+                s_arp_index = CHORD_LEN - 2;
+                s_arp_direction = -1;
+            } else if (s_arp_index < 0) {
+                s_arp_index = 1;
+                s_arp_direction = 1;
+            }
+        }
+    }
+}
+
+/* ── Voicing 1: Continuous (Mono + Dual Osc + Delay + Drone) ── */
+
+static void voicing_continuous(const gamepad_state_t *gp, uint16_t face_pressed)
+{
+    const voicing_cfg_t cfg = s_cfg[VOICING_CONTINUOUS];
+    bool lb_held = (gp->buttons & BTN_SHOULDER_L) != 0;
+
+    /* LFO from settings (Mono+Drone both wired this up). */
+    synth_set_lfo((lfo_target_t)s_settings.lfo_target, s_settings.lfo_rate_hz,
+                  s_settings.lfo_depth);
+
+    /* Face-button interval pick (dual-osc, not drone-hold). Drone-hold
+     * doesn't use intervals because osc B is piezo-only and follows
+     * RY-integrating pitch instead. */
+    if (cfg.dual_osc && !cfg.drone_hold) {
+        if (face_pressed & BTN_A) {
+            s_cfg[VOICING_CONTINUOUS].interval_semitones = 0;
+            synth_blip(BLIP_FREQ_DOWN);
+        } else if (face_pressed & BTN_B) {
+            s_cfg[VOICING_CONTINUOUS].interval_semitones = 7;
+            synth_blip(BLIP_FREQ_NEUTRAL);
+        } else if (face_pressed & BTN_X) {
+            s_cfg[VOICING_CONTINUOUS].interval_semitones = 12;
+            synth_blip(BLIP_FREQ_UP);
+        } else if (face_pressed & BTN_Y) {
+            s_cfg[VOICING_CONTINUOUS].interval_semitones = 24;
+            synth_blip(BLIP_FREQ_UP * 1.5f);
+        }
+    }
+
+    /* Right-stick tweaks — delay params if LB+delay, else filter. */
+    if (cfg.delay && lb_held) {
+        bool bumped = false;
+        bumped |= integrate_exp(&s_tweak_delay_ms, stick_rate(gp->axis_ry), 2.0f, 20.0f, 500.0f,
+                                INTEGRATION_DT);
+        bumped |= integrate_lin(&s_tweak_feedback, stick_rate(gp->axis_rx), 0.5f, 0.0f, 0.9f,
+                                INTEGRATION_DT);
+        static uint32_t last_bump_ms = 0;
+        if (bumped) {
+            uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
+            if (now - last_bump_ms > 400) {
+                synth_blip(BLIP_FREQ_NEUTRAL * 0.5f);
+                last_bump_ms = now;
+            }
+        }
+    } else if (cfg.drone_hold) {
+        /* Drone-hold: LX integrates filter cutoff, RX integrates resonance.
+         * (LY=pitch A, RY=pitch B are handled below in the render path.) */
+        integrate_exp(&s_tweak_cutoff_hz, stick_rate(gp->axis_x), 4.0f, FILTER_CUTOFF_MIN,
+                      FILTER_CUTOFF_MAX, INTEGRATION_DT);
+        integrate_lin(&s_tweak_resonance, stick_rate(gp->axis_rx), 3.0f, FILTER_Q_MIN, FILTER_Q_MAX,
+                      INTEGRATION_DT);
+        synth_set_filter(true, s_tweak_cutoff_hz, s_tweak_resonance);
+    } else {
+        integrate_right_stick_filter(gp->axis_ry, gp->axis_rx);
+    }
+
+    /* Apply delay from persistent tweak state (when delay is enabled). */
+    if (cfg.delay) {
+        int delay_samples = (int)(SAMPLE_RATE * s_tweak_delay_ms / 1000.0f);
+        synth_set_delay(true, delay_samples, s_tweak_feedback, 0.5f);
+    } else {
+        synth_set_delay(false, 1, 0.0f, 0.0f);
+    }
+
+    float bend_mult = compute_bend_mult(gp);
+
+    if (cfg.drone_hold) {
+        /* Both DAC osc A pitch (LY) and piezo osc B pitch (RY) integrate. */
+        integrate_exp(&s_drone_freq_a, stick_rate(gp->axis_y), 2.0f, (float)MIN_FREQ,
+                      (float)MAX_FREQ, INTEGRATION_DT);
+        integrate_exp(&s_drone_freq_b, stick_rate(gp->axis_ry), 2.0f, (float)MIN_FREQ,
+                      (float)MAX_FREQ, INTEGRATION_DT);
+        float pitch_a = s_drone_freq_a * bend_mult;
+        float pitch_b = s_drone_freq_b * bend_mult;
+        tone_play((uint32_t)pitch_a);
+        synth_set_osc_b(false, (float)MIN_FREQ, cfg.waveform); /* Osc B is piezo-only in drone */
+        piezo_voice_note_on(PIEZO_A, pitch_b);
+        piezo_voice_note_on(PIEZO_B, pitch_b * PIEZO_DETUNE_RATIO);
+        led_on();
+        return;
+    }
+
+    /* Standard continuous: LY=absolute pitch, LX=vibrato depth. */
+    int16_t ly = gp->axis_y;
+    int16_t lx = gp->axis_x;
+    if (abs(ly) < STICK_DEADZONE && abs(lx) < STICK_DEADZONE) {
+        tone_stop();
+        synth_set_osc_b(false, (float)MIN_FREQ, cfg.waveform);
+        piezo_voice_note_off(PIEZO_A);
+        piezo_voice_note_off(PIEZO_B);
+        led_off();
+        DBG_AXES("voicing=continuous ly=%d lx=%d stop_reason=deadzone", ly, lx);
+        return;
+    }
+
+    float pitch = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
+    float vib_depth = map_range((float)abs(lx), 0, STICK_MAX, 0, 100);
+    static uint32_t tick = 0;
+    tick++;
+    float vib = vib_depth * sinf(2.0f * 3.14159f * 5.0f * (float)tick / CONTROL_TASK_HZ);
+    pitch += vib;
+    pitch *= bend_mult;
+
+    tone_play((uint32_t)pitch);
+
+    if (cfg.dual_osc) {
+        int interval = s_cfg[VOICING_CONTINUOUS].interval_semitones;
+        float detune_mult = powf(2.0f, s_tweak_detune_cents / 1200.0f);
+        float pitch_b = pitch * powf(2.0f, (float)interval / 12.0f) * detune_mult;
+        synth_set_osc_b(true, pitch_b, cfg.waveform);
+    } else {
+        synth_set_osc_b(false, (float)MIN_FREQ, cfg.waveform);
+    }
+    led_on();
+}
+
+/* ── Voicing 2: Discrete (Scale + Arpeggio) ───────────────── */
+
+static void voicing_discrete(const gamepad_state_t *gp, uint16_t face_pressed)
+{
+    const voicing_cfg_t cfg = s_cfg[VOICING_DISCRETE];
+    bool lb_held = (gp->buttons & BTN_SHOULDER_L) != 0;
+
+    /* LY integrates pitch offset (±12 st) — root transpose or scale slide. */
+    integrate_lin(&s_tweak_pitch_offset_st, stick_rate(gp->axis_y), 6.0f, -12.0f, 12.0f,
+                  INTEGRATION_DT);
+
+    /* RX integrates filter cutoff (resonance stays at current tweak state
+     * unless the user flips over to Continuous and adjusts it). */
+    if (cfg.delay && lb_held) {
+        bool bumped = false;
+        bumped |= integrate_exp(&s_tweak_delay_ms, stick_rate(gp->axis_ry), 2.0f, 20.0f, 500.0f,
+                                INTEGRATION_DT);
+        bumped |= integrate_lin(&s_tweak_feedback, stick_rate(gp->axis_rx), 0.5f, 0.0f, 0.9f,
+                                INTEGRATION_DT);
+        static uint32_t last_bump_ms = 0;
+        if (bumped) {
+            uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
+            if (now - last_bump_ms > 400) {
+                synth_blip(BLIP_FREQ_NEUTRAL * 0.5f);
+                last_bump_ms = now;
+            }
+        }
+    } else {
+        integrate_exp(&s_tweak_cutoff_hz, stick_rate(gp->axis_rx), 4.0f, FILTER_CUTOFF_MIN,
+                      FILTER_CUTOFF_MAX, INTEGRATION_DT);
+    }
+    synth_set_filter(true, s_tweak_cutoff_hz, s_tweak_resonance);
+
+    if (cfg.delay) {
+        int delay_samples = (int)(SAMPLE_RATE * s_tweak_delay_ms / 1000.0f);
+        synth_set_delay(true, delay_samples, s_tweak_feedback, 0.5f);
+    } else {
+        synth_set_delay(false, 1, 0.0f, 0.0f);
+    }
+    synth_set_osc_b(false, (float)MIN_FREQ, cfg.waveform);
+
+    if (cfg.arp) {
+        arp_tick(gp, face_pressed);
+        return;
+    }
+
+    /* Scale mode: face buttons play scalar notes.
+     *   LB-not-held + A/B/X/Y → Do  Re  Mi  Fa
+     *   LB-held     + A/B/X/Y → Sol La  Ti  Do  */
+    int note_idx = -1;
+    if (gp->buttons & BTN_A)
+        note_idx = lb_held ? 4 : 0;
+    if (gp->buttons & BTN_B)
+        note_idx = lb_held ? 5 : 1;
+    if (gp->buttons & BTN_X)
+        note_idx = lb_held ? 6 : 2;
+    if (gp->buttons & BTN_Y)
+        note_idx = lb_held ? 7 : 3;
+
+    if (note_idx < 0) {
+        tone_stop();
+        led_off();
+        DBG_AXES("voicing=discrete arp=off stop_reason=no_face_button");
+        return;
+    }
+
+    int semitone = (12 /* base C5 */) + SCALE_MAJOR[note_idx] + (int)s_tweak_pitch_offset_st;
+    float freq = (float)note_at(semitone);
+    /* RY = fine bend (absolute). */
+    freq += map_range((float)gp->axis_ry, -STICK_MAX, STICK_MAX, -50, 50);
+    freq *= compute_bend_mult(gp);
+    tone_play((uint32_t)freq);
+    led_on();
+}
+
+/* ── Voicing 3: One-Shot (Retro SFX) ──────────────────────── */
+
+static void voicing_one_shot(const gamepad_state_t *gp, uint16_t face_pressed)
 {
     /* RT = speed multiplier on the sweep tick count. */
     float speed = map_range((float)gp->throttle, 0, TRIGGER_MAX, 1.0f, 0.3f);
@@ -1012,14 +1034,7 @@ static void mode_sfx(const gamepad_state_t *gp)
     if (ticks < 5)
         ticks = 5;
 
-    /* Trigger SFX on rising edge. D-pad is now global (vol/tempo), so the
-     * four ex-d-pad SFX ride LB-held + face buttons. */
-    static uint16_t prev_btn = 0;
-    uint16_t btn_pressed = gp->buttons & ~prev_btn;
-    prev_btn = gp->buttons;
-
     bool lb_held = (gp->buttons & BTN_SHOULDER_L) != 0;
-    uint16_t face_pressed = btn_pressed & BTN_FACE_MASK;
 
     if (!lb_held) {
         if (face_pressed & BTN_A)
@@ -1044,19 +1059,18 @@ static void mode_sfx(const gamepad_state_t *gp)
     sfx_tick();
 }
 
-/* ── Mode Signature Gestures ─────────────────────────────
+/* ── Voicing Signature Gestures ──────────────────────────
  *
- * On mode switch, play a short phrase *in that mode's own voice* so the
- * user hears which mode they're in without having to count LED blinks.
- * Blocks the control task for ~300-500 ms while it plays — audio render
- * keeps running, so the user hears the gesture immediately. Restores
- * silence at the end so the mode starts from a clean state.
+ * On voicing switch, play a short phrase *in that voicing's own voice*
+ * so the user hears which voicing they're in without having to count
+ * LED blinks. Blocks the control task for ~300-500 ms; audio render
+ * keeps running, so the user hears the gesture immediately.
  */
-static void play_mode_signature(sound_mode_t mode)
+static void play_voicing_signature(voicing_t voicing)
 {
-    switch (mode) {
-        case MODE_MONO: {
-            /* Pitch-bend chirp (sawtooth, 400→1200 Hz) */
+    switch (voicing) {
+        case VOICING_CONTINUOUS: {
+            /* Pitch-bend chirp (sawtooth, 400→1200 Hz) — instrument feel */
             synth_set_waveform(WAVE_SAWTOOTH);
             synth_set_filter(true, 6000.0f, 1.5f);
             synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
@@ -1068,34 +1082,8 @@ static void play_mode_signature(sound_mode_t mode)
             }
             break;
         }
-        case MODE_DUAL_OSC: {
-            /* Perfect fifth dyad */
-            synth_set_waveform(WAVE_SAWTOOTH);
-            synth_set_filter(true, 4000.0f, 1.2f);
-            synth_set_osc_b(true, 440.0f * 1.5f, WAVE_SAWTOOTH);
-            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
-            synth_set_delay(false, 1, 0.0f, 0.0f);
-            tone_play(440);
-            vTaskDelay(pdMS_TO_TICKS(350));
-            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
-            break;
-        }
-        case MODE_DELAY_SYNTH: {
-            /* One note ringing through the delay */
-            synth_set_waveform(WAVE_SAWTOOTH);
-            synth_set_filter(true, 4000.0f, 1.2f);
-            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
-            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
-            synth_set_delay(true, SAMPLE_RATE * 140 / 1000, 0.55f, 0.5f);
-            tone_play(523);
-            vTaskDelay(pdMS_TO_TICKS(80));
-            tone_stop();
-            vTaskDelay(pdMS_TO_TICKS(400));
-            synth_set_delay(false, 1, 0.0f, 0.0f);
-            break;
-        }
-        case MODE_SCALE: {
-            /* Do-Mi-Sol ascending on sine */
+        case VOICING_DISCRETE: {
+            /* Do-Mi-Sol ascending on sine — melodic feel */
             synth_set_waveform(WAVE_SINE);
             synth_set_filter(true, 5000.0f, 0.8f);
             synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
@@ -1109,22 +1097,8 @@ static void play_mode_signature(sound_mode_t mode)
             vTaskDelay(pdMS_TO_TICKS(160));
             break;
         }
-        case MODE_ARPEGGIO: {
-            /* Fast C-major arp */
-            synth_set_waveform(WAVE_SQUARE);
-            synth_set_filter(true, 4000.0f, 1.2f);
-            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
-            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
-            synth_set_delay(true, SAMPLE_RATE * 100 / 1000, 0.4f, 0.3f);
-            const uint16_t notes[] = {262, 330, 392, 523};
-            for (int i = 0; i < 4; i++) {
-                tone_play(notes[i]);
-                vTaskDelay(pdMS_TO_TICKS(75));
-            }
-            break;
-        }
-        case MODE_SFX: {
-            /* Laser zap (descending square-wave sweep) */
+        case VOICING_ONE_SHOT: {
+            /* Laser zap — descending square sweep */
             synth_set_waveform(WAVE_SQUARE);
             synth_set_filter(false, FILTER_CUTOFF_MAX, FILTER_Q_MIN);
             synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
@@ -1136,24 +1110,37 @@ static void play_mode_signature(sound_mode_t mode)
             }
             break;
         }
-        case MODE_DRONE: {
-            /* Held open fifth with an LFO cutoff sweep */
-            synth_set_waveform(WAVE_SAWTOOTH);
-            synth_set_filter(true, 2500.0f, 1.5f);
-            synth_set_osc_b(true, 330.0f, WAVE_SAWTOOTH);
-            synth_set_lfo(LFO_TARGET_CUTOFF, 4.0f, 0.4f);
-            synth_set_delay(false, 1, 0.0f, 0.0f);
-            tone_play(220);
-            vTaskDelay(pdMS_TO_TICKS(500));
-            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
-            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
-            break;
-        }
         default:
             break;
     }
     tone_stop();
-    vTaskDelay(pdMS_TO_TICKS(60)); /* short silence tail before user takes over */
+    vTaskDelay(pdMS_TO_TICKS(60));
+}
+
+/* ── Toggle cues ─────────────────────────────────────────── */
+
+/* Two-blip rising cue for toggle-on, single descending blip for toggle-off. */
+static void toggle_cue(bool enabled)
+{
+    if (enabled) {
+        synth_blip(BLIP_FREQ_UP);
+        vTaskDelay(pdMS_TO_TICKS(110));
+        synth_blip(BLIP_FREQ_UP * 1.25f);
+    } else {
+        synth_blip(BLIP_FREQ_DOWN);
+    }
+}
+
+/* Waveform cycle cue: signature blip frequency per waveform so the user
+ * can identify the new timbre without hearing it yet. */
+static void waveform_cue(waveform_t w)
+{
+    static const float freqs[WAVE_COUNT] = {
+        [WAVE_SQUARE] = BLIP_FREQ_NEUTRAL,      [WAVE_SAWTOOTH] = BLIP_FREQ_UP,
+        [WAVE_TRIANGLE] = BLIP_FREQ_UP * 1.15f, [WAVE_SINE] = BLIP_FREQ_UP * 1.3f,
+        [WAVE_NOISE] = BLIP_FREQ_DOWN * 0.75f,
+    };
+    synth_blip(freqs[w]);
 }
 
 /* ── Bluepad32 Custom Platform ───────────────────────────── */
@@ -1358,9 +1345,16 @@ static void audio_render_task(void *arg)
 
     ESP_ERROR_CHECK(i2s_channel_enable(s_tx_chan));
 
+    bool prev_active = false;
     while (1) {
         float freq = s_synth.target_freq;
         bool active = s_synth.active;
+
+        if (active != prev_active) {
+            DBG_AXES("audio: active %d -> %d (freq=%.1f reason=%s)", prev_active, active, freq,
+                     !active ? (freq < (float)MIN_FREQ ? "freq<MIN" : "!active") : "on");
+            prev_active = active;
+        }
 
         if (!active || freq < (float)MIN_FREQ) {
             memset(stereo_buf, 0, sizeof(stereo_buf));
@@ -1432,6 +1426,17 @@ static void audio_render_task(void *arg)
                 phase += phase_inc;
                 if (phase >= 1.0f)
                     phase -= 1.0f;
+            }
+
+            /* Defensive NaN guard — TPT SVF should be unconditionally
+             * stable, but a stale config or coefficient corner could
+             * still propagate NaN and silence the audio until the
+             * active-flag reset. Clear to zero and log once per event. */
+            if (isnan(svf_low) || isnan(svf_band)) {
+                ESP_LOGW(TAG, "SVF state NaN recovered (cutoff=%.1f Q=%.2f)", cutoff,
+                         s_synth.filter_resonance);
+                svf_low = 0.0f;
+                svf_band = 0.0f;
             }
         }
 
@@ -1624,82 +1629,128 @@ static void settings_edit_handle(const gamepad_state_t *gp)
 
 /* ── Control Task (Core 1, reads gamepad, updates synth) ── */
 
-/* Apply per-mode synth defaults on entry. Waveform, osc B, filter, LFO,
- * and delay are all reset so the user starts from a known state. */
-static void apply_mode_defaults(sound_mode_t mode)
+/* Apply per-voicing synth defaults on entry. Waveform comes from the
+ * persistent voicing cfg; osc B, filter, LFO, and delay reset so the
+ * user starts from a known state. Per-voicing toggles (dual_osc, arp,
+ * delay) are re-applied on the first tick of the voicing function. */
+static void apply_voicing_defaults(voicing_t voicing)
 {
-    static const waveform_t mode_waves[] = {
-        [MODE_MONO] = WAVE_SAWTOOTH,        [MODE_DUAL_OSC] = WAVE_SAWTOOTH,
-        [MODE_DELAY_SYNTH] = WAVE_SAWTOOTH, [MODE_SCALE] = WAVE_SINE,
-        [MODE_ARPEGGIO] = WAVE_SQUARE,      [MODE_SFX] = WAVE_SQUARE,
-        [MODE_DRONE] = WAVE_SAWTOOTH,
-    };
-    synth_set_waveform(mode_waves[mode]);
-    synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+    const voicing_cfg_t cfg = s_cfg[voicing];
+    synth_set_waveform(cfg.waveform);
+    synth_set_osc_b(false, (float)MIN_FREQ, cfg.waveform);
 
-    switch (mode) {
-        case MODE_MONO:
-        case MODE_DUAL_OSC:
-        case MODE_DELAY_SYNTH:
-        case MODE_DRONE:
+    switch (voicing) {
+        case VOICING_CONTINUOUS:
             synth_set_filter(true, TWEAK_CUTOFF_DEFAULT, TWEAK_RESONANCE_DEFAULT);
             break;
-        case MODE_SCALE:
+        case VOICING_DISCRETE:
             synth_set_filter(true, 5000.0f, 0.8f);
             break;
-        case MODE_ARPEGGIO:
-            synth_set_filter(true, 4000.0f, 1.2f);
-            break;
-        case MODE_SFX:
+        case VOICING_ONE_SHOT:
         default:
             synth_set_filter(false, FILTER_CUTOFF_MAX, FILTER_Q_MIN);
             break;
     }
 
-    /* LFO is driven per-tick by Mono and Drone (from settings). Other
-     * modes silence it on entry. */
-    if (mode != MODE_MONO && mode != MODE_DRONE)
+    /* LFO is driven per-tick by Continuous (from settings). Discrete
+     * and One-shot silence it on entry. */
+    if (voicing != VOICING_CONTINUOUS)
         synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
 
-    switch (mode) {
-        case MODE_SCALE:
-            synth_set_delay(true, SAMPLE_RATE * 120 / 1000, 0.25f, 0.3f);
-            break;
-        case MODE_ARPEGGIO:
-            synth_set_delay(true, SAMPLE_RATE * 250 / 1000, 0.55f, 0.4f);
-            break;
-        case MODE_DELAY_SYNTH:
-            synth_set_delay(true, SAMPLE_RATE * 200 / 1000, 0.5f, 0.5f);
-            break;
-        default:
-            synth_set_delay(false, 1, 0.0f, 0.0f);
-            break;
+    /* Delay tail default; if cfg.delay is true, the voicing function
+     * will re-enable on the next tick via synth_set_delay(). */
+    if (cfg.delay) {
+        int delay_samples = (int)(SAMPLE_RATE * s_tweak_delay_ms / 1000.0f);
+        synth_set_delay(true, delay_samples, s_tweak_feedback, 0.5f);
+    } else {
+        synth_set_delay(false, 1, 0.0f, 0.0f);
     }
 }
 
-/* Handle a mode-switch: silence voices, reset transient state, play the
- * signature gesture, and restore the mode's defaults. */
-static void enter_mode(sound_mode_t new_mode)
+/* Handle a voicing switch: silence voices, reset transient state, play
+ * the signature gesture, and restore the voicing's defaults. Per-voicing
+ * cfg (dual_osc, delay, waveform, ...) is preserved across switches. */
+static void enter_voicing(voicing_t new_voicing)
 {
     tone_stop();
     piezo_voice_note_off(PIEZO_A);
     piezo_voice_note_off(PIEZO_B);
-    s_mode = new_mode;
+    s_voicing = new_voicing;
     s_arp_running = false;
     s_sfx.ticks_left = 0;
     reset_tweaks();
 
-    /* Short LED flash = "mode changed". The signature gesture below
-     * tells the user *which* mode. */
     led_on();
     vTaskDelay(pdMS_TO_TICKS(40));
     led_off();
 
-    apply_mode_defaults(new_mode);
-    play_mode_signature(new_mode);
-    apply_mode_defaults(new_mode); /* restore in case the signature left state around */
+    apply_voicing_defaults(new_voicing);
+    play_voicing_signature(new_voicing);
+    apply_voicing_defaults(new_voicing);
 
-    ESP_LOGI(TAG, "Mode: %d", s_mode);
+    ESP_LOGI(TAG, "Voicing: %d cfg={dual=%d drone=%d delay=%d arp=%d wave=%d}", s_voicing,
+             s_cfg[s_voicing].dual_osc, s_cfg[s_voicing].drone_hold, s_cfg[s_voicing].delay,
+             s_cfg[s_voicing].arp, s_cfg[s_voicing].waveform);
+}
+
+/* Handle RB-held + face-button toggle combos. Returns the bitmask of
+ * face buttons "consumed" (suppressed from voicing dispatch) when RB is
+ * held, so the normal face-button-as-note behavior doesn't fire. */
+static uint16_t handle_toggle_combo(uint16_t face_pressed, bool rb_held, bool lb_pressed)
+{
+    if (!rb_held)
+        return 0;
+
+    uint16_t consumed = 0;
+
+    if (face_pressed & BTN_A) {
+        if (s_voicing == VOICING_CONTINUOUS) {
+            s_cfg[VOICING_CONTINUOUS].dual_osc = !s_cfg[VOICING_CONTINUOUS].dual_osc;
+            if (!s_cfg[VOICING_CONTINUOUS].dual_osc)
+                s_cfg[VOICING_CONTINUOUS].drone_hold = false;
+            toggle_cue(s_cfg[VOICING_CONTINUOUS].dual_osc);
+            ESP_LOGI(TAG, "Toggle DUAL_OSC: %d", s_cfg[VOICING_CONTINUOUS].dual_osc);
+        }
+        consumed |= BTN_A;
+    }
+    if (face_pressed & BTN_B) {
+        if (s_voicing == VOICING_CONTINUOUS) {
+            s_cfg[VOICING_CONTINUOUS].drone_hold = !s_cfg[VOICING_CONTINUOUS].drone_hold;
+            if (s_cfg[VOICING_CONTINUOUS].drone_hold)
+                s_cfg[VOICING_CONTINUOUS].dual_osc = true;
+            toggle_cue(s_cfg[VOICING_CONTINUOUS].drone_hold);
+            ESP_LOGI(TAG, "Toggle DRONE_HOLD: %d", s_cfg[VOICING_CONTINUOUS].drone_hold);
+        }
+        consumed |= BTN_B;
+    }
+    if (face_pressed & BTN_X) {
+        if (s_voicing == VOICING_CONTINUOUS || s_voicing == VOICING_DISCRETE) {
+            s_cfg[s_voicing].delay = !s_cfg[s_voicing].delay;
+            toggle_cue(s_cfg[s_voicing].delay);
+            ESP_LOGI(TAG, "Toggle DELAY[%d]: %d", s_voicing, s_cfg[s_voicing].delay);
+        }
+        consumed |= BTN_X;
+    }
+    if (face_pressed & BTN_Y) {
+        waveform_t next =
+            (waveform_t)((s_cfg[s_voicing].waveform + 1) % (WAVE_NOISE)); /* skip noise */
+        s_cfg[s_voicing].waveform = next;
+        synth_set_waveform(next);
+        waveform_cue(next);
+        ESP_LOGI(TAG, "Cycle WAVEFORM[%d]: %d", s_voicing, next);
+        consumed |= BTN_Y;
+    }
+    if (lb_pressed && s_voicing == VOICING_DISCRETE) {
+        s_cfg[VOICING_DISCRETE].arp = !s_cfg[VOICING_DISCRETE].arp;
+        if (!s_cfg[VOICING_DISCRETE].arp) {
+            s_arp_running = false;
+            tone_stop();
+        }
+        toggle_cue(s_cfg[VOICING_DISCRETE].arp);
+        ESP_LOGI(TAG, "Toggle ARP: %d", s_cfg[VOICING_DISCRETE].arp);
+    }
+
+    return consumed;
 }
 
 /* Global d-pad: ↑/↓ nudges master_volume by ±0.05, ←/→ nudges tempo by
@@ -1763,10 +1814,10 @@ static void control_task(void *arg)
         uint16_t btn_pressed_global = gp.buttons & ~s_prev_buttons_global;
         s_prev_buttons_global = gp.buttons;
 
-        /* Mode switch on Share button (rising edge) */
+        /* Voicing switch on Share button (rising edge) */
         if (misc_pressed & MISC_BACK) {
-            sound_mode_t next = (sound_mode_t)((s_mode + 1) % MODE_COUNT);
-            enter_mode(next);
+            voicing_t next = (voicing_t)((s_voicing + 1) % VOICING_COUNT);
+            enter_voicing(next);
         }
 
         /* Home held → modifier for drum-pattern select. Face-button tap
@@ -1867,28 +1918,40 @@ static void control_task(void *arg)
         /* Global d-pad: volume (↑/↓) and tempo (←/→). */
         handle_global_dpad(gp.dpad);
 
-        /* Dispatch to current mode */
-        switch (s_mode) {
-            case MODE_MONO:
-                mode_mono(&gp);
+        /* RB-held + face / LB toggles combos. Face buttons consumed by
+         * toggle combos are masked out before reaching voicing dispatch
+         * so the normal note/interval behavior doesn't double-fire. */
+        bool rb_held = (gp.buttons & BTN_SHOULDER_R) != 0;
+        uint16_t face_pressed = btn_pressed_global & BTN_FACE_MASK;
+        bool lb_pressed_edge = (btn_pressed_global & BTN_SHOULDER_L) != 0;
+        uint16_t consumed = handle_toggle_combo(face_pressed, rb_held, lb_pressed_edge);
+        uint16_t face_for_voicing = face_pressed & ~consumed;
+        /* While RB is held, suppress note/interval face-button semantics
+         * entirely so the user can think of RB as a "modifier" key. */
+        if (rb_held)
+            face_for_voicing = 0;
+
+        /* Periodic axis log (every ~10 ticks, 5 Hz) for diagnostics. */
+        static int s_dbg_tick = 0;
+        if (++s_dbg_tick >= 10) {
+            s_dbg_tick = 0;
+            DBG_AXES("lx=%d ly=%d rx=%d ry=%d btns=0x%04x dpad=0x%02x misc=0x%02x "
+                     "voicing=%d active=%d freq=%.1f cutoff=%.1f Q=%.2f",
+                     gp.axis_x, gp.axis_y, gp.axis_rx, gp.axis_ry, gp.buttons, gp.dpad,
+                     gp.misc_buttons, s_voicing, s_synth.active, s_synth.target_freq,
+                     s_synth.filter_cutoff, s_synth.filter_resonance);
+        }
+
+        /* Dispatch to current voicing */
+        switch (s_voicing) {
+            case VOICING_CONTINUOUS:
+                voicing_continuous(&gp, face_for_voicing);
                 break;
-            case MODE_DUAL_OSC:
-                mode_dual_osc(&gp);
+            case VOICING_DISCRETE:
+                voicing_discrete(&gp, face_for_voicing);
                 break;
-            case MODE_DELAY_SYNTH:
-                mode_delay_synth(&gp);
-                break;
-            case MODE_SCALE:
-                mode_scale(&gp);
-                break;
-            case MODE_ARPEGGIO:
-                mode_arpeggio(&gp);
-                break;
-            case MODE_SFX:
-                mode_sfx(&gp);
-                break;
-            case MODE_DRONE:
-                mode_drone(&gp);
+            case VOICING_ONE_SHOT:
+                voicing_one_shot(&gp, face_for_voicing);
                 break;
             default:
                 break;

--- a/packages/audio/gamepad-synth/main/main.c
+++ b/packages/audio/gamepad-synth/main/main.c
@@ -2,15 +2,27 @@
  * @file main.c
  * @brief ESP32-S3 Gamepad Synth — Bluetooth controller drives I2S audio
  *
- * Four sound modes cycled via View button (Xbox) / Share (PS) / - (Switch):
- *   1. Theremin  — sticks control pitch, vibrato, triggers bend pitch
- *   2. Scale     — face buttons + d-pad play notes, shoulders shift octave
- *   3. Arpeggio  — face buttons pick chord, stick controls speed/pattern
- *   4. Retro SFX — buttons trigger classic game sound effects
+ * Seven sound modes cycled via the Share/View/- button. Each announces
+ * itself with a "signature gesture" played in its own voice on mode
+ * switch (Tier-A audible cue).
+ *
+ * Unified control scheme:
+ *   D-pad ↑/↓     = master volume         (global, 4 Hz auto-repeat)
+ *   D-pad ←/→     = drum tempo / arp step (global, 4 Hz auto-repeat)
+ *   Share/View/-  = cycle sound mode
+ *   Home/PS/Xbox  = tap toggles drum engine, hold+face selects pattern 1-4
+ *   Menu/Options  = enter settings-edit overlay (d-pad navigates fields)
+ *   LT/RT         = ±7-semitone pitch bend in pitched modes
+ *   LS click      = reset per-mode tweak parameters to defaults
+ *
+ * Sticks use *rate control* for tweak parameters (RY/RX, plus LX/LY in
+ * Drone): holding off-center changes the value over time; releasing
+ * holds. Primary pitch sticks (LY in Mono/Dual/Delay) stay absolute.
  *
  * Bluepad32 runs on Core 0 (BTstack event loop, blocks forever).
  * Core 1 runs two tasks:
- *   - Control task at 50 Hz: reads gamepad, updates synth parameters
+ *   - Control task at 50 Hz: reads gamepad, integrates stick state,
+ *     drives synth parameters
  *   - Audio render task: generates samples, writes to I2S DMA (MAX98357A)
  *
  * Tested with: Xbox Series X/S controller (BLE, firmware v5.15+)
@@ -117,6 +129,10 @@ static inline int16_t osc_sample(float phase, waveform_t wave)
 #define BTN_Y (1 << 3)          /* Y (Xbox) / Triangle (PS) */
 #define BTN_SHOULDER_L (1 << 4) /* LB (Xbox) / L1 (PS) */
 #define BTN_SHOULDER_R (1 << 5) /* RB (Xbox) / R1 (PS) */
+#define BTN_THUMB_L (1 << 8)    /* Left-stick click (LSB/L3) */
+#define BTN_THUMB_R (1 << 9)    /* Right-stick click (RSB/R3) */
+
+#define BTN_FACE_MASK (BTN_A | BTN_B | BTN_X | BTN_Y)
 
 #define DPAD_UP (1 << 0)
 #define DPAD_DOWN (1 << 1)
@@ -226,10 +242,11 @@ static volatile synth_state_t s_synth = {0};
  * this module does not consume them.
  */
 
+/* Master volume and tempo moved to the d-pad (global) in phase 1, so
+ * they are no longer fields here. Pattern stays because it's a discrete
+ * four-way selector and Home+face is the other entry point. */
 typedef enum {
-    SETTING_MASTER_VOL = 0,
-    SETTING_DRUM_PATTERN,
-    SETTING_DRUM_TEMPO,
+    SETTING_DRUM_PATTERN = 0,
     SETTING_DRUM_VOLUME,
     SETTING_LFO_RATE,
     SETTING_LFO_DEPTH,
@@ -262,6 +279,10 @@ volatile int s_settings_cursor = 0;
 
 /* Settings edit input debounce tracking (rising-edge and d-pad repeat) */
 #define SETTINGS_DPAD_REPEAT_MS 200
+
+/* Global d-pad auto-repeat: 4 Hz while held. Applies to the volume
+ * (↑/↓) and tempo (←/→) nudges outside the settings-edit overlay. */
+#define GLOBAL_DPAD_REPEAT_MS 250
 
 /* ── State-Variable Filter (TPT form, unconditionally stable) ── */
 
@@ -520,6 +541,133 @@ static float map_range(float val, float in_min, float in_max, float out_min, flo
     return out_min + (out_max - out_min) * ((val - in_min) / (in_max - in_min));
 }
 
+/* ── Integrating-stick helpers ─────────────────────────────
+ *
+ * Sticks now drive *rate of change* for parameters rather than absolute
+ * position (except for the primary pitch stick in pitched modes, where
+ * absolute mapping preserves theremin-style muscle memory).
+ *
+ * stick_rate()        : raw stick value → normalized rate in [-1, +1]
+ *                       after deadzone. Linear beyond the deadzone.
+ *
+ * integrate_exp()     : multiply a value by 2^(rate·octaves_per_sec·dt)
+ *                       and clamp. Use for log-perceptual params like
+ *                       cutoff, pitch, delay-time.
+ *
+ * integrate_lin()     : value += rate·units_per_sec·dt, clamped.
+ *                       Use for linear params (resonance, feedback,
+ *                       detune cents, mix).
+ *
+ * Both integrate_* return true when the value is clamped at a limit
+ * *this tick*, so the caller can emit a "bump" blip at the edge.
+ */
+#define INTEGRATION_DT (1.0f / (float)CONTROL_TASK_HZ)
+#define STICK_RATE_RANGE ((float)(STICK_MAX - STICK_DEADZONE))
+
+static inline float stick_rate(int16_t stick_val)
+{
+    if (stick_val > STICK_DEADZONE)
+        return (float)(stick_val - STICK_DEADZONE) / STICK_RATE_RANGE;
+    if (stick_val < -STICK_DEADZONE)
+        return (float)(stick_val + STICK_DEADZONE) / STICK_RATE_RANGE;
+    return 0.0f;
+}
+
+static inline bool integrate_exp(float *value, float rate, float octaves_per_sec, float min_v,
+                                 float max_v, float dt)
+{
+    if (rate == 0.0f)
+        return false;
+    float prev = *value;
+    *value *= powf(2.0f, rate * octaves_per_sec * dt);
+    if (*value < min_v) {
+        *value = min_v;
+        return prev > min_v;
+    }
+    if (*value > max_v) {
+        *value = max_v;
+        return prev < max_v;
+    }
+    return false;
+}
+
+static inline bool integrate_lin(float *value, float rate, float units_per_sec, float min_v,
+                                 float max_v, float dt)
+{
+    if (rate == 0.0f)
+        return false;
+    float prev = *value;
+    *value += rate * units_per_sec * dt;
+    if (*value < min_v) {
+        *value = min_v;
+        return prev > min_v;
+    }
+    if (*value > max_v) {
+        *value = max_v;
+        return prev < max_v;
+    }
+    return false;
+}
+
+/* ── Shared Tweak Parameter State ─────────────────────────
+ *
+ * These persist across ticks within a mode (so finding a sweet spot and
+ * releasing the stick keeps the value). They reset on mode switch and on
+ * LS-click. Every pitched mode pulls cutoff/resonance from here so the
+ * right stick always means the same thing.
+ */
+#define TWEAK_CUTOFF_DEFAULT 6000.0f
+#define TWEAK_RESONANCE_DEFAULT 1.5f
+#define TWEAK_DELAY_MS_DEFAULT 200.0f
+#define TWEAK_FEEDBACK_DEFAULT 0.4f
+#define TWEAK_DETUNE_CENTS_DEFAULT 0.0f
+#define TWEAK_PITCH_OFFSET_ST_DEFAULT 0.0f
+
+static float s_tweak_cutoff_hz = TWEAK_CUTOFF_DEFAULT;
+static float s_tweak_resonance = TWEAK_RESONANCE_DEFAULT;
+static float s_tweak_delay_ms = TWEAK_DELAY_MS_DEFAULT;
+static float s_tweak_feedback = TWEAK_FEEDBACK_DEFAULT;
+static float s_tweak_detune_cents = TWEAK_DETUNE_CENTS_DEFAULT;
+static float s_tweak_pitch_offset_st = TWEAK_PITCH_OFFSET_ST_DEFAULT; /* Scale root slide */
+/* Drone mode: both oscillator freqs drift via integrating sticks. */
+static float s_drone_freq_a = 220.0f;
+static float s_drone_freq_b = 330.0f;
+
+static void reset_tweaks(void)
+{
+    s_tweak_cutoff_hz = TWEAK_CUTOFF_DEFAULT;
+    s_tweak_resonance = TWEAK_RESONANCE_DEFAULT;
+    s_tweak_delay_ms = TWEAK_DELAY_MS_DEFAULT;
+    s_tweak_feedback = TWEAK_FEEDBACK_DEFAULT;
+    s_tweak_detune_cents = TWEAK_DETUNE_CENTS_DEFAULT;
+    s_tweak_pitch_offset_st = TWEAK_PITCH_OFFSET_ST_DEFAULT;
+    s_drone_freq_a = 220.0f;
+    s_drone_freq_b = 330.0f;
+}
+
+/* Integrate cutoff (RY) and resonance (RX) from the right stick. Applies
+ * the result via synth_set_filter(). Emits a short bump-blip at the
+ * edges so the user can tell they're maxed out. */
+static void integrate_right_stick_filter(int16_t ry, int16_t rx)
+{
+    bool bumped = false;
+    bumped |= integrate_exp(&s_tweak_cutoff_hz, stick_rate(ry), 4.0f, FILTER_CUTOFF_MIN,
+                            FILTER_CUTOFF_MAX, INTEGRATION_DT);
+    bumped |= integrate_lin(&s_tweak_resonance, stick_rate(rx), 3.0f, FILTER_Q_MIN, FILTER_Q_MAX,
+                            INTEGRATION_DT);
+    synth_set_filter(true, s_tweak_cutoff_hz, s_tweak_resonance);
+
+    /* Rate-limit the bump blip so it doesn't spam while pinned at a limit. */
+    static uint32_t last_bump_ms = 0;
+    if (bumped) {
+        uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
+        if (now - last_bump_ms > 400) {
+            synth_blip(BLIP_FREQ_NEUTRAL * 0.5f); /* low "thud" */
+            last_bump_ms = now;
+        }
+    }
+}
+
 /* ── LED Helpers ─────────────────────────────────────────── */
 
 static void led_on(void)
@@ -531,54 +679,35 @@ static void led_off(void)
     gpio_set_level(LED_PIN, 0);
 }
 
-static void led_blink(int count, int on_ms, int off_ms)
-{
-    for (int i = 0; i < count; i++) {
-        led_on();
-        vTaskDelay(pdMS_TO_TICKS(on_ms));
-        led_off();
-        vTaskDelay(pdMS_TO_TICKS(off_ms));
-    }
-}
-
 /* ── Mode 1: Mono Synth (Monotron-style) ─────────────────── */
 
 static void mode_mono(const gamepad_state_t *gp)
 {
     int16_t ly = gp->axis_y;
     int16_t lx = gp->axis_x;
-    int16_t rx = gp->axis_rx;
-    int16_t ry = gp->axis_ry;
 
-    /* Dead zone check — silence if stick is centered */
+    /* Right stick integrates filter cutoff (RY) and resonance (RX) —
+     * set-and-release semantics, value persists across ticks. */
+    integrate_right_stick_filter(gp->axis_ry, gp->axis_rx);
+    synth_set_lfo((lfo_target_t)s_settings.lfo_target, s_settings.lfo_rate_hz,
+                  s_settings.lfo_depth);
+
+    /* Playing sticks (LY pitch, LX vibrato) stay absolute for expressive
+     * real-time control — the user wants muscle memory here, not rate. */
     if (abs(ly) < STICK_DEADZONE && abs(lx) < STICK_DEADZONE) {
         tone_stop();
         led_off();
         return;
     }
 
-    /* Base pitch from left stick Y */
     float pitch = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-
-    /* Manual vibrato from left stick X (depth) — fixed 5 Hz speed */
     float vib_depth = map_range((float)abs(lx), 0, STICK_MAX, 0, 100);
     static uint32_t tick = 0;
     tick++;
     float vib = vib_depth * sinf(2.0f * 3.14159f * 5.0f * (float)tick / CONTROL_TASK_HZ);
     pitch += vib;
 
-    /* Filter: right stick Y = cutoff (logarithmic), right stick X = resonance */
-    float cutoff_norm = map_range((float)ry, -STICK_MAX, STICK_MAX, 0.0f, 1.0f);
-    float cutoff = FILTER_CUTOFF_MIN * powf(FILTER_CUTOFF_MAX / FILTER_CUTOFF_MIN, cutoff_norm);
-    float resonance = map_range((float)abs(rx), 0, STICK_MAX, FILTER_Q_MIN, FILTER_Q_MAX);
-    synth_set_filter(true, cutoff, resonance);
-    synth_set_lfo((lfo_target_t)s_settings.lfo_target, s_settings.lfo_rate_hz,
-                  s_settings.lfo_depth);
-
-    /* Triggers = pitch bend (±7 semitones) */
-    float bend_mult = compute_bend_mult(gp);
-    pitch *= bend_mult;
-
+    pitch *= compute_bend_mult(gp);
     tone_play((uint32_t)pitch);
     led_on();
 }
@@ -587,33 +716,37 @@ static void mode_mono(const gamepad_state_t *gp)
 
 static void mode_dual_osc(const gamepad_state_t *gp)
 {
-    /* A=unison, B=fifth, X=octave, Y=two octaves */
+    /* A=unison, B=fifth, X=octave, Y=two octaves (rising-edge tap) */
     static int s_interval_semitones = 0;
     static uint16_t prev_buttons = 0;
     uint16_t pressed = gp->buttons & ~prev_buttons;
     prev_buttons = gp->buttons;
 
     if (pressed & BTN_A) {
-        s_interval_semitones = 0; /* unison */
+        s_interval_semitones = 0;
         synth_blip(BLIP_FREQ_DOWN);
     }
     if (pressed & BTN_B) {
-        s_interval_semitones = 7; /* perfect fifth */
+        s_interval_semitones = 7;
         synth_blip(BLIP_FREQ_NEUTRAL);
     }
     if (pressed & BTN_X) {
-        s_interval_semitones = 12; /* octave */
+        s_interval_semitones = 12;
         synth_blip(BLIP_FREQ_UP);
     }
     if (pressed & BTN_Y) {
-        s_interval_semitones = 24; /* two octaves */
+        s_interval_semitones = 24;
         synth_blip(BLIP_FREQ_UP * 1.5f);
     }
 
-    int16_t ly = gp->axis_y;
-    int16_t rx = gp->axis_rx;
-    int16_t ry = gp->axis_ry;
+    /* Right stick integrates filter. Detune moves onto an integrating
+     * axis too (driven by shoulder-held modifier in a later phase); for
+     * now it persists at 0 cents and can be nudged via RS-click + RX
+     * (see control_task). */
+    integrate_right_stick_filter(gp->axis_ry, gp->axis_rx);
 
+    /* Playing stick (LY pitch) stays absolute. */
+    int16_t ly = gp->axis_y;
     if (abs(ly) < STICK_DEADZONE) {
         tone_stop();
         synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
@@ -622,17 +755,9 @@ static void mode_dual_osc(const gamepad_state_t *gp)
     }
 
     float pitch_a = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-    /* Detune from RX: ±50 cents */
-    float detune_cents = map_range((float)rx, -STICK_MAX, STICK_MAX, -50.0f, 50.0f);
-    float detune_mult = powf(2.0f, detune_cents / 1200.0f);
+    float detune_mult = powf(2.0f, s_tweak_detune_cents / 1200.0f);
     float pitch_b = pitch_a * powf(2.0f, (float)s_interval_semitones / 12.0f) * detune_mult;
 
-    /* Filter cutoff from RY (logarithmic) */
-    float cutoff_norm = map_range((float)ry, -STICK_MAX, STICK_MAX, 0.0f, 1.0f);
-    float cutoff = FILTER_CUTOFF_MIN * powf(FILTER_CUTOFF_MAX / FILTER_CUTOFF_MIN, cutoff_norm);
-    synth_set_filter(true, cutoff, 1.0f);
-
-    /* Triggers = pitch bend on both oscillators */
     float bend_mult = compute_bend_mult(gp);
     pitch_a *= bend_mult;
     pitch_b *= bend_mult;
@@ -646,13 +771,30 @@ static void mode_dual_osc(const gamepad_state_t *gp)
 
 static void mode_delay_synth(const gamepad_state_t *gp)
 {
-    /* Fixed filter — triggers are repurposed as pitch bend. */
+    /* In Delay Synth the right stick is repurposed for the delay line
+     * (the whole point of the mode), so filter stays fixed. RY integrates
+     * delay time (log, 20..500 ms). RX integrates feedback (linear). */
     synth_set_filter(true, 4000.0f, 1.2f);
 
-    int16_t ly = gp->axis_y;
-    int16_t rx = gp->axis_rx;
-    int16_t ry = gp->axis_ry;
+    bool bumped = false;
+    bumped |= integrate_exp(&s_tweak_delay_ms, stick_rate(gp->axis_ry), 2.0f, 20.0f, 500.0f,
+                            INTEGRATION_DT);
+    bumped |=
+        integrate_lin(&s_tweak_feedback, stick_rate(gp->axis_rx), 0.5f, 0.0f, 0.9f, INTEGRATION_DT);
+    int delay_samples = (int)(SAMPLE_RATE * s_tweak_delay_ms / 1000.0f);
+    synth_set_delay(true, delay_samples, s_tweak_feedback, 0.5f);
 
+    static uint32_t last_bump_ms = 0;
+    if (bumped) {
+        uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
+        if (now - last_bump_ms > 400) {
+            synth_blip(BLIP_FREQ_NEUTRAL * 0.5f);
+            last_bump_ms = now;
+        }
+    }
+
+    /* Playing stick (LY pitch) absolute. */
+    int16_t ly = gp->axis_y;
     if (abs(ly) < STICK_DEADZONE) {
         tone_stop();
         led_off();
@@ -660,18 +802,7 @@ static void mode_delay_synth(const gamepad_state_t *gp)
     }
 
     float pitch = map_range((float)ly, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-
-    /* Delay time: RY from -STICK_MAX..STICK_MAX → 20..500 ms */
-    float delay_ms = map_range((float)ry, -STICK_MAX, STICK_MAX, 20.0f, 500.0f);
-    int delay_samples = (int)(SAMPLE_RATE * delay_ms / 1000.0f);
-    /* Feedback: RX from -STICK_MAX..STICK_MAX → 0.0..0.9 */
-    float feedback = map_range((float)rx, -STICK_MAX, STICK_MAX, 0.0f, 0.9f);
-    synth_set_delay(true, delay_samples, feedback, 0.5f);
-
-    /* Triggers = pitch bend (±7 semitones) */
-    float bend_mult = compute_bend_mult(gp);
-    pitch *= bend_mult;
-
+    pitch *= compute_bend_mult(gp);
     tone_play((uint32_t)pitch);
     led_on();
 }
@@ -680,25 +811,29 @@ static void mode_delay_synth(const gamepad_state_t *gp)
 
 static void mode_drone(const gamepad_state_t *gp)
 {
-    /* Both oscillators always active; sticks control their pitches */
-    float pitch_a = map_range((float)gp->axis_y, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-    float pitch_b = map_range((float)gp->axis_ry, -STICK_MAX, STICK_MAX, MIN_FREQ, MAX_FREQ);
-
-    /* LFO from settings — triggers repurposed as pitch bend. */
+    /* Drone integrates *both* pitch sticks — slow glides are the point,
+     * so rate-control fits better than absolute. LX integrates filter
+     * cutoff, RX integrates resonance (different axes from Mono because
+     * the right stick is the second melodic voice here). */
+    integrate_exp(&s_drone_freq_a, stick_rate(gp->axis_y), 2.0f, (float)MIN_FREQ, (float)MAX_FREQ,
+                  INTEGRATION_DT);
+    integrate_exp(&s_drone_freq_b, stick_rate(gp->axis_ry), 2.0f, (float)MIN_FREQ, (float)MAX_FREQ,
+                  INTEGRATION_DT);
+    integrate_exp(&s_tweak_cutoff_hz, stick_rate(gp->axis_x), 4.0f, FILTER_CUTOFF_MIN,
+                  FILTER_CUTOFF_MAX, INTEGRATION_DT);
+    integrate_lin(&s_tweak_resonance, stick_rate(gp->axis_rx), 3.0f, FILTER_Q_MIN, FILTER_Q_MAX,
+                  INTEGRATION_DT);
+    synth_set_filter(true, s_tweak_cutoff_hz, s_tweak_resonance);
     synth_set_lfo((lfo_target_t)s_settings.lfo_target, s_settings.lfo_rate_hz,
                   s_settings.lfo_depth);
 
-    /* Filter: slightly warm default, modulated by LFO */
-    synth_set_filter(true, 3000.0f, 1.5f);
-
-    /* Triggers = pitch bend on both oscillators */
     float bend_mult = compute_bend_mult(gp);
-    pitch_a *= bend_mult;
-    pitch_b *= bend_mult;
+    float pitch_a = s_drone_freq_a * bend_mult;
+    float pitch_b = s_drone_freq_b * bend_mult;
 
     tone_play((uint32_t)pitch_a);
-    /* Route osc B onto the two piezos with a fixed detune so the beating
-     * happens acoustically in air rather than inside the DAC mix. */
+    /* Osc B is rendered on the piezos with a fixed detune ratio so the
+     * beating happens acoustically in air rather than inside the DAC. */
     piezo_voice_note_on(PIEZO_A, pitch_b);
     piezo_voice_note_on(PIEZO_B, pitch_b * PIEZO_DETUNE_RATIO);
     led_on();
@@ -708,38 +843,24 @@ static void mode_drone(const gamepad_state_t *gp)
 
 static void mode_scale(const gamepad_state_t *gp)
 {
-    /* LB/RB shift octave (rising edge) */
-    static uint16_t prev_buttons = 0;
-    uint16_t pressed = gp->buttons & ~prev_buttons;
-    prev_buttons = gp->buttons;
+    /* Face buttons = scale degrees (held = sustain note):
+     *   LB-not-held + A/B/X/Y → Do  Re  Mi  Fa  (lower tetrachord)
+     *   LB-held     + A/B/X/Y → Sol La  Ti  Do  (upper tetrachord)
+     * LY integrates pitch offset (±12 semitones) to replace the previous
+     * LB/RB octave shift with smooth, rate-controlled motion. */
+    integrate_lin(&s_tweak_pitch_offset_st, stick_rate(gp->axis_y), 6.0f, -12.0f, 12.0f,
+                  INTEGRATION_DT);
 
-    if (pressed & BTN_SHOULDER_L && s_octave > 0) {
-        s_octave--;
-        synth_blip(BLIP_FREQ_DOWN);
-    }
-    if (pressed & BTN_SHOULDER_R && s_octave < 2) {
-        s_octave++;
-        synth_blip(BLIP_FREQ_UP);
-    }
-
-    /* Map buttons to scale degrees */
+    bool lb_held = (gp->buttons & BTN_SHOULDER_L) != 0;
     int note_idx = -1;
     if (gp->buttons & BTN_A)
-        note_idx = 0; /* A = Do */
+        note_idx = lb_held ? 4 : 0;
     if (gp->buttons & BTN_B)
-        note_idx = 1; /* B = Re */
+        note_idx = lb_held ? 5 : 1;
     if (gp->buttons & BTN_X)
-        note_idx = 2; /* X = Mi */
+        note_idx = lb_held ? 6 : 2;
     if (gp->buttons & BTN_Y)
-        note_idx = 3; /* Y = Fa */
-    if (gp->dpad & DPAD_UP)
-        note_idx = 4; /* Sol */
-    if (gp->dpad & DPAD_RIGHT)
-        note_idx = 5; /* La */
-    if (gp->dpad & DPAD_DOWN)
-        note_idx = 6; /* Ti */
-    if (gp->dpad & DPAD_LEFT)
-        note_idx = 7; /* Do (high) */
+        note_idx = lb_held ? 7 : 3;
 
     if (note_idx < 0) {
         tone_stop();
@@ -747,16 +868,12 @@ static void mode_scale(const gamepad_state_t *gp)
         return;
     }
 
-    int semitone = (s_octave * 12) + SCALE_MAJOR[note_idx];
+    int semitone = (12 /* base C5 */) + SCALE_MAJOR[note_idx] + (int)s_tweak_pitch_offset_st;
     float freq = (float)note_at(semitone);
 
-    /* Pitch bend from right stick Y — fine bend in Hz. */
-    float bend = map_range((float)gp->axis_ry, -STICK_MAX, STICK_MAX, -50, 50);
-    freq += bend;
-
-    /* Triggers = coarse pitch bend (±7 semitones) */
-    float bend_mult = compute_bend_mult(gp);
-    freq *= bend_mult;
+    /* RY = fine bend (absolute, expressive). Triggers = coarse bend. */
+    freq += map_range((float)gp->axis_ry, -STICK_MAX, STICK_MAX, -50, 50);
+    freq *= compute_bend_mult(gp);
 
     tone_play((uint32_t)freq);
     led_on();
@@ -772,23 +889,23 @@ static void mode_arpeggio(const gamepad_state_t *gp)
     prev_buttons = gp->buttons;
 
     if (pressed & BTN_A) {
-        s_arp_chord = CHORD_MAJOR; /* A = major */
+        s_arp_chord = CHORD_MAJOR;
         synth_blip(BLIP_FREQ_UP);
     }
     if (pressed & BTN_B) {
-        s_arp_chord = CHORD_MINOR; /* B = minor */
+        s_arp_chord = CHORD_MINOR;
         synth_blip(BLIP_FREQ_DOWN);
     }
     if (pressed & BTN_X) {
-        s_arp_chord = CHORD_7TH; /* X = 7th */
+        s_arp_chord = CHORD_7TH;
         synth_blip(BLIP_FREQ_NEUTRAL);
     }
     if (pressed & BTN_Y) {
-        s_arp_chord = CHORD_DIM; /* Y = dim */
+        s_arp_chord = CHORD_DIM;
         synth_blip(BLIP_FREQ_DOWN * 0.75f);
     }
 
-    /* LB/RB shift octave */
+    /* LB/RB still shift octave */
     if (pressed & BTN_SHOULDER_L && s_octave > 0) {
         s_octave--;
         synth_blip(BLIP_FREQ_DOWN);
@@ -798,29 +915,11 @@ static void mode_arpeggio(const gamepad_state_t *gp)
         synth_blip(BLIP_FREQ_UP);
     }
 
-    /* D-pad transpose root note */
-    if (gp->dpad & DPAD_UP) {
-        static uint32_t last_up = 0;
-        uint32_t now = xTaskGetTickCount();
-        if (now - last_up > pdMS_TO_TICKS(200)) {
-            s_arp_root++;
-            if (s_arp_root > 11)
-                s_arp_root = 11;
-            synth_blip(BLIP_FREQ_UP);
-            last_up = now;
-        }
-    }
-    if (gp->dpad & DPAD_DOWN) {
-        static uint32_t last_down = 0;
-        uint32_t now = xTaskGetTickCount();
-        if (now - last_down > pdMS_TO_TICKS(200)) {
-            s_arp_root--;
-            if (s_arp_root < 0)
-                s_arp_root = 0;
-            synth_blip(BLIP_FREQ_DOWN);
-            last_down = now;
-        }
-    }
+    /* LY integrates the root note (±12 semitones from C). Replaces the
+     * d-pad root transpose — smooth, rate-controlled, releases at value. */
+    integrate_lin(&s_tweak_pitch_offset_st, stick_rate(gp->axis_y), 6.0f, -12.0f, 12.0f,
+                  INTEGRATION_DT);
+    s_arp_root = (int)s_tweak_pitch_offset_st;
 
     /* RT trigger toggles arpeggio on/off (rising edge) */
     static bool prev_r2 = false;
@@ -840,12 +939,12 @@ static void mode_arpeggio(const gamepad_state_t *gp)
         return;
     }
 
-    /* Speed from left stick Y: 50ms (fast) to 500ms (slow) */
-    float speed_ms = map_range((float)gp->axis_y, -STICK_MAX, STICK_MAX, 50, 500);
+    /* Step rate is derived from the global tempo (16th notes). Set via
+     * d-pad ←/→ — one groove for the whole device. */
+    float speed_ms = 60000.0f / (float)s_settings.drum_tempo_bpm / 4.0f;
 
-    /* Pattern from left stick X quadrant */
-    /* Left = down, right = up, center = up-down */
-    int pattern = 0; /* 0=up, 1=down, 2=up-down */
+    /* Pattern from left stick X quadrant: left = down, right = up, center = up-down */
+    int pattern = 0;
     if (gp->axis_x < -STICK_DEADZONE)
         pattern = 1;
     else if (gp->axis_x > STICK_DEADZONE)
@@ -906,54 +1005,155 @@ static void sfx_tick(void)
 
 static void mode_sfx(const gamepad_state_t *gp)
 {
-    /* Speed multiplier from RT trigger: 0.5x to 2x */
+    /* RT = speed multiplier on the sweep tick count. */
     float speed = map_range((float)gp->throttle, 0, TRIGGER_MAX, 1.0f, 0.3f);
     int base_ticks = 25;
     int ticks = (int)((float)base_ticks * speed);
     if (ticks < 5)
         ticks = 5;
 
-    /* Trigger SFX on button press (rising edge) */
+    /* Trigger SFX on rising edge. D-pad is now global (vol/tempo), so the
+     * four ex-d-pad SFX ride LB-held + face buttons. */
     static uint16_t prev_btn = 0;
-    static uint8_t prev_dpad = 0;
     uint16_t btn_pressed = gp->buttons & ~prev_btn;
-    uint8_t dpad_pressed = gp->dpad & ~prev_dpad;
     prev_btn = gp->buttons;
-    prev_dpad = gp->dpad;
 
-    /* A = Laser (descending sweep) */
-    if (btn_pressed & BTN_A)
-        sfx_start(1800, 200, ticks);
+    bool lb_held = (gp->buttons & BTN_SHOULDER_L) != 0;
+    uint16_t face_pressed = btn_pressed & BTN_FACE_MASK;
 
-    /* B = Explosion (descending with low end) */
-    if (btn_pressed & BTN_B)
-        sfx_start(800, 100, ticks * 2);
-
-    /* X = Power-up (ascending sweep) */
-    if (btn_pressed & BTN_X)
-        sfx_start(200, 1600, ticks);
-
-    /* Y = Coin (high double-beep handled via short sweep) */
-    if (btn_pressed & BTN_Y)
-        sfx_start(1200, 1800, ticks / 2);
-
-    /* D-pad Up = Siren (oscillating — start high, go low, we'll reverse) */
-    if (dpad_pressed & DPAD_UP)
-        sfx_start(400, 1200, ticks * 3);
-
-    /* D-pad Down = Engine (low rumble) */
-    if (dpad_pressed & DPAD_DOWN)
-        sfx_start(100, 250, ticks * 3);
-
-    /* D-pad Left = Jump (quick ascending chirp) */
-    if (dpad_pressed & DPAD_LEFT)
-        sfx_start(300, 1400, ticks / 2);
-
-    /* D-pad Right = Warp (sweep up then down via two-phase) */
-    if (dpad_pressed & DPAD_RIGHT)
-        sfx_start(400, 1800, ticks);
+    if (!lb_held) {
+        if (face_pressed & BTN_A)
+            sfx_start(1800, 200, ticks); /* Laser */
+        if (face_pressed & BTN_B)
+            sfx_start(800, 100, ticks * 2); /* Explosion */
+        if (face_pressed & BTN_X)
+            sfx_start(200, 1600, ticks); /* Power-up */
+        if (face_pressed & BTN_Y)
+            sfx_start(1200, 1800, ticks / 2); /* Coin */
+    } else {
+        if (face_pressed & BTN_A)
+            sfx_start(400, 1200, ticks * 3); /* Siren */
+        if (face_pressed & BTN_B)
+            sfx_start(100, 250, ticks * 3); /* Engine */
+        if (face_pressed & BTN_X)
+            sfx_start(300, 1400, ticks / 2); /* Jump */
+        if (face_pressed & BTN_Y)
+            sfx_start(400, 1800, ticks); /* Warp */
+    }
 
     sfx_tick();
+}
+
+/* ── Mode Signature Gestures ─────────────────────────────
+ *
+ * On mode switch, play a short phrase *in that mode's own voice* so the
+ * user hears which mode they're in without having to count LED blinks.
+ * Blocks the control task for ~300-500 ms while it plays — audio render
+ * keeps running, so the user hears the gesture immediately. Restores
+ * silence at the end so the mode starts from a clean state.
+ */
+static void play_mode_signature(sound_mode_t mode)
+{
+    switch (mode) {
+        case MODE_MONO: {
+            /* Pitch-bend chirp (sawtooth, 400→1200 Hz) */
+            synth_set_waveform(WAVE_SAWTOOTH);
+            synth_set_filter(true, 6000.0f, 1.5f);
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            synth_set_delay(false, 1, 0.0f, 0.0f);
+            for (int i = 0; i < 5; i++) {
+                tone_play(400 + i * 200);
+                vTaskDelay(pdMS_TO_TICKS(60));
+            }
+            break;
+        }
+        case MODE_DUAL_OSC: {
+            /* Perfect fifth dyad */
+            synth_set_waveform(WAVE_SAWTOOTH);
+            synth_set_filter(true, 4000.0f, 1.2f);
+            synth_set_osc_b(true, 440.0f * 1.5f, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            synth_set_delay(false, 1, 0.0f, 0.0f);
+            tone_play(440);
+            vTaskDelay(pdMS_TO_TICKS(350));
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            break;
+        }
+        case MODE_DELAY_SYNTH: {
+            /* One note ringing through the delay */
+            synth_set_waveform(WAVE_SAWTOOTH);
+            synth_set_filter(true, 4000.0f, 1.2f);
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            synth_set_delay(true, SAMPLE_RATE * 140 / 1000, 0.55f, 0.5f);
+            tone_play(523);
+            vTaskDelay(pdMS_TO_TICKS(80));
+            tone_stop();
+            vTaskDelay(pdMS_TO_TICKS(400));
+            synth_set_delay(false, 1, 0.0f, 0.0f);
+            break;
+        }
+        case MODE_SCALE: {
+            /* Do-Mi-Sol ascending on sine */
+            synth_set_waveform(WAVE_SINE);
+            synth_set_filter(true, 5000.0f, 0.8f);
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            synth_set_delay(true, SAMPLE_RATE * 120 / 1000, 0.25f, 0.3f);
+            tone_play(523);
+            vTaskDelay(pdMS_TO_TICKS(110));
+            tone_play(659);
+            vTaskDelay(pdMS_TO_TICKS(110));
+            tone_play(784);
+            vTaskDelay(pdMS_TO_TICKS(160));
+            break;
+        }
+        case MODE_ARPEGGIO: {
+            /* Fast C-major arp */
+            synth_set_waveform(WAVE_SQUARE);
+            synth_set_filter(true, 4000.0f, 1.2f);
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            synth_set_delay(true, SAMPLE_RATE * 100 / 1000, 0.4f, 0.3f);
+            const uint16_t notes[] = {262, 330, 392, 523};
+            for (int i = 0; i < 4; i++) {
+                tone_play(notes[i]);
+                vTaskDelay(pdMS_TO_TICKS(75));
+            }
+            break;
+        }
+        case MODE_SFX: {
+            /* Laser zap (descending square-wave sweep) */
+            synth_set_waveform(WAVE_SQUARE);
+            synth_set_filter(false, FILTER_CUTOFF_MAX, FILTER_Q_MIN);
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            synth_set_delay(false, 1, 0.0f, 0.0f);
+            for (int i = 0; i < 10; i++) {
+                tone_play(1800 - i * 160);
+                vTaskDelay(pdMS_TO_TICKS(22));
+            }
+            break;
+        }
+        case MODE_DRONE: {
+            /* Held open fifth with an LFO cutoff sweep */
+            synth_set_waveform(WAVE_SAWTOOTH);
+            synth_set_filter(true, 2500.0f, 1.5f);
+            synth_set_osc_b(true, 330.0f, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_CUTOFF, 4.0f, 0.4f);
+            synth_set_delay(false, 1, 0.0f, 0.0f);
+            tone_play(220);
+            vTaskDelay(pdMS_TO_TICKS(500));
+            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+            synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+            break;
+        }
+        default:
+            break;
+    }
+    tone_stop();
+    vTaskDelay(pdMS_TO_TICKS(60)); /* short silence tail before user takes over */
 }
 
 /* ── Bluepad32 Custom Platform ───────────────────────────── */
@@ -1314,21 +1514,11 @@ static void settings_play_ladder(int count, float freq_hz)
 static void settings_play_value_ladder(int cursor)
 {
     switch (cursor) {
-        case SETTING_MASTER_VOL: {
-            int n = (int)(s_settings.master_volume * 10.0f + 0.5f) + 1;
-            settings_play_ladder(n, BLIP_FREQ_NEUTRAL);
-            break;
-        }
         case SETTING_DRUM_PATTERN: {
             int n = s_settings.drum_pattern + 1;
             settings_play_ladder(n, BLIP_FREQ_NEUTRAL);
             break;
         }
-        case SETTING_DRUM_TEMPO:
-            /* 3 neutral blips — hearing the exact BPM isn't useful yet
-             * because no drum engine consumes the value (sibling agent). */
-            settings_play_ladder(3, BLIP_FREQ_NEUTRAL);
-            break;
         case SETTING_DRUM_VOLUME: {
             int n = (int)(s_settings.drum_volume * 10.0f + 0.5f) + 1;
             settings_play_ladder(n, BLIP_FREQ_NEUTRAL);
@@ -1374,15 +1564,8 @@ static inline int clampi(int v, int lo, int hi)
 static void settings_adjust(int cursor, int direction)
 {
     switch (cursor) {
-        case SETTING_MASTER_VOL:
-            s_settings.master_volume =
-                clampf(s_settings.master_volume + 0.1f * direction, 0.0f, 1.0f);
-            break;
         case SETTING_DRUM_PATTERN:
             s_settings.drum_pattern = clampi(s_settings.drum_pattern + direction, 0, 4);
-            break;
-        case SETTING_DRUM_TEMPO:
-            s_settings.drum_tempo_bpm = clampi(s_settings.drum_tempo_bpm + 5 * direction, 60, 200);
             break;
         case SETTING_DRUM_VOLUME:
             s_settings.drum_volume = clampf(s_settings.drum_volume + 0.1f * direction, 0.0f, 1.0f);
@@ -1441,12 +1624,124 @@ static void settings_edit_handle(const gamepad_state_t *gp)
 
 /* ── Control Task (Core 1, reads gamepad, updates synth) ── */
 
+/* Apply per-mode synth defaults on entry. Waveform, osc B, filter, LFO,
+ * and delay are all reset so the user starts from a known state. */
+static void apply_mode_defaults(sound_mode_t mode)
+{
+    static const waveform_t mode_waves[] = {
+        [MODE_MONO] = WAVE_SAWTOOTH,        [MODE_DUAL_OSC] = WAVE_SAWTOOTH,
+        [MODE_DELAY_SYNTH] = WAVE_SAWTOOTH, [MODE_SCALE] = WAVE_SINE,
+        [MODE_ARPEGGIO] = WAVE_SQUARE,      [MODE_SFX] = WAVE_SQUARE,
+        [MODE_DRONE] = WAVE_SAWTOOTH,
+    };
+    synth_set_waveform(mode_waves[mode]);
+    synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
+
+    switch (mode) {
+        case MODE_MONO:
+        case MODE_DUAL_OSC:
+        case MODE_DELAY_SYNTH:
+        case MODE_DRONE:
+            synth_set_filter(true, TWEAK_CUTOFF_DEFAULT, TWEAK_RESONANCE_DEFAULT);
+            break;
+        case MODE_SCALE:
+            synth_set_filter(true, 5000.0f, 0.8f);
+            break;
+        case MODE_ARPEGGIO:
+            synth_set_filter(true, 4000.0f, 1.2f);
+            break;
+        case MODE_SFX:
+        default:
+            synth_set_filter(false, FILTER_CUTOFF_MAX, FILTER_Q_MIN);
+            break;
+    }
+
+    /* LFO is driven per-tick by Mono and Drone (from settings). Other
+     * modes silence it on entry. */
+    if (mode != MODE_MONO && mode != MODE_DRONE)
+        synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
+
+    switch (mode) {
+        case MODE_SCALE:
+            synth_set_delay(true, SAMPLE_RATE * 120 / 1000, 0.25f, 0.3f);
+            break;
+        case MODE_ARPEGGIO:
+            synth_set_delay(true, SAMPLE_RATE * 250 / 1000, 0.55f, 0.4f);
+            break;
+        case MODE_DELAY_SYNTH:
+            synth_set_delay(true, SAMPLE_RATE * 200 / 1000, 0.5f, 0.5f);
+            break;
+        default:
+            synth_set_delay(false, 1, 0.0f, 0.0f);
+            break;
+    }
+}
+
+/* Handle a mode-switch: silence voices, reset transient state, play the
+ * signature gesture, and restore the mode's defaults. */
+static void enter_mode(sound_mode_t new_mode)
+{
+    tone_stop();
+    piezo_voice_note_off(PIEZO_A);
+    piezo_voice_note_off(PIEZO_B);
+    s_mode = new_mode;
+    s_arp_running = false;
+    s_sfx.ticks_left = 0;
+    reset_tweaks();
+
+    /* Short LED flash = "mode changed". The signature gesture below
+     * tells the user *which* mode. */
+    led_on();
+    vTaskDelay(pdMS_TO_TICKS(40));
+    led_off();
+
+    apply_mode_defaults(new_mode);
+    play_mode_signature(new_mode);
+    apply_mode_defaults(new_mode); /* restore in case the signature left state around */
+
+    ESP_LOGI(TAG, "Mode: %d", s_mode);
+}
+
+/* Global d-pad: ↑/↓ nudges master_volume by ±0.05, ←/→ nudges tempo by
+ * ±5 BPM. Auto-repeats at GLOBAL_DPAD_REPEAT_MS while held. */
+static void handle_global_dpad(uint8_t dpad)
+{
+    static uint32_t last_repeat_ms = 0;
+    uint32_t now = xTaskGetTickCount() * portTICK_PERIOD_MS;
+    if (now - last_repeat_ms < GLOBAL_DPAD_REPEAT_MS)
+        return;
+
+    bool acted = false;
+    if (dpad & DPAD_UP) {
+        s_settings.master_volume = clampf(s_settings.master_volume + 0.05f, 0.0f, 1.0f);
+        synth_blip(BLIP_FREQ_UP);
+        acted = true;
+    } else if (dpad & DPAD_DOWN) {
+        s_settings.master_volume = clampf(s_settings.master_volume - 0.05f, 0.0f, 1.0f);
+        synth_blip(BLIP_FREQ_DOWN);
+        acted = true;
+    } else if (dpad & DPAD_RIGHT) {
+        s_settings.drum_tempo_bpm = clampi(s_settings.drum_tempo_bpm + 5, 60, 200);
+        synth_blip(BLIP_FREQ_UP);
+        acted = true;
+    } else if (dpad & DPAD_LEFT) {
+        s_settings.drum_tempo_bpm = clampi(s_settings.drum_tempo_bpm - 5, 60, 200);
+        synth_blip(BLIP_FREQ_DOWN);
+        acted = true;
+    }
+    if (acted)
+        last_repeat_ms = now;
+}
+
 static void control_task(void *arg)
 {
     (void)arg;
     ESP_LOGI(TAG, "Control task started on core %d", xPortGetCoreID());
 
     TickType_t last_wake = xTaskGetTickCount();
+    static uint16_t s_prev_buttons_global = 0;
+    static uint16_t s_home_prev_face = 0;
+    static bool s_home_used_as_modifier = false;
 
     while (1) {
         gamepad_state_t gp;
@@ -1461,104 +1756,78 @@ static void control_task(void *arg)
             continue;
         }
 
-        /* Mode switch on Share button (rising edge) */
         uint8_t misc_pressed = gp.misc_buttons & ~s_prev_misc;
+        uint8_t misc_released = s_prev_misc & ~gp.misc_buttons;
         s_prev_misc = gp.misc_buttons;
 
+        uint16_t btn_pressed_global = gp.buttons & ~s_prev_buttons_global;
+        s_prev_buttons_global = gp.buttons;
+
+        /* Mode switch on Share button (rising edge) */
         if (misc_pressed & MISC_BACK) {
-            tone_stop();
-            piezo_voice_note_off(PIEZO_A);
-            piezo_voice_note_off(PIEZO_B);
-            s_mode = (s_mode + 1) % MODE_COUNT;
-            s_arp_running = false;
-            s_sfx.ticks_left = 0;
-
-            /* Set default waveform per mode */
-            static const waveform_t mode_waves[] = {
-                [MODE_MONO] = WAVE_SAWTOOTH,        [MODE_DUAL_OSC] = WAVE_SAWTOOTH,
-                [MODE_DELAY_SYNTH] = WAVE_SAWTOOTH, [MODE_SCALE] = WAVE_SINE,
-                [MODE_ARPEGGIO] = WAVE_SQUARE,      [MODE_SFX] = WAVE_SQUARE,
-                [MODE_DRONE] = WAVE_SAWTOOTH,
-            };
-            synth_set_waveform(mode_waves[s_mode]);
-
-            /* Turn off osc B unless the mode uses it */
-            synth_set_osc_b(false, (float)MIN_FREQ, WAVE_SAWTOOTH);
-
-            /* Set per-mode filter defaults */
-            switch (s_mode) {
-                case MODE_MONO:
-                case MODE_DUAL_OSC:
-                case MODE_DELAY_SYNTH:
-                case MODE_DRONE:
-                    /* Updated dynamically from sticks each tick */
-                    synth_set_filter(true, 6000.0f, 1.5f);
-                    break;
-                case MODE_SCALE:
-                    synth_set_filter(true, 5000.0f, 0.8f);
-                    break;
-                case MODE_ARPEGGIO:
-                    synth_set_filter(true, 4000.0f, 1.2f);
-                    break;
-                case MODE_SFX:
-                default:
-                    synth_set_filter(false, FILTER_CUTOFF_MAX, FILTER_Q_MIN);
-                    break;
-            }
-
-            /* LFO: Mono (triggers) and Drone (triggers) drive it per-tick.
-             * Others get it disabled. */
-            if (s_mode != MODE_MONO && s_mode != MODE_DRONE) {
-                synth_set_lfo(LFO_TARGET_NONE, 5.0f, 0.0f);
-            }
-
-            /* Per-mode delay preset */
-            switch (s_mode) {
-                case MODE_SCALE:
-                    synth_set_delay(true, SAMPLE_RATE * 120 / 1000, 0.25f, 0.3f);
-                    break;
-                case MODE_ARPEGGIO:
-                    synth_set_delay(true, SAMPLE_RATE * 250 / 1000, 0.55f, 0.4f);
-                    break;
-                case MODE_DELAY_SYNTH:
-                    /* Starting preset — mode_delay_synth updates each tick */
-                    synth_set_delay(true, SAMPLE_RATE * 200 / 1000, 0.5f, 0.5f);
-                    break;
-                case MODE_MONO:
-                case MODE_DUAL_OSC:
-                case MODE_SFX:
-                case MODE_DRONE:
-                default:
-                    synth_set_delay(false, 1, 0.0f, 0.0f);
-                    break;
-            }
-
-            ESP_LOGI(TAG, "Mode: %d waveform: %d", s_mode, mode_waves[s_mode]);
-            synth_blip(BLIP_FREQ_NEUTRAL);
-            led_blink(s_mode + 1, 80, 80);
+            sound_mode_t next = (sound_mode_t)((s_mode + 1) % MODE_COUNT);
+            enter_mode(next);
         }
 
-        /* Home button toggles the background drum engine (rising edge).
-         * Reads s_settings.drum_pattern as the "remembered" pattern so
-         * settings-page changes take effect on the next toggle. */
-        if (misc_pressed & MISC_HOME) {
-            s_drum_on = !s_drum_on;
-            if (s_drum_on) {
-                int pat = s_settings.drum_pattern;
-                if (pat < 1 || pat > 4)
-                    pat = 1;
+        /* Home held → modifier for drum-pattern select. Face-button tap
+         * while Home held assigns pattern 1..4 and marks Home as "used as
+         * modifier" so the tap-release doesn't toggle drums off. */
+        bool home_held = (gp.misc_buttons & MISC_HOME) != 0;
+        if (home_held) {
+            uint16_t face_pressed = gp.buttons & ~s_home_prev_face;
+            s_home_prev_face = gp.buttons;
+            int pat = 0;
+            if (face_pressed & BTN_A)
+                pat = 1;
+            else if (face_pressed & BTN_B)
+                pat = 2;
+            else if (face_pressed & BTN_X)
+                pat = 3;
+            else if (face_pressed & BTN_Y)
+                pat = 4;
+            if (pat > 0) {
+                s_settings.drum_pattern = pat;
+                s_drum_on = true;
                 drums_set_pattern(pat);
                 synth_blip(BLIP_FREQ_UP);
-            } else {
-                drums_set_pattern(0);
-                synth_blip(BLIP_FREQ_DOWN);
+                s_home_used_as_modifier = true;
+                ESP_LOGI(TAG, "Drum pattern: %d (via Home+face)", pat);
             }
-            ESP_LOGI(TAG, "Drums: %s", s_drum_on ? "on" : "off");
+        } else {
+            s_home_prev_face = gp.buttons;
         }
 
-        /* Push live settings-page values into the drum engine so tempo/volume
-         * changes take effect while drums are running. Cheap assignments —
-         * the drum engine re-arms the esp_timer only if BPM actually changed. */
+        /* Home released: only toggle drums if Home wasn't used as modifier
+         * during this press. */
+        if (misc_released & MISC_HOME) {
+            if (s_home_used_as_modifier) {
+                s_home_used_as_modifier = false;
+            } else {
+                s_drum_on = !s_drum_on;
+                if (s_drum_on) {
+                    int pat = s_settings.drum_pattern;
+                    if (pat < 1 || pat > 4)
+                        pat = 1;
+                    drums_set_pattern(pat);
+                    synth_blip(BLIP_FREQ_UP);
+                } else {
+                    drums_set_pattern(0);
+                    synth_blip(BLIP_FREQ_DOWN);
+                }
+                ESP_LOGI(TAG, "Drums: %s", s_drum_on ? "on" : "off");
+            }
+        }
+
+        /* LS-click (left thumb) resets per-mode tweak parameters to
+         * defaults. Confirmation blip descends like "reset". */
+        if (btn_pressed_global & BTN_THUMB_L) {
+            reset_tweaks();
+            synth_blip(BLIP_FREQ_DOWN);
+            ESP_LOGI(TAG, "Tweaks reset to defaults");
+        }
+
+        /* Push live settings-page values into the drum engine so
+         * d-pad-tempo and settings-volume changes take effect immediately. */
         drums_set_tempo(s_settings.drum_tempo_bpm);
         drums_set_volume(s_settings.drum_volume);
 
@@ -1571,9 +1840,6 @@ static void control_task(void *arg)
                 piezo_voice_note_off(PIEZO_B);
                 synth_blip(BLIP_FREQ_UP);
                 ESP_LOGI(TAG, "Settings edit: ENTER (cursor=%d)", s_settings_cursor);
-                /* Render the current field's value ladder so the user knows
-                 * what they're adjusting. Gap before the ladder so the entry
-                 * blip stays distinct. */
                 vTaskDelay(pdMS_TO_TICKS(SETTINGS_LADDER_GAP_MS));
                 settings_play_value_ladder(s_settings_cursor);
             } else {
@@ -1582,12 +1848,24 @@ static void control_task(void *arg)
             }
         }
 
-        /* While editing, suppress mode dispatch and run the edit handler */
+        /* Settings overlay: d-pad is navigation, mode dispatch suppressed. */
         if (s_settings_edit_active) {
             settings_edit_handle(&gp);
             vTaskDelayUntil(&last_wake, pdMS_TO_TICKS(CONTROL_TASK_PERIOD_MS));
             continue;
         }
+
+        /* Home held without a face-button hit also suppresses mode dispatch
+         * (otherwise holding Home to try patterns would accidentally play
+         * notes/scales). */
+        if (home_held) {
+            tone_stop();
+            vTaskDelayUntil(&last_wake, pdMS_TO_TICKS(CONTROL_TASK_PERIOD_MS));
+            continue;
+        }
+
+        /* Global d-pad: volume (↑/↓) and tempo (←/→). */
+        handle_global_dpad(gp.dpad);
 
         /* Dispatch to current mode */
         switch (s_mode) {


### PR DESCRIPTION
## Summary

Two stacked changes on the same branch:

**Phase 1** (commit 7e5c3f9): Unified control scheme — integrating sticks, global d-pad (volume/tempo), drum engine on Home tap / Home+face pattern select, settings-edit overlay, LS-click tweak reset, per-mode signature gestures, ±7 st pitch bend on LT/RT.

**Phase 2** (commit 7b351e0): Collapse 7 ad-hoc modes into 3 voicings.

- `VOICING_CONTINUOUS` — Mono + Dual Osc + Delay + Drone collapsed
- `VOICING_DISCRETE` — Scale + Arpeggio collapsed
- `VOICING_ONE_SHOT` — Retro SFX

Orthogonal toggles layer on top via RB-held + face button:

| Combo | Toggle | Scope |
|-------|--------|-------|
| RB+A | DUAL_OSC | Continuous |
| RB+B | DRONE_HOLD | Continuous (forces DUAL_OSC) |
| RB+X | DELAY | Continuous + Discrete |
| RB+Y | WAVEFORM | All (cycles sq→saw→tri→sine) |
| RB+LB | ARP | Discrete |

Per-voicing config persists across voicing switches. While RB is held, face buttons are fully suppressed from voicing dispatch so RB stays a clean modifier.

Also lands:
- `CONFIG_GAMEPAD_SYNTH_DEBUG_AXES` menuconfig symbol gating verbose axis/dispatch logging. Intended for diagnosing the right-stick cardinal-axis cutoff symptom on real hardware.
- Defensive NaN guard in `audio_render_task` after the per-block filter loop (TPT SVF is already unconditionally stable; belt-and-suspenders against future regressions).

Phase 3 (Gemini TTS announcement clips) is deferred to a follow-up PR per the plan.

## Test plan

- [x] `just build` — clean, no warnings. Binary 687 KB / 1 MB OTA partition (34% free).
- [x] `just format-check` — clang-format clean.
- [ ] Flash to ESP32-S3, pair controller.
- [ ] Share cycles 3 voicings with correct signature gestures.
- [ ] RB+A enables dual-osc in Continuous; face buttons pick interval.
- [ ] RB+B enables drone-hold in Continuous; LY/RY integrate, piezos sing.
- [ ] RB+X toggles delay in Continuous and Discrete.
- [ ] RB+Y cycles waveform (audible timbre change).
- [ ] RB+LB toggles arp in Discrete.
- [ ] Config persists across voicing switches.
- [ ] Phase-1 behaviors still work (integrating sticks, global d-pad, drum pattern on Home+face, LS reset, settings overlay).
- [ ] Enable `CONFIG_GAMEPAD_SYNTH_DEBUG_AXES`, reproduce right-stick cardinal-axis cutoff, read logs, apply targeted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)