### PR TITLE
ci(schematics): fail PRs when rendered SVGs drift from source

### DIFF
--- a/.github/workflows/schematics-check.yml
+++ b/.github/workflows/schematics-check.yml
@@ -1,0 +1,59 @@
+name: Schematics Up-to-Date Check
+
+on:
+  push:
+    branches: [main, develop, 'claude/**']
+    paths:
+      - 'docs/schematics/**'
+      - '.github/workflows/schematics-check.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'docs/schematics/**'
+      - '.github/workflows/schematics-check.yml'
+  workflow_dispatch:
+
+jobs:
+  svgs-up-to-date:
+    name: Verify rendered SVGs match circuit source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # cairosvg dlopens libcairo at import time. Ubuntu runners don't ship
+      # it by default in all images, so install explicitly.
+      - name: Install system cairo
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libcairo2
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Install Python deps
+        working-directory: docs/schematics
+        run: uv sync
+
+      - name: Render all circuits
+        working-directory: docs/schematics
+        run: uv run python render.py
+
+      # SVGs are byte-deterministic from schemdraw, so a diff means the
+      # author edited circuits/<name>.py without committing the regenerated
+      # image. PNG output via cairosvg is encoder-version-sensitive — we
+      # skip the strict PNG check on purpose.
+      - name: Verify SVGs are up to date
+        run: |
+          if ! git diff --exit-code -- 'docs/schematics/images/*.svg'; then
+            echo "::error::Rendered SVG(s) are out of sync with circuit source."
+            echo "::error::Run 'just schematics::render' locally and commit the regenerated images."
+            exit 1
+          fi
+
+      - name: Surface incidental PNG drift
+        if: always()
+        run: |
+          if ! git diff --quiet -- 'docs/schematics/images/*.png'; then
+            echo "::notice::PNG(s) differ from committed copy — likely cairo encoder version drift across machines, not a content change. Not failing the build."
+          fi


### PR DESCRIPTION
## Summary

Adds a CI check that re-renders all schemdraw circuits and fails the PR if `docs/schematics/images/*.svg` would differ — i.e., someone edited a `circuits/<name>.py` file without committing the regenerated image.

- **Triggers** on changes under `docs/schematics/**` (or to the workflow itself), on `pull_request` to `main`/`develop` and `push` to `main`/`develop`/`claude/**`.
- **SVG-only strict check**. schemdraw's SVG output is byte-deterministic across runs and machines, so a `git diff` is reliable signal.
- **PNG drift is informational**. cairosvg PNG bytes vary with the system cairo version (we hit this in #287), so a strict PNG check would create spurious failures on local-vs-CI version drift. The job posts a `::notice` if PNGs differ but does not fail.

## Why check-only (not auto-commit)

Auto-commit would need `contents: write` and a bot-rerun loop on the PR. Check-only with a clear "run `just schematics::render` and commit the result" error message keeps the contract simple — the author owns the regen.

## Test plan

- [ ] CI green on this PR (no schematic source changes, so no diff)
- [ ] Manual follow-up test on a future PR that edits a circuit without re-rendering — should fail with the documented error
- [x] `actionlint .github/workflows/schematics-check.yml` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)