### PR TITLE
docs: ADR-017 melody detector with ESP-DL + TinyML reference docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,7 +28,9 @@
       "autoUpdate": true
     }
   },
-  "enabledPlugins": {},
+  "enabledPlugins": {
+    "blueprint-plugin@claude-plugins": true
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,7 +29,27 @@
     }
   },
   "enabledPlugins": {
-    "blueprint-plugin@claude-plugins": true
+    "agent-patterns-plugin@claude-plugins": true,
+    "agents-plugin@claude-plugins": true,
+    "blueprint-plugin@claude-plugins": true,
+    "code-quality-plugin@claude-plugins": true,
+    "codebase-attributes-plugin@claude-plugins": true,
+    "configure-plugin@claude-plugins": true,
+    "container-plugin@claude-plugins": true,
+    "documentation-plugin@claude-plugins": true,
+    "feedback-plugin@claude-plugins": true,
+    "git-plugin@claude-plugins": true,
+    "github-actions-plugin@claude-plugins": true,
+    "health-plugin@claude-plugins": true,
+    "home-assistant-plugin@claude-plugins": true,
+    "hooks-plugin@claude-plugins": true,
+    "networking-plugin@claude-plugins": true,
+    "project-plugin@claude-plugins": true,
+    "prompt-engineering-plugin@claude-plugins": true,
+    "python-plugin@claude-plugins": true,
+    "testing-plugin@claude-plugins": true,
+    "tools-plugin@claude-plugins": true,
+    "workflow-orchestration-plugin@claude-plugins": true
   },
   "hooks": {
     "SessionStart": [

--- a/docs/blueprint/feature-tracker.json
+++ b/docs/blueprint/feature-tracker.json
@@ -130,12 +130,36 @@
       "status": "planned",
       "priority": "P3",
       "notes": "Listed as future enhancement"
+    },
+    {
+      "id": "FR-017",
+      "name": "Melody detector firmware (CV + ESP-DL + I2S)",
+      "prd": "PRD-011",
+      "status": "planned",
+      "priority": "P2",
+      "notes": "XIAO ESP32-S3 Sense + MAX98357A; ROI classifier with INT8 CNN"
+    },
+    {
+      "id": "FR-018",
+      "name": "Melody detector training pipeline",
+      "prd": "PRD-011",
+      "status": "planned",
+      "priority": "P2",
+      "notes": "PyTorch + ESP-PPQ; programmatic + diffusion synthetic data"
+    },
+    {
+      "id": "FR-019",
+      "name": "Melody detector validation harness",
+      "prd": "PRD-011",
+      "status": "planned",
+      "priority": "P3",
+      "notes": "Gemini Robotics-ER 1.6 oracle benchmark"
     }
   ],
   "summary": {
-    "total": 16,
+    "total": 19,
     "active": 12,
-    "planned": 3,
+    "planned": 6,
     "in_progress": 0,
     "blocked": 0
   }

--- a/docs/blueprint/feature-tracker.md
+++ b/docs/blueprint/feature-tracker.md
@@ -22,6 +22,9 @@
 | ESP32 host-based unit tests | — | planned | P2 | Blocked; no tests exist yet |
 | SLAM / autonomous navigation | — | planned | P3 | Listed as future enhancement |
 | Multi-robot swarm coordination | — | planned | P3 | Listed as future enhancement |
+| Melody detector firmware (CV + ESP-DL + I2S) | PRD-011 | planned | P2 | XIAO ESP32-S3 Sense + MAX98357A; ROI classifier with INT8 CNN |
+| Melody detector training pipeline | PRD-011 | planned | P2 | PyTorch + ESP-PPQ; programmatic + diffusion synthetic data |
+| Melody detector validation harness | PRD-011 | planned | P3 | Gemini Robotics-ER 1.6 oracle benchmark |
 
 ## Status Key
 

--- a/docs/blueprint/manifest.md
+++ b/docs/blueprint/manifest.md
@@ -22,11 +22,14 @@ Primary project: dual-ESP32 AI-powered robot car with pluggable AI vision backen
 | ADR-010 | ADR | MQTT Logging Architecture | accepted | 2026-03-25 |
 | ADR-011 | ADR | Gamepad Synth I2S Audio | accepted | 2026-04-07 |
 | ADR-012 | ADR | Browser-Based Web Flasher Architecture | accepted | 2026-04-03 |
+| ADR-017 | ADR | ESP-DL for On-Device Vision (Melody Detector) | proposed | 2026-04-26 |
 | PRD-004 | PRD | IT Troubleshooter | draft | 2026-03-12 |
 | PRD-005 | PRD | Xbox-to-Switch Bridge | draft | 2026-03-15 |
 | PRD-006 | PRD | NFC Scavenger Hunt | draft | 2026-03-18 |
 | PRD-007 | PRD | Audiobook Player | draft | 2026-03-22 |
 | PRD-008 | PRD | Gamepad Synth | draft | 2026-04-07 |
+| PRD-011 | PRD | Melody Detector | draft | 2026-04-26 |
+| PRP-melody-detector | PRP | Melody Detector — Implementation Plan | planned | 2026-04-26 |
 
 ## Project Overview
 

--- a/docs/decisions/ADR-017-melody-detector-esp-dl.md
+++ b/docs/decisions/ADR-017-melody-detector-esp-dl.md
@@ -47,28 +47,60 @@ Use **ESP-DL v3.x** as the on-device inference framework. Train models in
 PyTorch on the local workstation, quantize to INT8 with **ESP-PPQ**, and
 ship `.espdl` model files as part of the firmware.
 
-### Pipeline
+### Training pipeline
 
+```mermaid
+flowchart LR
+    A[PyTorch model<br/>on RTX 4090] --> B[ONNX export]
+    B --> C[ESP-PPQ<br/>INT8 quantization<br/>+ calibration]
+    C --> D[.espdl model file]
+    D --> E[Embedded in firmware<br/>via EMBED_FILES]
+    E --> F[ESP-DL runtime<br/>on XIAO ESP32-S3 Sense]
 ```
-PyTorch (RTX 4090) ── ONNX export ── ESP-PPQ (calibration + INT8) ── .espdl
-                                                                        │
-                                                                        ▼
-                                                    ESP-DL runtime in ESP-IDF
-                                                          on XIAO ESP32-S3 Sense
+
+### Runtime pipeline
+
+```mermaid
+flowchart LR
+    A[Camera frame<br/>OV2640<br/>640×480] --> B
+
+    subgraph CV["Classical CV (on-device, no ML)"]
+        direction TB
+        B[1. Fiducial detect] --> C[2. Perspective rectify]
+        C --> D[3. Staff line refine]
+        D --> E[4. ROI extraction]
+    end
+
+    E -->|"30–80 ROIs<br/>32×32 each"| F
+
+    subgraph ML["ESP-DL CNN classifier"]
+        F[5. INT8 inference]
+    end
+
+    F -->|"empty / quarter / half /<br/>rest / other"| G
+
+    subgraph LU["Geometric lookup (no ML)"]
+        G[6. Pitch from row<br/>Duration from class<br/>Time from column]
+    end
+
+    G -->|"[(pitch, duration), ...]"| H[7. I2S tone synthesis]
+    H --> I[MAX98357A<br/>→ speaker]
 ```
 
 ### Model approach
 
-- Stage 1 (classical CV, on-device): detect the 5 staff lines via Hough
-  transform, locate the corner fiducials, rectify the image, and extract
-  notehead-sized ROIs.
+- Stage 1 (classical CV, on-device): detect the corner fiducials on the
+  pre-printed sheet, compute a perspective homography to rectify the image,
+  refine the 5 staff lines by per-row darkness peak, and extract a grid of
+  32×32 ROIs covering each beat-column × staff-row intersection.
 - Stage 2 (ESP-DL, on-device): a small INT8 CNN (~50–200 KB) classifies
   each ROI as `empty / quarter / half / rest / other`.
-- Pitch is determined geometrically from ROI position relative to the
-  rectified staff lines, not by the model.
+- Pitch is determined geometrically from ROI row index, not by the model.
 
 This split keeps the model small and fast (a classifier, not a detector)
-and offloads spatial reasoning to deterministic geometry.
+and offloads spatial reasoning to deterministic geometry. The pre-printed
+sheets that anchor this geometry are in
+[`packages/audio/melody-detector/sheets/`](../../packages/audio/melody-detector/sheets/).
 
 ### Training data
 

