### PR TITLE
fix(schematics): repair render-one + auto-find Homebrew cairo on macOS

### DIFF
--- a/docs/schematics/justfile
+++ b/docs/schematics/justfile
@@ -1,5 +1,20 @@
 project_dir := "docs/schematics"
 
+# On macOS, cairosvg dlopens libcairo.2.dylib via cairocffi but Homebrew
+# installs it under /opt/homebrew/opt/cairo/lib (or /usr/local/opt on Intel),
+# which isn't on the dynamic loader search path by default. macOS SIP scrubs
+# DYLD_* from sh's environment on exec of hardened binaries, so the value has
+# to be inline-prefixed in front of the (non-hardened) `uv` invocation rather
+# than `export`ed at the justfile level. Linux/CI ships libcairo on the system
+# path — the prefix is empty there.
+cairo_dyld := if path_exists("/opt/homebrew/opt/cairo/lib") == "true" {
+    "DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/opt/cairo/lib"
+} else if path_exists("/usr/local/opt/cairo/lib") == "true" {
+    "DYLD_FALLBACK_LIBRARY_PATH=/usr/local/opt/cairo/lib"
+} else {
+    ""
+}
+
 default:
     @just --list
 
@@ -11,13 +26,12 @@ sync:
 # Render every circuit in circuits/ to SVG + PNG in images/
 [group: "build"]
 render: sync
-    uv run python render.py
+    {{cairo_dyld}} uv run python render.py
 
 # Render a single circuit by name (without .py), e.g. `just schematics::render-one gamepad_synth`
 [group: "build"]
 render-one name: sync
-    uv run python circuits/{{name}}.py images/{{name}}.svg
-    uv run python -c "import cairosvg; cairosvg.svg2png(url='images/{{name}}.svg', write_to='images/{{name}}.png', output_width=1400)"
+    {{cairo_dyld}} uv run python render.py {{name}}
 
 # Delete generated images
 [group: "clean"]

--- a/docs/schematics/render.py
+++ b/docs/schematics/render.py
@@ -1,8 +1,9 @@
-"""Render every circuit in ``circuits/`` to SVG + PNG in ``images/``.
+"""Render circuits in ``circuits/`` to SVG + PNG in ``images/``.
 
 Each file in ``circuits/`` that defines a ``draw() -> Drawing`` function is
-rendered. Run with ``just schematics::render`` or directly via
-``python render.py``.
+rendered. Run with ``just schematics::render`` (all circuits) or
+``just schematics::render-one <name>`` (single circuit), or directly via
+``python render.py [name ...]``.
 """
 
 from __future__ import annotations
@@ -28,14 +29,22 @@ def _load_module(path: Path):
     return mod
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    names = list(argv) if argv is not None else sys.argv[1:]
     sys.path.insert(0, str(ROOT))
     IMAGES.mkdir(exist_ok=True)
 
-    circuit_files = sorted(CIRCUITS.glob("*.py"))
-    if not circuit_files:
-        print(f"no circuits found in {CIRCUITS}", file=sys.stderr)
-        return 1
+    if names:
+        circuit_files = [CIRCUITS / f"{name}.py" for name in names]
+        missing = [str(p) for p in circuit_files if not p.is_file()]
+        if missing:
+            print(f"no such circuit(s): {', '.join(missing)}", file=sys.stderr)
+            return 1
+    else:
+        circuit_files = sorted(CIRCUITS.glob("*.py"))
+        if not circuit_files:
+            print(f"no circuits found in {CIRCUITS}", file=sys.stderr)
+            return 1
 
     for py in circuit_files:
         if py.stem.startswith("_"):


### PR DESCRIPTION
## Summary

Two pre-existing bugs in the schemdraw rendering tooling, surfaced while regenerating `gamepad_synth.png` in #286.

- **#284 — `render-one` ModuleNotFoundError**: the recipe ran `python circuits/<name>.py` directly, so `sys.path[0]` was `circuits/` and the sibling `components.py` at `docs/schematics/components.py` couldn't be imported. `render.py` now accepts positional circuit-name args and the recipe delegates to it — single code path, single `sys.path` setup, useful "no such circuit" error if the name is wrong.
- **#285 — cairo dlopen on macOS**: `cairosvg` → `cairocffi` dlopens `libcairo.2.dylib`, which Homebrew installs under `/opt/homebrew/opt/cairo/lib` (or `/usr/local/opt` on Intel) — not on the dynamic loader path. Auto-detected via `path_exists`. **Note:** macOS SIP scrubs `DYLD_*` on exec of hardened binaries (`/bin/sh`, `/usr/bin/env`), so `export DYLD_FALLBACK_LIBRARY_PATH := …` at the justfile level doesn't survive into the recipe. The fix inline-prefixes the assignment in front of the (non-hardened) `uv` invocation, which keeps the value on the exec environment that `uv` then passes to Python. Linux/CI gets an empty prefix and continues to use the system libcairo unchanged.

## Test plan

- [x] `just schematics::render-one gamepad_synth` → `rendered gamepad_synth …`
- [x] `just schematics::render` → renders both circuits
- [x] `just schematics::render-one nope` → fails fast with `no such circuit(s): …/circuits/nope.py`
- [x] No accidental SVG/PNG drift staged (verified with `git diff --staged --stat`)

Closes #284, closes #285.

🤖 Generated with [Claude Code](https://claude.com/claude-code)