--- a/docs/decisions/ADR-017-melody-detector-esp-dl.md
+++ b/docs/decisions/ADR-017-melody-detector-esp-dl.md
@@ -1,0 +1,162 @@
+# ADR-017: ESP-DL for On-Device Vision in Melody Detector
+
+**Status**: proposed
+**Date**: 2026-04-26
+**Confidence**: 8/10
+
+---
+
+## Context
+
+A new project, **melody-detector**, will let a child draw musical notes on
+a pre-printed staff sheet, photograph the drawing with the on-board camera,
+and play the resulting melody through a MAX98357A I2S amplifier and
+speaker.
+
+Hardware:
+
+- **XIAO ESP32-S3 Sense** — dual-core LX7, 8 MB Octal PSRAM, OV2640 camera,
+  PIE vector instructions for INT8 SIMD.
+- **MAX98357A** — I2S Class-D mono amplifier driving a small speaker.
+- Pre-printed staff sheets with corner fiducials for camera alignment.
+
+The vision task: locate noteheads on the staff and classify each one's
+position (which line or space) and optionally duration. The detector must
+run on-device so the project works offline as a self-contained toy.
+
+Two structurally different paths exist:
+
+1. **Classical CV** (OpenCV-style staff-line detection + blob extraction).
+   Cheap, deterministic, but limited to highly constrained input
+   (dots-in-cells style sheets, no freeform note shapes).
+2. **On-device ML** with a small CNN. Tolerates messy kid drawings, varied
+   note shapes, off-line noteheads — at the cost of model authoring,
+   training, and quantization.
+
+This ADR covers path 2: which TinyML framework to use. We retain classical
+CV as a useful preprocessing step (staff-line detection, ROI extraction)
+upstream of the model.
+
+We also have an RTX 4090 for local training and Gemini API access for
+synthetic data and oracle labeling, which makes the OSS-end-to-end path
+viable as a showcase project.
+
+## Decision
+
+Use **ESP-DL v3.x** as the on-device inference framework. Train models in
+PyTorch on the local workstation, quantize to INT8 with **ESP-PPQ**, and
+ship `.espdl` model files as part of the firmware.
+
+### Pipeline
+
+```
+PyTorch (RTX 4090) ── ONNX export ── ESP-PPQ (calibration + INT8) ── .espdl
+                                                                        │
+                                                                        ▼
+                                                    ESP-DL runtime in ESP-IDF
+                                                          on XIAO ESP32-S3 Sense
+```
+
+### Model approach
+
+- Stage 1 (classical CV, on-device): detect the 5 staff lines via Hough
+  transform, locate the corner fiducials, rectify the image, and extract
+  notehead-sized ROIs.
+- Stage 2 (ESP-DL, on-device): a small INT8 CNN (~50–200 KB) classifies
+  each ROI as `empty / quarter / half / rest / other`.
+- Pitch is determined geometrically from ROI position relative to the
+  rectified staff lines, not by the model.
+
+This split keeps the model small and fast (a classifier, not a detector)
+and offloads spatial reasoning to deterministic geometry.
+
+### Training data
+
+- **Bulk (~95%)**: programmatic rendering of staff sheets with random note
+  positions, durations, and styles, plus albumentations for paper texture,
+  perspective warp, lighting, blur, ink-bleed, and stroke jitter.
+- **Diversity (~5%)**: ControlNet-conditioned diffusion (FLUX or SDXL on
+  the 4090) seeded with programmatic templates, to inject stylistic
+  variation that augmentations can't produce.
+- **Validation set**: ~50–100 real photographs of kid drawings, labeled
+  via **Gemini Robotics-ER 1.6** as an oracle, with 10% spot-checked by
+  hand.
+
+## Consequences
+
+**Positive**
+
+- Best inference performance on ESP32-S3 — ESP-DL's PIE assembly kernels
+  are 2–10× faster than TFLM equivalents.
+- Native ESP-IDF integration; no extra runtime to maintain.
+- ESP-PPQ provides mature post-training quantization with calibration and
+  per-layer sensitivity analysis.
+- All-OSS pipeline (PyTorch + ESP-DL + ESP-PPQ) is showcase-friendly and
+  reproducible.
+- No vendor lock-in to a SaaS labeling/training platform.
+
+**Negative**
+
+- `.espdl` model format is ESP32-only and not portable to other
+  targets.
+- ONNX export step adds a serialization hop between PyTorch and ESP-PPQ.
+- Quantization calibration requires a representative dataset (~1K images)
+  and produces minor accuracy degradation that must be measured.
+- ESP-DL community is smaller than TFLM — expect to occasionally read
+  source.
+
+## Alternatives Considered
+
+Detailed evaluations live in
+[`docs/reference/tinyml-esp32-frameworks.md`](../reference/tinyml-esp32-frameworks.md).
+
+1. **TFLite Micro + ESP-NN** — Mature, large community, but slower than
+   ESP-DL on ESP32-S3 because kernels are not vectorized for PIE
+   instructions. Picked only for projects on classic ESP32 (no S3).
+2. **ExecuTorch** — Pure-PyTorch end-to-end and cross-target portable, but
+   the ESP32 backend is early (2024+) with incomplete operator coverage
+   and inference speed behind ESP-DL on the same hardware. Defer until the
+   ecosystem matures.
+3. **Edge Impulse** — Lowest-friction workflow, free Developer tier
+   sufficient for hobby use. Rejected because the SaaS lock-in conflicts
+   with the OSS-showcase goal, free-tier projects are public, and
+   generated firmware uses TFLM under the hood (slower than ESP-DL).
+4. **LiteRT (TFLite successor)** — Targets phones / Pi / desktop edge, no
+   MCU backend. Not applicable.
+5. **Pure classical CV (no ML)** — Viable for grid-style sheets where each
+   cell is "filled or not." Rejected because we want to support freeform
+   note shapes (quarter / half / rest distinction) that classical CV
+   cannot reliably distinguish.
+6. **Cloud inference (Gemini Robotics-ER 1.6 at runtime)** — Highest
+   accuracy and zero on-device ML complexity, but requires WiFi at
+   runtime, adds 500 ms+ latency per shot, and per-API-call cost. Used as
+   a labeling oracle during development; not a runtime dependency.
+
+For the data-pipeline alternatives (programmatic vs diffusion vs real
+photos) see
+[`docs/reference/synthetic-image-generation.md`](../reference/synthetic-image-generation.md).
+
+For labeling-service alternatives (Gemini Robotics-ER, Claude Vision,
+self-hosted Florence-2) see
+[`docs/reference/vision-labeling-services.md`](../reference/vision-labeling-services.md).
+
+## Implementation Notes
+
+- Project location: `packages/audio/melody-detector/` (audio-domain toy
+  with vision input; sits alongside `kids-audio-toy` and
+  `audiobook-player`).
+- Training scripts live in a sibling directory
+  `packages/audio/melody-detector/training/` (gitignored model artifacts;
+  reproducible from `gen.py` + seed).
+- Model artifact (`model.espdl`) embedded in firmware via ESP-IDF's
+  `EMBED_FILES`.
+- Calibration dataset: 1K samples drawn from the synthetic generator.
+- RAM budget for inference: ≤ 1 MB PSRAM (well under the S3 Sense's 8 MB).
+- Inference latency target: < 200 ms per ROI batch on a 5×8 grid sheet.
+
+## Related
+
+- ADR-013: Single-Board XIAO ESP32-S3 Sense (hardware family)
+- `docs/reference/tinyml-esp32-frameworks.md`
+- `docs/reference/vision-labeling-services.md`
+- `docs/reference/synthetic-image-generation.md`

--- a/docs/prompts/melody-detector.md
+++ b/docs/prompts/melody-detector.md
@@ -1,0 +1,262 @@
+# PRP: Melody Detector — Implementation Plan
+
+**Status**: planned
+**Source**: PRD-011, ADR-017
+**Priority**: P2
+**Confidence**: 7/10
+
+---
+
+## Goal
+
+Implement the melody-detector firmware and training pipeline as specified
+in [PRD-011](../requirements/PRD-011-melody-detector.md) using the
+architecture chosen in
+[ADR-017](../decisions/ADR-017-melody-detector-esp-dl.md). Deliver an
+end-to-end OSS pipeline: synthetic data → PyTorch training → INT8
+quantization → ESP-DL deployment → on-device playback.
+
+## Background
+
+The melody-detector project is a children's toy and TinyML showcase
+combining classical CV (deterministic geometry from pre-printed
+fiducials) with a small INT8 CNN (per-ROI classification). PRD-011
+defines the requirements; this PRP defines the build order, track
+dependencies, and deliverables for each track.
+
+The project lives at `packages/audio/melody-detector/` and is registered
+in the monorepo root justfile and CI matrix.
+
+## Track Dependencies
+
+```mermaid
+flowchart LR
+    A[Track A:<br/>Project scaffolding] --> C[Track C:<br/>Classical CV]
+    A --> D[Track D:<br/>ESP-DL inference]
+    A --> E[Track E:<br/>I2S audio synth]
+    B[Track B:<br/>Training pipeline] --> D
+    C --> F[Track F:<br/>Main loop integration]
+    D --> F
+    E --> F
+    F --> G[Track G:<br/>Validation]
+```
+
+Tracks A and B have no dependencies and can start in parallel. Tracks C,
+D, and E all depend on A's project structure and can run in parallel
+once A is merged. Track F is the integration point. Track G closes the
+loop with on-hardware measurements.
+
+## Implementation Plan
+
+### Track A — Project scaffolding (Phase 1)
+
+**Deliverables**
+
+- `packages/audio/melody-detector/` ESP-IDF project skeleton
+- `CMakeLists.txt`, `main/CMakeLists.txt`, `main/main.c` (stub)
+- `sdkconfig.defaults` enabling: PSRAM, OV2640 camera driver, I2S, ESP-DL
+  managed component
+- `partitions.csv` matching the standard dual-OTA layout (1.8 MB app,
+  factory + ota_0 + ota_1)
+- `justfile` importing `tools/esp32-idf.just`, defining `flash` and
+  `info` recipes
+- Root `justfile` registers the module: `mod melody-detector
+  'packages/audio/melody-detector'`
+- CI matrix entry in `.github/workflows/esp32-build.yml`
+- Skeleton `README.md`, `WIRING.md`, `CLAUDE.md` (use the
+  `project-readme`, `wiring-doc`, `project-claude-md` skills)
+- Status LED feedback patterns
+
+**Acceptance**
+
+- `just melody-detector::build` succeeds in the container
+- CI builds the firmware on every push
+- Binary fits the 1.8 MB OTA partition
+
+### Track B — Training pipeline (Phase 5)
+
+**Deliverables**
+
+- `packages/audio/melody-detector/training/` Python package managed by
+  `uv`
+- `gen.py` — synthetic ROI generator using PIL + albumentations
+- `dataset.py` — PyTorch `Dataset` wrapper with seedable shuffle / split
+- `model.py` — small CNN, 3–4 conv layers, ~50–200 KB INT8 weights
+- `train.py` — training loop with WandB / TensorBoard logging optional
+- `export.py` — ONNX export with the opset ESP-PPQ requires
+- `quantize.py` — ESP-PPQ INT8 quantization with calibration set
+- `pytest` tests for the generator (output shapes, label correctness,
+  reproducibility from seed)
+- `pyproject.toml` with reproducible dependency pins
+
+**Acceptance**
+
+- `uv run python gen.py --seed 0 --out data/` produces a deterministic
+  dataset (verified by `sha256sum`)
+- `uv run python train.py` produces a model checkpoint at ≥ 95 %
+  validation accuracy on synthetic data
+- `uv run python quantize.py` produces a `model.espdl` artifact
+- All tests pass on `pytest`
+
+### Track C — Classical CV pipeline (Phase 2)
+
+**Deliverables**
+
+- `main/cv_pipeline.h` — public API: `cv_extract_rois(frame, rois_out)`
+- `main/cv_pipeline.c` — implementation: fiducial detect, homography,
+  staff line refinement, ROI extraction
+- `main/cv_homography.c` — 3 × 3 matrix math (no float-heavy deps)
+- Host-buildable: `CONFIG_IDF_TARGET_LINUX=y` with Unity test harness
+  using a fixture image set
+- Test fixtures derived from the synthetic generator output (Track B)
+
+**Acceptance**
+
+- Host tests pass on Linux + macOS in CI
+- Per-stage timing instrumented and logged
+- ROI extraction produces correctly-sized outputs (32 × 32) at known
+  positions
+
+### Track D — ESP-DL inference (Phase 3)
+
+**Deliverables**
+
+- `main/inference.h/c` — load model from `EMBED_FILES`, allocate input /
+  output tensors, batch-infer ROIs
+- ESP-DL managed component dependency in `idf_component.yml`
+- Stub `model.espdl` until Track B finishes (fixed-output stub for
+  pipeline testing)
+- Memory-instrumentation hooks for `uxTaskGetStackHighWaterMark` and
+  `heap_caps_get_free_size`
+
+**Acceptance**
+
+- Model loads at boot without error
+- 56-ROI batch inference completes in < 250 ms on hardware
+- Total PSRAM footprint < 1 MB (model + activations + ROI buffer)
+
+### Track E — I2S audio synthesis (Phase 4)
+
+**Deliverables**
+
+- `main/audio.h/c` — I2S driver setup for MAX98357A, DDS oscillator,
+  ADSR envelope, note-sequence playback
+- Pitch lookup table for treble-clef rows (covered in PRD-011 FR-4.01)
+- Configurable tempo and gain
+- Test mode that plays a known scale on boot for hardware verification
+
+**Acceptance**
+
+- Test mode emits a clean major scale through the speaker
+- No audible clicks at note boundaries (envelope verified on a 'scope or
+  by ear)
+- Sample buffer underrun rate = 0 over a 10-second playback
+
+### Track F — Main loop integration
+
+**Deliverables**
+
+- `main/main.c` — orchestrator: button → capture → CV → inference →
+  synth → playback
+- FreeRTOS task layout (capture / CV / inference on Core 1, audio on
+  Core 0 with audio task at priority 10)
+- Button GPIO + debounce
+- Status LED state machine
+- End-to-end smoke test on real hardware
+
+**Acceptance**
+
+- Button press → first audio sample in < 1 second
+- Recovers cleanly from a sheet that has no detectable fiducials
+  (graceful error tone)
+- Handles back-to-back captures without leaking memory
+
+### Track G — Validation (Phase 6)
+
+**Deliverables**
+
+- `validation/` directory with the real-photo holdout (gitignored;
+  documented collection process)
+- `validation/oracle_label.py` — Gemini Robotics-ER 1.6 oracle labeling
+  script
+- `validation/benchmark.py` — runs both on-device model and oracle on the
+  same set, computes per-class confusion matrix
+- README section publishing the benchmark numbers
+
+**Acceptance**
+
+- ≥ 90 % per-ROI accuracy on the real-photo holdout (PRD-011 acceptance
+  criterion)
+- Benchmark numbers documented in the project README
+- Oracle-labeling script reproducible with documented prompt + API
+  version
+
+## Skills to Use
+
+The following project-level skills should be invoked as appropriate
+during implementation:
+
+- `project-readme` — Track A README scaffolding
+- `wiring-doc` — Track A WIRING.md
+- `project-claude-md` — Track A CLAUDE.md
+- `register-project` — Track A justfile + CI registration
+- `sdkconfig-audit` — Track A sdkconfig.defaults audit
+- `wifi-sta-setup` — only if WiFi/OTA is added in v2 (out of scope for
+  v1)
+- `embedded-best-practices` — review C/C++ code in tracks C, D, E, F
+- `review-firmware` — pre-merge review on each firmware track
+- `lint` — pre-commit on every track
+- `monitor` / `flash` / `develop` — bring-up and on-device debugging
+- `safe-build-operations` — guarded build / flash commands
+
+## Test Framework
+
+- **Track B (Python)**: `pytest` with `--cov`, run via
+  `cd packages/audio/melody-detector/training && uv run pytest`
+- **Track C (C/C++)**: ESP-IDF Unity with `CONFIG_IDF_TARGET_LINUX=y`
+  for host-based tests; fixture images checked into the repo
+- **Tracks D, E, F (firmware)**: manual hardware tests + log-based
+  smoke tests
+- **Track G**: oracle benchmark script committed; numbers regenerated
+  on demand
+
+## Acceptance Criteria
+
+Mirror PRD-011's acceptance criteria. Specifically:
+
+- [ ] On-device per-ROI classification ≥ 90 % on the real-photo holdout
+- [ ] End-to-end latency from button press to first audio sample < 1 s
+- [ ] Firmware fits the 1.8 MB OTA partition (enforced in CI)
+- [ ] Synthetic dataset reproducible from a single seed
+- [ ] External developer can build, train, and flash the system in < 1
+  day from a clean checkout
+- [ ] Benchmark vs. Gemini Robotics-ER 1.6 published in the project
+  README
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| ESP-DL `.espdl` quantization quality lower than expected | Mixed-precision quantization (INT8 conv, INT16 final FC); retrain with quantization-aware training if needed |
+| Fiducial detection unreliable under low-contrast lighting | Add a flash LED alongside the camera; document required lighting in the README |
+| Synthetic-to-real domain gap > expected | Increase albumentations diversity; add ControlNet-stylized samples; collect more real photos for the holdout |
+| Inference latency exceeds 250 ms target | Reduce ROI grid density (skip pre-filtered empty patches); consider INT8 first-conv vector intrinsics |
+| MAX98357A audible clicks at low volume | Add software DC blocker; ensure ADSR release is ≥ 5 ms |
+
+## Out of Scope (Deferred to v2)
+
+- WiFi provisioning + Improv-WiFi
+- OTA via GitHub Releases
+- Polyphony / chord recognition
+- Note durations beyond quarter / half / rest
+- Companion mobile app
+- Multi-language pitch-letter labels (German B vs. American B)
+- Battery / portable enclosure
+
+## Related Documents
+
+- [PRD-011: Melody Detector](../requirements/PRD-011-melody-detector.md)
+- [ADR-017: ESP-DL for On-Device Vision](../decisions/ADR-017-melody-detector-esp-dl.md)
+- [TinyML frameworks reference](../reference/tinyml-esp32-frameworks.md)
+- [Vision labeling services reference](../reference/vision-labeling-services.md)
+- [Synthetic image generation reference](../reference/synthetic-image-generation.md)

--- a/docs/reference/notebook-mapping.md
+++ b/docs/reference/notebook-mapping.md
@@ -21,7 +21,7 @@ purpose below.
 
 | Notebook | ID | Primary repo touchpoints |
 |---|---|---|
-| ESP32-S3 hardware families (XIAO Sense, XIAO Plus, ESP32-S3-Zero) | `3bb67ba2-58b4-4485-a306-6ab49ec38160` | ADR-013; `packages/robocar/unified/`, XIAO projects; XIAO ESP32-C6 cross-ref |
+| ESP32-S3 hardware families (XIAO Sense, XIAO Plus, ESP32-S3-Zero) | `3bb67ba2-58b4-4485-a306-6ab49ec38160` | ADR-013, ADR-017; PRD-011; `packages/robocar/unified/`, `packages/audio/melody-detector/`, XIAO projects; XIAO ESP32-C6 cross-ref |
 | ESP32 classic boards (CAM, Heltec, TTGO) | `d2d63711-4843-48e7-9965-018362dad0e5` | `packages/robocar/camera/`, `packages/robocar/main/`, `docs/reference/boards/ttgo-lora32-v2.md` |
 
 ### Peripheral IC classes
@@ -30,7 +30,7 @@ purpose below.
 |---|---|---|
 | Sensors & modules used in this lab | `c2d44a8c-cba1-436f-9c5c-0fe98f672909` | Module references used anywhere in `packages/` |
 | Motor drivers & power electronics | `197ef318-9983-4168-9a3b-d92288d832b6` | `packages/robocar/*/main/motor_controller.*`; TB6612FNG, L298N, DRV8833, TP4056, MT3608, XL6009, AMS1117, NE555 |
-| I2S audio & synthesis on ESP32 | `8cbdd8bb-e88e-4a26-a94f-d0126e68a09e` | ADR-011; PRD-008; `packages/audio/`, `packages/camera-vision/cam-i2s-audio/` |
+| I2S audio & synthesis on ESP32 | `8cbdd8bb-e88e-4a26-a94f-d0126e68a09e` | ADR-011, ADR-017; PRD-008, PRD-011; `packages/audio/`, `packages/camera-vision/cam-i2s-audio/` |
 | USB gadget & HID on ESP32-S3 | `e91ebe8d-4b93-4321-9d7e-b97aa34956aa` | ADR-006, ADR-009; PRD-005; `packages/input-gaming/` |
 | ChameleonUltra: Advanced RFID and NFC Card Emulation Platform | `4831062f-84ab-4f67-89c0-61345941e3ea` | PRD-006; `packages/games/nfc-scavenger-hunt/` |
 
@@ -54,7 +54,7 @@ purpose below.
 
 | Notebook | ID | Primary repo touchpoints |
 |---|---|---|
-| AI vision backends for embedded (Claude / Ollama / Gemini) | `a755b5cd-22ec-4b5a-844e-ba7c1a258957` | ADR-003, ADR-008, ADR-016; PRD-002; `packages/robocar/camera/`, `packages/camera-vision/` |
+| AI vision backends for embedded (Claude / Ollama / Gemini) | `a755b5cd-22ec-4b5a-844e-ba7c1a258957` | ADR-003, ADR-008, ADR-016; PRD-002; `packages/robocar/camera/`, `packages/camera-vision/`; `docs/reference/vision-labeling-services.md`; `docs/reference/synthetic-image-generation.md` |
 
 ### Dev tooling & simulation
 
@@ -73,7 +73,7 @@ purpose below.
 | `docs/decisions/ADR-010-*`, `packages/components/improv-wifi/**`, `.claude/rules/mdns-hostname.md` | WiFi / mDNS / MQTT |
 | `docs/decisions/ADR-006-*`, `docs/requirements/PRD-005-*` | USB / HID |
 | `docs/decisions/ADR-009-*`, `docs/requirements/PRD-008-*`, `packages/audio/gamepad-synth/**`, `packages/input-gaming/**` | USB / HID + Bluepad32 |
-| `docs/decisions/ADR-011-*`, `packages/audio/**` (non-gamepad) | I2S audio |
+| `docs/decisions/ADR-011-*`, `docs/decisions/ADR-017-*`, `docs/requirements/PRD-011-*`, `packages/audio/**` (non-gamepad) | I2S audio + ESP32-S3 boards |
 | `docs/decisions/ADR-007-*`, `packages/components/i2c-protocol/**` | ESP32 peripherals |
 | `docs/requirements/PRD-006-*`, `packages/games/nfc-scavenger-hunt/**` | ChameleonUltra RFID/NFC |
 | `packages/robocar/camera/**`, `packages/robocar/main/**`, `docs/reference/boards/ttgo-lora32-v2.md` | ESP32 classic boards |
@@ -81,6 +81,8 @@ purpose below.
 | `docs/requirements/PRD-007-*`, `packages/audio/audiobook-player/**`, `packages/networking/wireguard-ha/**` | ESPHome platform & components |
 | `docs/requirements/PRD-003-*`, `packages/robocar/simulation/**` | Python simulation & robotics math |
 | `CLAUDE.md`, `.claude/**` | Claude Code workflow |
+| `docs/reference/vision-labeling-services.md`, `docs/reference/synthetic-image-generation.md` | AI vision backends |
+| `docs/reference/tinyml-esp32-frameworks.md` | *(no notebook yet — candidate for a new "TinyML & on-device inference" notebook)* |
 
 ## Maintenance cadence
 

--- a/docs/reference/synthetic-image-generation.md
+++ b/docs/reference/synthetic-image-generation.md
@@ -1,0 +1,178 @@
+# Synthetic Image Generation for ML Training
+
+Reference for generating labeled training data when real data is scarce or
+expensive to label. Aimed at small computer-vision tasks where the
+input domain is structured enough to render programmatically.
+
+Last reviewed: 2026-04-26.
+
+## Decision tree
+
+```
+Is the input domain structured (geometry, layout, known classes)?
+├── Yes  → Programmatic rendering + augmentation (cheapest, free labels)
+└── No   → Diffusion-based generation (expensive, needs labeling step)
+
+Need stylistic diversity beyond augmentations?
+└── Add diffusion-generated images as ~5–10% of dataset.
+
+Need real-world appearance fidelity?
+└── Validate with a small real-world holdout set; bridge with domain
+    randomization.
+```
+
+## Programmatic rendering
+
+Generate images deterministically from code. Labels come for free because
+the rendering parameters are the labels.
+
+**Tools**
+- **PIL / Pillow** — simple 2D rasterization, fast.
+- **Cairo** — vector graphics, anti-aliased, good for clean diagrams.
+- **SVG → PNG (cairosvg, resvg)** — author in vector, render at multiple
+  scales.
+- **Blender (bpy)** — 3D scenes, physically-based lighting; overkill for 2D
+  but unbeatable for 3D.
+- **NVISII / OmniSim / Isaac Sim** — physics-based synthesis for robotics.
+
+**Strengths**
+- Free at scale — generate millions of images.
+- Perfect labels — no annotation cost.
+- Reproducible — the dataset is `git clone && python gen.py`.
+- Full control over class balance, edge cases, hard examples.
+
+**Weaknesses**
+- Domain gap: synthetic images may not match real-world appearance.
+- Authoring the renderer takes engineering time upfront.
+- Diversity is bounded by what you code.
+
+**When to pick**
+- Structured domains: charts, diagrams, board games, sheet music, UIs,
+  barcodes, AR markers.
+- Geometric scenes with known objects.
+- Anything where you can describe a sample as code.
+
+## Augmentation libraries
+
+Multiplicative on top of programmatic rendering. Apply photometric and
+geometric transforms to expand a small base set.
+
+| Library | Strengths | Notes |
+|---|---|---|
+| **albumentations** | Fastest, broadest set of transforms, handles bboxes / masks / keypoints | de-facto standard in 2026 |
+| **kornia** | GPU-accelerated, differentiable, integrates with PyTorch | Use when augmentations need to run inside the training loop |
+| **imgaug** | Older, slower than albumentations | Legacy projects |
+| **torchvision.transforms.v2** | Stdlib, GPU-friendly | Sufficient for simple cases |
+
+**Standard transform set for paper/document tasks**
+- Random affine (rotation ±5°, scale 0.9–1.1, shear)
+- Perspective warp (camera not perpendicular)
+- Brightness / contrast / gamma
+- Gaussian / motion blur (camera focus, motion)
+- Gaussian noise (sensor noise)
+- JPEG compression (camera artifacts)
+- Random erasing / coarse dropout (occlusion)
+- Color jitter / hue shift (lighting variation)
+- Paper texture overlay (synthetic + real paper backgrounds)
+
+## Diffusion-based generation
+
+Use generative models to produce images that programmatic rendering can't
+synthesize naturally — stylistic variation, photorealistic textures, novel
+poses.
+
+| Model | Pricing | Self-hostable? | Notes |
+|---|---|---|---|
+| **Imagen 4 Fast** | $0.02 / image | No (Gemini API) | 1024×1024 default, up to 2K. Cheapest Tier-1 |
+| **Imagen 4 Standard** | $0.04 / image | No | Higher quality |
+| **Imagen 4 Ultra** | $0.06 / image | No | Best quality, photorealism |
+| **FLUX.1 dev** | Free (open weights) | Yes (RTX 4090: 5–10 s/image) | State-of-the-art open model in 2026 |
+| **SDXL / SD 3.x** | Free (open weights) | Yes | Older but well-supported, lots of LoRAs |
+| **GPT Image 1.5 (OpenAI)** | ~$0.04–0.17 / image (resolution-tier) | No | Strong instruction-following |
+| **Grok Imagine** | API, varies | No | Growing capability |
+
+**Strengths**
+- Photorealistic output, stylistic diversity.
+- Can produce things programmatic rendering can't (lighting, materials,
+  unusual angles).
+
+**Weaknesses**
+- **Labels are not free** — must label generated images post-hoc, or
+  condition tightly on a known prompt.
+- Cost adds up: 10K images at $0.02 each = $200.
+- Can hallucinate domain-specific details (text, fingers, exact geometry).
+- Reproducibility requires pinning model version + seed.
+
+**When to pick**
+- Domain has critical visual variety that augmentations can't capture.
+- Adding ~5–10% of dataset for diversity, not the bulk.
+- One-time generation of hero examples or hard-case demos.
+
+### Conditional generation: ControlNet, IP-Adapter, image-to-image
+
+Condition diffusion on a programmatically rendered template — get the
+benefits of free labels and stylistic diversity together.
+
+```
+Programmatic render (clean template + ground truth labels)
+         ↓
+ControlNet conditioning (Canny / depth / pose)
+         ↓
+Diffusion model (FLUX, SD 3.x)
+         ↓
+Stylized image (still labeled by the template)
+```
+
+**When to pick**
+- Best-of-both-worlds when you need labels AND stylistic variation.
+- Requires self-hosted setup (ControlNet workflows are mature in
+  ComfyUI / Forge but not generally available via cloud APIs).
+
+## Domain randomization
+
+Aggressively vary non-essential aspects of the synthetic scene during
+generation: lighting, background textures, camera pose, color schemes,
+distractors. Forces the model to learn invariant features.
+
+**Standard knobs**
+- Background: random natural images (ImageNet, Places365) behind the
+  subject.
+- Lighting: directional + ambient, random color temperature.
+- Camera: perspective, distance, angle within plausible range.
+- Distractors: random objects / shapes pasted into the scene.
+- Color: full hue rotation if class-irrelevant.
+
+**When to pick**
+- Always, when shipping a synthetic-only model to the real world.
+- Especially important for 3D / physics-based synthesis.
+
+## GAN-based synthesis
+
+Largely superseded by diffusion in 2026. Mention only for completeness:
+StyleGAN / pix2pix / CycleGAN. Still useful for narrow domains where you
+have a small real dataset and want to expand it via image-to-image
+translation.
+
+## Cost-quality matrix
+
+| Approach | Cost per 10K images | Label fidelity | Diversity | Recommended share |
+|---|---|---|---|---|
+| Programmatic + albumentations | ~$0 | Perfect | Bounded by code | 80–95% |
+| Diffusion (Imagen 4 Fast) | $200 | Manual or oracle-labeled | High | 0–10% |
+| Diffusion (FLUX self-hosted) | ~$0 (compute) | Manual or oracle-labeled | High | 0–15% |
+| ControlNet on programmatic | ~$0 (compute) | Inherited from template | High | 0–15% |
+| Real photographs + Robotics-ER labels | $10–50 (API) + collection time | Oracle-labeled | Real | 5–20% (validation set) |
+
+A typical mix for a small-budget project: **90% programmatic + augmentation,
+5% ControlNet-stylized, 5% real photos as validation.**
+
+## Reproducibility checklist
+
+- Pin random seeds in the generation script.
+- Pin diffusion model versions and revisions (Hugging Face commit hash).
+- Commit the generation script alongside the firmware repo, not the
+  dataset itself.
+- Document augmentation parameters (probability, range) in the dataset
+  README.
+- Hash the generated dataset (`sha256sum`) and store the digest with the
+  trained model checkpoint.

--- a/docs/reference/tinyml-esp32-frameworks.md
+++ b/docs/reference/tinyml-esp32-frameworks.md
@@ -1,0 +1,178 @@
+# TinyML Inference Frameworks for ESP32-Class Targets
+
+Reference summary of on-device ML inference frameworks evaluated for the
+melody-detector project (XIAO ESP32-S3 Sense). Useful as a starting point for
+future ESP32 / ESP32-S3 projects that need on-device vision or audio
+inference.
+
+Last reviewed: 2026-04-26.
+
+## At a glance
+
+| Framework | Vendor | License | ESP32-S3 status | Best inference perf on S3 | Training flow |
+|---|---|---|---|---|---|
+| **ESP-DL v3.x** | Espressif | Apache 2.0 | First-class, production | Yes (PIE assembly kernels) | PyTorch → ONNX → ESP-PPQ → `.espdl` |
+| **TFLite Micro + ESP-NN** | Google + Espressif | Apache 2.0 | Mature | Good | Keras/TF → TFLite converter → `.tflite` |
+| **LiteRT (TFLite successor)** | Google | Apache 2.0 | Targets phone/Pi/desktop, not MCU | N/A on MCU | TF/Keras/PyTorch → LiteRT converter |
+| **ExecuTorch** | Meta (PyTorch) | BSD-3 | Early ESP32 backend (2024+) | Behind ESP-DL on S3 | PyTorch → `torch.export` → `.pte` |
+| **Edge Impulse** | Edge Impulse / Qualcomm | Proprietary SaaS (free tier) | Officially supported | Wraps TFLM (slower than ESP-DL) | Web UI → exports as Arduino lib / IDF component |
+
+## ESP-DL
+
+Espressif's official deep learning library, designed for ESP32-S3 and later
+SoCs that have PIE (Packed-SIMD-like) vector instructions.
+
+**Strengths**
+- Hand-tuned assembly kernels for conv / matmul on ESP32-S3 deliver 2–10×
+  speedup over generic TFLM kernels.
+- ESP-PPQ (forked from PPQ, the PyTorch quantization toolkit) provides
+  post-training INT8/INT16 quantization with calibration, mixed precision,
+  and per-layer sensitivity analysis.
+- Espressif ships a model zoo with pretrained detectors (face, person,
+  pedestrian) suitable for fine-tuning.
+- Tightly integrated with ESP-IDF — ships as a managed component.
+
+**Weaknesses**
+- Custom `.espdl` model format is ESP32-only; not portable to phones / Pi.
+- Documentation is improving but you will read source occasionally.
+- Smaller community than TFLM / LiteRT.
+
+**When to pick**
+- Production ESP32-S3 deployments where inference latency matters.
+- Projects already inside the ESP-IDF ecosystem.
+- Showcases that benefit from "runs natively on the SoC's vector unit"
+  framing.
+
+**Repo / docs**
+- [github.com/espressif/esp-dl](https://github.com/espressif/esp-dl)
+- [github.com/espressif/esp-ppq](https://github.com/espressif/esp-ppq)
+
+## TFLite Micro + ESP-NN
+
+The classic TinyML stack: TensorFlow Lite for Microcontrollers with
+Espressif's ESP-NN providing optimized kernels for ESP32 / ESP32-S3.
+
+**Strengths**
+- Largest community, most tutorials, most reference models.
+- Mature toolchain: `.tflite` flatbuffer model is a stable target.
+- Works on classic ESP32 (no S3 vector unit required) — only option for
+  older boards.
+- Edge Impulse exports use this stack under the hood.
+
+**Weaknesses**
+- Slower than ESP-DL on ESP32-S3 because kernel optimization stops at
+  ESP-NN's level (no PIE assembly).
+- Google has shifted active investment to LiteRT, which targets larger
+  devices; TFLM is in maintenance mode.
+
+**When to pick**
+- Projects on classic ESP32 (no S3) that need ML inference.
+- Projects where the existing TFLM ecosystem (model zoo, tutorials)
+  outweighs raw speed.
+
+**Repo**
+- [github.com/tensorflow/tflite-micro](https://github.com/tensorflow/tflite-micro)
+- [github.com/espressif/esp-nn](https://github.com/espressif/esp-nn)
+
+## LiteRT (TensorFlow Lite successor)
+
+Google's renamed and modernized edge runtime. Includes the new
+`CompiledModel` API for hardware acceleration, supports loading PyTorch
+models alongside TF, and powers on-device LLMs (LiteRT-LM) on phones and
+Chromebooks.
+
+**Strengths**
+- Modern API, active development, multi-framework input.
+- Targets phones, Pi-class Linux, web (WASM), desktop.
+- LiteRT-LM enables on-device GenAI on capable edge devices.
+
+**Weaknesses**
+- **Does not target microcontroller-class hardware.** No ESP32 backend.
+- Confusion risk: "LiteRT" sometimes used loosely to mean "TFLite for
+  edge" — for MCUs, TFLite Micro is still the relevant stack.
+
+**When to pick**
+- Edge ML on phones, Pi, embedded Linux, web.
+- Not for ESP32 / ESP32-S3 firmware.
+
+**Repo**
+- [github.com/google-ai-edge/LiteRT](https://github.com/google-ai-edge/LiteRT)
+
+## ExecuTorch
+
+PyTorch's official edge runtime, replacing TorchScript / PyTorch Mobile. Uses
+the new PT2 export flow (`torch.export`) to produce `.pte` model files that
+run on a small C++ runtime.
+
+**Strengths**
+- PyTorch end-to-end — no ONNX detour.
+- Same `.pte` model can run on phone, Pi, ESP32 — strong portability story.
+- Modern quantization via `torchao` and PT2E.
+- Active development, large PyTorch community.
+
+**Weaknesses**
+- ESP32 backend is recent (2024+) and kernel coverage lags ESP-DL.
+- Inference speed on ESP32-S3 is behind ESP-DL because PIE-vectorized
+  kernels are not yet at parity.
+- Expect to occasionally hit "operator not implemented" and need
+  workarounds.
+
+**When to pick**
+- Cross-target deployments (same model on phone + ESP32).
+- Pure-PyTorch pipelines where avoiding ONNX is a hard requirement.
+- Projects where being on the bleeding edge is acceptable.
+
+**Repo**
+- [github.com/pytorch/executorch](https://github.com/pytorch/executorch)
+
+## Edge Impulse
+
+Web-based platform for collecting data, training, and deploying TinyML
+models. Generates Arduino libraries and ESP-IDF components.
+
+**Strengths**
+- Lowest friction end-to-end workflow: web UI for data labeling, training,
+  quantization, deployment.
+- Officially supports XIAO ESP32-S3 Sense.
+- Free Developer (Community) tier covers personal / hobby / educational
+  projects with full feature access.
+- Good fit for non-ML-experts on a team.
+
+**Weaknesses**
+- Proprietary SaaS — free-tier projects are public (anyone with the URL can
+  view the dataset and model).
+- Acquired by Qualcomm in 2025; long-term roadmap and free-tier terms may
+  shift.
+- Generated firmware uses TFLM under the hood, so inference on ESP32-S3 is
+  slower than ESP-DL.
+- Lock-in: dataset and trained model live on their platform; export is
+  possible but not seamless.
+
+**When to pick**
+- Rapid prototyping, hackathons, classroom projects.
+- Teams without an ML engineer.
+- Projects where you accept SaaS lock-in for workflow speed.
+
+**Site**
+- [edgeimpulse.com](https://edgeimpulse.com)
+
+## Decision matrix for new projects
+
+```
+Need to run on classic ESP32 (no S3)?     → TFLite Micro + ESP-NN
+Need cross-platform model (phone + MCU)?  → ExecuTorch
+Need fastest inference on ESP32-S3?       → ESP-DL
+Need lowest workflow friction?            → Edge Impulse (free tier)
+Targeting phone / Pi / desktop edge?      → LiteRT
+```
+
+## Useful adjacent tools
+
+- **PPQ / ESP-PPQ** — quantization toolkit (PyTorch-based), backend for
+  ESP-DL.
+- **ONNX Runtime Web / Mobile** — alternative inference runtime, does not
+  target MCUs but useful for shared models on companion apps.
+- **MLflow / Weights & Biases** — experiment tracking; orthogonal to the
+  framework choice.
+- **Roboflow** — dataset management and augmentation; can export to TFLite,
+  ONNX, ExecuTorch.

--- a/docs/reference/vision-labeling-services.md
+++ b/docs/reference/vision-labeling-services.md
@@ -1,0 +1,163 @@
+# Cloud Vision APIs as Labeling Oracles
+
+Reference for using cloud vision-language models to label images for
+supervised training. Useful when you need a fast validation set or want to
+bootstrap labels for fine-tuning a small on-device model.
+
+Last reviewed: 2026-04-26.
+
+## Decision shortcut
+
+| Need | Recommended service |
+|---|---|
+| Spatial labels (bounding boxes, points, segments) | **Gemini Robotics-ER 1.6** |
+| General descriptive labels | Gemini 3.x Flash (free tier) or Claude Sonnet 4.6 |
+| OCR / structured text from images | Gemini 3.x Pro |
+| Self-hosted / private data only | Florence-2, Qwen2-VL, or YOLO-World (open weights) |
+
+## Gemini Robotics-ER 1.6
+
+Purpose-built for spatial reasoning and embodied tasks. Returns normalized
+bounding boxes and segmentation masks in a stable JSON format — ideal as a
+labeling oracle for object-detection training data.
+
+**Output format**
+
+```json
+[
+  {"box_2d": [ymin, xmin, ymax, xmax], "label": "notehead_line_1"},
+  {"box_2d": [...], "label": "notehead_space_2"}
+]
+```
+
+Coordinates are normalized to 0–1000 (independent of image resolution).
+Output is capped at 25 objects per image.
+
+**Strengths**
+- Stable structured output — no prompt-engineering struct hacks needed.
+- Spatial reasoning quality is genuinely better than general-purpose Gemini
+  for "where is each X" tasks.
+- Optional segmentation masks alongside boxes.
+- Single API call gives detection + classification.
+
+**Weaknesses**
+- Hard cap of 25 objects per image — not suitable for dense scenes.
+- 0–1000 normalization quirk to handle in code.
+- Pro tier required for reliable output on hard cases (paid as of April
+  2026).
+
+**Pricing (April 2026)**
+- Available via Gemini API: `generativelanguage.googleapis.com/v1beta/...`
+- Auth: `x-goog-api-key` header.
+- Pro pricing: see Gemini 3.x Pro tier.
+
+**When to pick**
+- Bootstrapping labels for a new computer-vision dataset.
+- Building a validation set quickly (50–500 images).
+- Spatial tasks where coordinates matter, not just class labels.
+
+**Docs**
+- [Gemini Robotics overview](https://ai.google.dev/gemini-api/docs/robotics-overview)
+- [Vertex AI bounding box detection](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/bounding-box-detection)
+
+## Gemini 3.x Flash / Pro (general vision)
+
+The mainline Gemini multimodal models, useful for descriptive captions, OCR,
+and free-form visual Q&A.
+
+**Pricing (April 2026)**
+- Gemini 3.1 Pro: $2.00 / $12.00 per 1M tokens (≤200K context); $4.00 /
+  $18.00 above.
+- Gemini 3.1 Flash-Lite: $0.25 / $1.50 per 1M tokens.
+- Image input: 560 tokens per image regardless of model.
+- Free tier: Flash models still free with reduced daily quotas. **Pro models
+  removed from free tier on April 1, 2026.**
+
+**When to pick**
+- Generic image understanding ("describe this", "is this a cat?").
+- OCR — Pro is the strongest mainstream OCR model in 2026.
+- Cheap, high-volume tagging — Flash-Lite at $0.25/M input is the cheapest
+  Tier-1 vision model.
+
+**Docs**
+- [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing)
+- [Gemini API models](https://ai.google.dev/gemini-api/docs/models)
+
+## Claude Vision (Sonnet 4.6 / Opus 4.7)
+
+Anthropic's multimodal models. Excellent at reading messy human handwriting,
+diagrams, and reasoning about images.
+
+**Strengths**
+- Strong at handwriting, diagrams, charts.
+- Long context window (Opus 4.7: 200K, Sonnet 4.6: similar).
+- Reliable structured output via tool use / JSON mode.
+
+**Weaknesses**
+- No native bounding-box output — coordinates are best-effort via prompting.
+- More expensive than Gemini Flash for bulk labeling.
+
+**When to pick**
+- Tasks involving handwriting, sketches, or messy real-world documents.
+- When Anthropic SDK is already in the project.
+
+## OpenAI GPT-4o / GPT-5.x Vision
+
+Capable, broadly comparable to Gemini Pro on most benchmarks. No native
+spatial-output mode equivalent to Gemini Robotics-ER.
+
+**When to pick**
+- Existing OpenAI integration.
+- Otherwise no specific advantage for spatial labeling.
+
+## Open-source / self-hosted alternatives
+
+For projects where data privacy or offline operation matters.
+
+| Model | Strength | Notes |
+|---|---|---|
+| **Florence-2** (Microsoft) | Bounding boxes + segmentation, small footprint | 230M / 770M params, runs on a 4090 easily |
+| **Qwen2-VL** (Alibaba) | Strong general VLM, supports tool use | 2B / 7B / 72B params |
+| **YOLO-World** (Tencent) | Open-vocabulary detection | Real-time on GPU; no LLM in the loop |
+| **OWLv2** (Google) | Open-vocabulary detection, text queries | Older but solid |
+| **Grounding DINO** | Text-prompted detection | Strong for "find all X" tasks |
+
+**When to pick**
+- Sensitive data that can't leave your infrastructure.
+- Bulk labeling where API costs would be prohibitive.
+- Reproducibility — the model and weights are pinned.
+
+## Cost worked example: 1000-image validation set
+
+Labeling 1000 images for "find every notehead, return position":
+
+| Service | Cost | Notes |
+|---|---|---|
+| Gemini Robotics-ER 1.6 (Pro) | ~$10 | One call/image, ~3K tokens per response |
+| Gemini 3.1 Flash-Lite | ~$1 | Free tier covers it if rate limits allow |
+| Claude Sonnet 4.6 | ~$15 | Higher quality on messy drawings |
+| Florence-2 (self-hosted) | $0 (compute only) | RTX 4090 batches 16+ images at once |
+
+For a hobby project, free-tier Gemini Flash plus a few hundred Pro calls on
+hard cases is the practical sweet spot.
+
+## Workflow patterns
+
+### Bootstrap labels → fine-tune small model
+
+1. Hand-label 50 seed images.
+2. Use Robotics-ER to label 1000–10000 more (oracle labels).
+3. Spot-check 10% by hand; reject obvious errors.
+4. Train a small on-device model on the bulk dataset.
+5. Use the seed set + a held-out set as the true validation.
+
+### Oracle-as-baseline
+
+Quote on-device model accuracy as a fraction of oracle accuracy. "Our
+200KB on-device model hits 94% of Gemini Robotics-ER's accuracy at 0%
+of the per-inference cost" is a more compelling number than raw mAP.
+
+### Active learning
+
+Use the oracle to label only images where the on-device model is uncertain.
+Reduces oracle API spend by an order of magnitude.

--- a/docs/requirements/PRD-011-melody-detector.md
+++ b/docs/requirements/PRD-011-melody-detector.md
@@ -1,0 +1,255 @@
+# PRD-011: Melody Detector
+
+**Status**: draft
+**Created**: 2026-04-26
+**Confidence**: 7/10
+
+---
+
+## Overview
+
+Melody Detector is a self-contained children's musical toy. A child draws
+notes on a pre-printed staff sheet, places it under the device's camera,
+presses a button, and hears the melody play back through a built-in
+speaker. All inference runs on-device — no cloud, no WiFi at runtime.
+
+The device is a single XIAO ESP32-S3 Sense board paired with a MAX98357A
+I2S amplifier and a small speaker. Printable A4 staff sheets with corner
+fiducials are checked into the repository and provide the geometric
+ground truth the on-device CV pipeline depends on.
+
+This is also a TinyML showcase: the entire pipeline (synthetic data
+generation, PyTorch training, INT8 quantization, ESP-DL deployment) is
+open source and reproducible from a `gen.py` + seed.
+
+## Problem
+
+Children learning music have a chicken-and-egg problem: composing melodies
+typically requires reading and writing standard notation, but reading and
+writing notation is itself a multi-year skill. Drawing-based interfaces
+collapse the gap — a child who can place a dot on a line can compose a
+melody — and immediate audio feedback turns composition into play. No
+existing affordable toy combines pre-printed staff paper with offline
+on-device note recognition.
+
+## Goals
+
+- Children compose monophonic melodies by drawing on printed sheets
+- Self-contained device: capture, recognize, and play locally with no
+  runtime network dependency
+- Robust to messy real-world drawings (varying note shapes, paper
+  texture, lighting, hand-drawn imperfection)
+- Deployment-ready firmware on a XIAO ESP32-S3 Sense (~$15 board)
+- All-OSS pipeline suitable for a public showcase
+
+## Non-Goals
+
+- No melody composition assistance, autocomplete, or correction
+- No multi-voice / polyphonic playback (monophonic only in v1)
+- No rhythms beyond quarter / half / rest
+- No internet connectivity at runtime (WiFi reserved for OTA only)
+- No editing UI — each capture produces a fresh playback
+- No companion app (v1 is fully standalone)
+
+## User Stories
+
+### Primary user — child (age 5–10)
+
+- **US-01**: As a child, I want to draw notes on a pre-printed sheet and
+  press a button to hear my song, so that I can experience my own
+  composition.
+- **US-02**: As a child, I want to draw approximately (close to but not
+  perfectly on a line) and still have my notes recognized, so that the toy
+  forgives my motor-skill limits.
+- **US-03**: As a child, I want clear feedback (LED + audio chirp) when
+  the toy is reading vs. playing, so that I know what's happening.
+- **US-04**: As a child, I want to hear my song clearly even in a noisy
+  room, so that I can share it with siblings or friends.
+- **US-05**: As a child, I want short, hollow, and rest symbols to
+  produce noticeably different sounds, so that I can hear the structure
+  of my melody.
+
+### Secondary user — parent / educator
+
+- **US-06**: As a parent, I want to print fresh sheets on demand using a
+  standard inkjet printer, so that we don't run out of paper.
+- **US-07**: As a parent, I want the toy to work offline anywhere
+  (camping, car), so that it doesn't depend on WiFi.
+- **US-08**: As a parent, I want pitch-letter labels in the margin of the
+  printable, so that my child can learn note-naming as a side effect of
+  play.
+- **US-09**: As a parent, I want to safely re-flash firmware updates
+  without specialized tools, so that the device stays useful long-term.
+- **US-10**: As an educator, I want a visible class boundary (filled =
+  short, hollow = long, squiggle = rest), so that the recognizable
+  vocabulary scales with the child.
+
+### Tertiary user — developer / showcase audience
+
+- **US-11**: As a developer, I want a reproducible end-to-end OSS
+  pipeline (synthetic data → train → quantize → deploy), so that I can
+  fork and adapt for similar projects.
+- **US-12**: As a developer, I want documented inference benchmarks
+  against a cloud baseline (Gemini Robotics-ER 1.6), so that I can evaluate
+  the on-device accuracy / cost tradeoff.
+- **US-13**: As a developer, I want the synthetic data generator and
+  augmentation parameters documented and seedable, so that experimental
+  results are reproducible.
+- **US-14**: As a maintainer, I want host-based unit tests for the
+  classical-CV stage (no hardware required), so that I can validate
+  pipeline changes in CI.
+
+## Hardware
+
+| Component | Specification |
+|-----------|--------------|
+| MCU | Seeed Studio XIAO ESP32-S3 Sense (dual-core LX7, 8 MB Octal PSRAM, 8 MB flash) |
+| Camera | OV2640 (built into Sense expansion) |
+| DAC / Amp | MAX98357A I2S Class-D amplifier module |
+| Speaker | 3 W 4 Ω or 8 Ω small enclosure speaker |
+| Capture trigger | Tactile push-button on a free GPIO |
+| Status indicator | On-board user LED + (optional) RGB indicator |
+| Power | USB-C (no battery in v1) |
+| Print medium | A4 inkjet paper, standard 80–100 g/m², printed at 100 % scale |
+
+## Features
+
+### Phase 1 — Hardware bring-up + scaffolding
+
+**FR-1.01**: ESP-IDF project skeleton at
+`packages/audio/melody-detector/` registered in the root justfile and
+CI matrix.
+
+**FR-1.02**: Camera capture on button press (single-shot JPEG to PSRAM
+via the on-board OV2640 driver).
+
+**FR-1.03**: I2S audio output stub: 1 kHz test tone confirms the
+amplifier and speaker chain works.
+
+**FR-1.04**: Status LED feedback: distinct patterns for idle / capturing
+/ processing / playing.
+
+### Phase 2 — Classical CV pipeline
+
+**FR-2.01**: Fiducial detection. Locate the four corner markers on the
+captured frame via threshold + contour detection. Identify the oriented
+top-left marker by its inner-dot pattern.
+
+**FR-2.02**: Perspective rectification. Compute a 3 × 3 homography from
+the four fiducial centers to the canonical sheet rectangle and warp the
+frame to a fixed-resolution staff strip.
+
+**FR-2.03**: Staff line refinement. Sum darkness per row in the
+rectified strip; locate the five staff lines as peaks in a known search
+window.
+
+**FR-2.04**: ROI grid extraction. Crop a 32 × 32 px patch at each beat
+column × staff row intersection (default 8 columns × 9 rows). Optionally
+skip patches whose darkness falls below an empty-threshold to save
+inference time.
+
+### Phase 3 — ESP-DL inference
+
+**FR-3.01**: Embed the quantized `.espdl` model in firmware via
+`EMBED_FILES`.
+
+**FR-3.02**: Load the model at boot using the ESP-DL runtime; allocate
+input / output tensors in PSRAM.
+
+**FR-3.03**: Batch ROI inference. Feed the ROI grid through the model;
+return an array of class labels (`empty / quarter / half / rest /
+other`).
+
+### Phase 4 — Audio synthesis + playback
+
+**FR-4.01**: Pitch / frequency lookup table for treble-clef rows (E4
+through F5 inclusive, plus optional ledger-line extensions).
+
+**FR-4.02**: I2S DDS oscillator with sine + square waveforms at 44.1
+kHz, 16-bit.
+
+**FR-4.03**: ADSR envelope per note (attack, decay, sustain, release)
+to avoid clicks at note boundaries.
+
+**FR-4.04**: Sequence playback. Convert the ROI class grid to a
+`[(pitch, duration)]` list (geometric lookup from row + class) and play
+sequentially with configurable tempo.
+
+### Phase 5 — Training pipeline
+
+**FR-5.01**: Synthetic ROI generator (PIL + albumentations). Renders 32
+× 32 px patches for each class with parametrized augmentations: paper
+texture, rotation, scale, blur, noise, ink-bleed, brightness.
+
+**FR-5.02**: PyTorch model definition. Small CNN: 3–4 conv layers,
+~50–200 KB INT8 weights, 5-class softmax output.
+
+**FR-5.03**: Training script with reproducibility (random seed,
+parameter dump, dataset hash on `sha256sum`).
+
+**FR-5.04**: ONNX export with opset compatible with ESP-PPQ.
+
+**FR-5.05**: ESP-PPQ quantization config + calibration data extraction
+(~1 K samples drawn from the synthetic generator).
+
+### Phase 6 — Validation
+
+**FR-6.01**: Real-photo holdout collection (~50–100 photographed kid
+drawings).
+
+**FR-6.02**: Oracle labeling via Gemini Robotics-ER 1.6 with manual
+spot-checking on ~10 % of the holdout.
+
+**FR-6.03**: Per-class accuracy benchmark vs. the cloud baseline.
+
+**FR-6.04**: Inference latency measurement on the XIAO ESP32-S3 Sense.
+
+## Constraints
+
+- **Memory**: 8 MB PSRAM, 8 MB flash. Model + activations must fit in
+  ≤ 1 MB PSRAM.
+- **Latency**: < 1 s from button press to first note.
+- **Power**: USB-C powered, no battery in v1.
+- **Cost**: target BOM under $30 retail (board + amp + speaker +
+  enclosure).
+- **Print fidelity**: A4 sheet on standard inkjet at 100 % scale, no
+  professional printing required.
+- **Offline runtime**: WiFi optional and used only for OTA updates.
+
+## Acceptance Criteria
+
+- [ ] On-device per-ROI classification ≥ 90 % accuracy on the real-photo
+  holdout.
+- [ ] End-to-end latency from button press to first audio sample
+  < 1 second.
+- [ ] Firmware fits the 1.8 MB OTA partition (CI-enforced).
+- [ ] Synthetic dataset reproducible from a single seed +
+  `python gen.py`.
+- [ ] External developer can build, train, and flash the system in
+  under 1 day from a clean checkout.
+- [ ] Documented benchmark vs. Gemini Robotics-ER 1.6 oracle published
+  in the repo README.
+
+## Implementation Order
+
+1. Track A — Project scaffolding (Phase 1)
+2. Track B — Training pipeline (Phase 5) — runs in parallel with A
+3. Track C — Classical CV pipeline (Phase 2) — depends on A
+4. Track D — ESP-DL inference (Phase 3) — depends on A + first model
+   from B
+5. Track E — Audio synthesis (Phase 4) — depends on A
+6. Track F — Main loop integration — depends on A–E
+7. Track G — Validation (Phase 6) — depends on F
+
+Tracks A and B are independent (different languages, different domains)
+and can run in parallel. Tracks C–E share the firmware scaffolding from
+A. Track G closes the loop with hardware-on-device measurements.
+
+## Related Documents
+
+- [ADR-017: ESP-DL for On-Device Vision](../decisions/ADR-017-melody-detector-esp-dl.md)
+- [PRP: Melody Detector Implementation Plan](../prompts/melody-detector.md)
+- [TinyML frameworks reference](../reference/tinyml-esp32-frameworks.md)
+- [Vision labeling services reference](../reference/vision-labeling-services.md)
+- [Synthetic image generation reference](../reference/synthetic-image-generation.md)
+- [Printable staff sheet (LaTeX)](../../packages/audio/melody-detector/sheets/blank-staff.tex)

--- a/packages/audio/melody-detector/sheets/blank-staff.tex
+++ b/packages/audio/melody-detector/sheets/blank-staff.tex
@@ -1,0 +1,131 @@
+% blank-staff.tex - Printable melody sheet for the melody-detector project.
+%
+% Self-contained TikZ document: produces an A4 page with four corner
+% fiducials (for camera alignment), three 5-line staves, beat-column
+% guides, and pitch letter labels in the margin.
+%
+% The geometry here is the ground truth that the on-device CV pipeline
+% (fiducial detect -> homography -> staff-line refine -> ROI extract)
+% relies on. Do not change calibrated constants without also updating
+% the firmware and the synthetic data generator.
+%
+% Build:  pdflatex blank-staff.tex
+% Output: blank-staff.pdf (A4, ready to print at 100% scale)
+
+\documentclass[a4paper,10pt]{article}
+
+\usepackage[a4paper, top=15mm, bottom=15mm, left=15mm, right=15mm]{geometry}
+\usepackage{tikz}
+\usetikzlibrary{calc, positioning}
+
+\setlength{\parindent}{0pt}
+\pagestyle{empty}
+
+% ---------------------------------------------------------------------------
+% Calibrated constants (mm). Keep in sync with firmware + data generator.
+% ---------------------------------------------------------------------------
+\def\fidSize{8}        % side length of corner fiducial (mm)
+\def\fidInset{10}      % distance from page edge to fiducial (mm)
+\def\staffWidth{180}   % staff width (mm)
+\def\staffLineGap{5}   % vertical gap between staff lines (mm)
+\def\beatCount{8}      % number of beat columns per staff
+\def\rowLetters{F,D,B,G,E}  % pitch letters top-to-bottom (treble clef lines)
+
+% ---------------------------------------------------------------------------
+% Fiducial: solid black square with a centred white inner square. Simple
+% enough to detect by threshold + contour; distinctive enough to reject
+% noise. The orientation marker variant adds a black inner dot so the
+% top-left corner is identifiable.
+% ---------------------------------------------------------------------------
+\newcommand{\plainFiducial}[1]{%
+  \begin{scope}[shift={(#1)}]
+    \fill (0,0) rectangle (\fidSize mm, \fidSize mm);
+    \fill[white] (2mm, 2mm) rectangle (\fidSize mm - 2mm, \fidSize mm - 2mm);
+  \end{scope}
+}
+
+\newcommand{\orientedFiducial}[1]{%
+  \begin{scope}[shift={(#1)}]
+    \fill (0,0) rectangle (\fidSize mm, \fidSize mm);
+    \fill[white] (2mm, 2mm) rectangle (\fidSize mm - 2mm, \fidSize mm - 2mm);
+    \fill (3mm, 3mm) rectangle (\fidSize mm - 3mm, \fidSize mm - 3mm);
+  \end{scope}
+}
+
+% ---------------------------------------------------------------------------
+% One empty 5-line staff with beat column guides and pitch labels.
+% Origin at bottom-left of the lowest line. Width = \staffWidth mm.
+% ---------------------------------------------------------------------------
+\newcommand{\drawStaff}{%
+  \begin{tikzpicture}[x=1mm, y=1mm]
+    % 5 staff lines
+    \foreach \i in {0,1,2,3,4} {
+      \draw[line width=0.4pt, black]
+        (0, \i * \staffLineGap) -- (\staffWidth, \i * \staffLineGap);
+    }
+    % Faint beat column guides (interior columns only)
+    \foreach \b in {1,...,7} {
+      \draw[line width=0.2pt, gray!30]
+        ({\b * \staffWidth / \beatCount}, -3) --
+        ({\b * \staffWidth / \beatCount}, {4 * \staffLineGap + 3});
+    }
+    % Beat numbers above the staff
+    \foreach \b in {1,...,8} {
+      \node[gray!50, font=\tiny, anchor=south]
+        at ({(\b - 0.5) * \staffWidth / \beatCount},
+            {4 * \staffLineGap + 4}) {\b};
+    }
+    % Pitch letter labels in the left margin (top-down, so reverse i for line 4..0)
+    \foreach \name [count=\i from 0] in \rowLetters {
+      \node[gray!70, font=\footnotesize\bfseries, anchor=east]
+        at (-4, {(4 - \i) * \staffLineGap}) {\name};
+    }
+  \end{tikzpicture}%
+}
+
+\begin{document}
+
+% Corner fiducials, anchored to the page so position is invariant of
+% the document body content. Top-left uses the oriented variant.
+\begin{tikzpicture}[overlay, remember picture]
+  \orientedFiducial{[xshift=\fidInset mm,
+                     yshift=-\fidInset mm - \fidSize mm]current page.north west}
+  \plainFiducial{[xshift=-\fidInset mm - \fidSize mm,
+                  yshift=-\fidInset mm - \fidSize mm]current page.north east}
+  \plainFiducial{[xshift=\fidInset mm,
+                  yshift=\fidInset mm]current page.south west}
+  \plainFiducial{[xshift=-\fidInset mm - \fidSize mm,
+                  yshift=\fidInset mm]current page.south east}
+\end{tikzpicture}
+
+% Title and metadata block
+\vspace*{6mm}
+\begin{center}
+  {\Large\bfseries My Melody Sheet}\\[3mm]
+  {\footnotesize Name: \rule{50mm}{0.4pt} \hspace{8mm}
+                 Song: \rule{60mm}{0.4pt}}
+\end{center}
+
+\vspace{8mm}
+
+% Three staves, generously spaced
+\drawStaff
+
+\vspace{18mm}
+
+\drawStaff
+
+\vspace{18mm}
+
+\drawStaff
+
+\vfill
+
+% Legend at the bottom
+\begin{center}\footnotesize\itshape
+  Filled circle = short note (1 beat) \quad
+  Hollow circle = long note (2 beats) \quad
+  Squiggle = rest
+\end{center}
+
+\end{document}


### PR DESCRIPTION
## Summary

- Adds **ADR-017** recording the decision to use **ESP-DL v3.x** for on-device vision in a new `melody-detector` project (XIAO ESP32-S3 Sense + MAX98357A I2S amplifier). The toy lets a child draw musical notes on a pre-printed staff sheet, photograph it, and play the melody.
- Adds three reusable reference docs under `docs/reference/` so the alternatives we evaluated are discoverable for future projects without bloating the ADR.

## Files

- `docs/decisions/ADR-017-melody-detector-esp-dl.md` — proposed status. Captures hardware context, the ESP-DL choice, alternatives in one paragraph each, consequences, and implementation notes (project location at `packages/audio/melody-detector/`, RAM/latency budgets, calibration plan).
- `docs/reference/tinyml-esp32-frameworks.md` — comparison of ESP-DL, TFLM + ESP-NN, LiteRT, ExecuTorch, Edge Impulse with strengths / weaknesses and a decision shortcut.
- `docs/reference/vision-labeling-services.md` — Gemini Robotics-ER 1.6, Gemini 3.x, Claude Vision, GPT-4o, plus open-weights options (Florence-2, Qwen2-VL, YOLO-World). Includes April 2026 pricing and a 1000-image cost worked example.
- `docs/reference/synthetic-image-generation.md` — programmatic rendering, augmentation, diffusion (Imagen 4 / FLUX / SDXL), ControlNet hybrid, domain randomization. Cost-quality matrix and reproducibility checklist.

## Decision in one paragraph

PyTorch on the local RTX 4090 → ONNX → ESP-PPQ INT8 quantization → `.espdl` model embedded in firmware. Training data: ~95% programmatically rendered staff sheets with albumentations augmentation, ~5% ControlNet-conditioned diffusion for stylistic variety, validation set labeled by Gemini Robotics-ER 1.6 as oracle. On-device pipeline splits work between classical CV (staff-line detection, ROI extraction) and a tiny INT8 CNN classifier (~50–200 KB).

## Open questions to validate before this leaves "proposed"

- [ ] Confirm `packages/audio/melody-detector/` as the project location (vs `packages/camera-vision/`).
- [ ] Confirm the ROI-classifier model approach over a full object detector.
- [ ] Decide whether to also create a PRD for the product spec.

## Test plan

- [ ] Reviewer reads ADR-017 end-to-end; alternatives summary matches the decision.
- [ ] Reviewer skims the three reference docs for accuracy of pricing / framework status as of April 2026.
- [ ] Markdown renders correctly on GitHub (relative links between ADR and reference docs resolve).

https://claude.ai/code/session_0142LC1yrZS37UWSJt3L1tbw

---
_Generated by [Claude Code](https://claude.ai/code/session_0142LC1yrZS37UWSJt3L1tbw)_