### PR TITLE
feat(presence-detector): import XIAO ESP32-C6 + LD2410 mmWave ESPHome project

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ mod thinkpack-boombox 'packages/thinkpack/boombox'
 mod thinkpack-brainbox 'packages/thinkpack/brainbox'
 mod thinkpack-chatterbox 'packages/thinkpack/chatterbox'
 mod thinkpack-finderbox 'packages/thinkpack/finderbox'
+mod presence-detector 'packages/sensors/presence-detector'
 mod schematics 'docs/schematics'
 
 # Auto-detect ESP32-S3 USB-Serial-JTAG by Espressif VID; override with S3_PORT env var
@@ -295,6 +296,7 @@ list-projects:
     [ -d "packages/audio/kids-audio-toy" ]              && echo "  kids-audio-toy              — Potentiometer-controlled audio toy"      || true
     [ -d "packages/audio/audiobook-player" ]            && echo "  audiobook-player            — ESPHome audiobook player"                || true
     [ -d "packages/networking/wireguard-ha" ]  && echo "  esp32-wireguard-ha-example  — WireGuard + Home Assistant (ESPHome)"    || true
+    [ -d "packages/sensors/presence-detector" ] && echo "  presence-detector           — XIAO ESP32-C6 + LD2410 mmWave (ESPHome)"  || true
     echo ""
     echo "Use 'just <module>::build' to build individual projects."
     echo "Module names: just --list --list-submodules"

--- a/packages/sensors/presence-detector/README.md
+++ b/packages/sensors/presence-detector/README.md
@@ -1,0 +1,37 @@
+# Presence Detector
+
+ESPHome firmware for a 24 GHz mmWave human-presence sensor built on a
+Seeed Studio XIAO ESP32-C6 + Hi-Link LD2410. Reports presence, moving /
+still target distance, per-gate energy levels, and acts as a Bluetooth
+proxy for Home Assistant.
+
+## Hardware
+
+- **MCU:** [Seeed Studio XIAO ESP32-C6](https://wiki.seeedstudio.com/xiao_esp32c6_getting_started/) (4 MB flash)
+- **Sensor:** Hi-Link [LD2410](https://esphome.io/components/sensor/ld2410.html) 24 GHz mmWave radar
+- **Reference build:** [24 GHz mmWave for XIAO](https://wiki.seeedstudio.com/mmwave_for_xiao/)
+
+## Wiring
+
+| Signal       | XIAO pin |
+|--------------|----------|
+| LD2410 TX    | GPIO02   |
+| LD2410 RX    | GPIO21   |
+| UART baud    | 256000 8N1 |
+
+## Quick start
+
+```bash
+just init           # install ESPHome + create secrets.yaml from template
+$EDITOR secrets.yaml
+just upload         # first USB flash
+just wireless       # subsequent OTA updates
+just logs           # tail device logs (auto-detect USB, fall back to OTA)
+```
+
+## Background reading
+
+- [LD2410 component docs (ESPHome)](https://esphome.io/components/sensor/ld2410.html)
+- [ESP32 platform docs (esphome-docs/components/esp32.rst)](https://github.com/esphome/esphome-docs/blob/current/components/esp32.rst)
+- [DIY mmWave Presence Sensor walkthrough (digiblurDIY)](https://digiblur.com/2023/05/24/esphome-mmwave-presence-how-to-guide/)
+- [ESP32-C6 ESPHome support tracker](https://github.com/esphome/feature-requests/issues/2176)

--- a/packages/sensors/presence-detector/justfile
+++ b/packages/sensors/presence-detector/justfile
@@ -1,0 +1,88 @@
+# Presence Detector — ESPHome project (XIAO ESP32-C6 + LD2410 mmWave)
+# Run `just --list` to see available recipes
+
+import '../../../tools/esphome.just'
+
+device_name := "presence-detector"
+config_file := device_name + ".yaml"
+secrets_file := "secrets.yaml"
+secrets_example := "secrets.yaml.example"
+
+default:
+    @just --list
+
+# Create secrets.yaml from template
+[group: "setup"]
+config: _esphome-config
+
+# Initial setup: install ESPHome and create config
+[group: "setup"]
+init: install config
+    @echo ""
+    @echo "Initialization complete!"
+    @echo "Next steps:"
+    @echo "  1. Edit {{secrets_file}} with your WiFi credentials"
+    @echo "  2. Run 'just upload' to flash the device via USB"
+    @echo "  3. Run 'just logs' to view device logs"
+
+# Compile and upload via USB (auto-detects serial port)
+[group: "flash"]
+upload:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -f {{secrets_file}} ]; then
+        echo "Error: {{secrets_file}} not found — run 'just config' first"
+        exit 1
+    fi
+    PORT=$(ls /dev/cu.* 2>/dev/null | grep -E "(usbserial|SLAB|wchusbserial|usbmodem)" | head -1)
+    if [ -z "$PORT" ]; then
+        echo "Error: No ESP32 device found on USB"
+        echo "Available ports:"
+        ls /dev/cu.* 2>/dev/null | grep -v -E "(Bluetooth|debug|Suunto)" || echo "  None found"
+        exit 1
+    fi
+    echo "Found device at $PORT"
+    esphome run {{config_file}} --device "$PORT"
+
+# First USB flash (run before wireless updates are possible)
+[group: "flash"]
+first-flash: config upload
+    @echo ""
+    @echo "First flash complete! Future updates: just wireless"
+
+# View device logs via USB (auto-detects, falls back to OTA)
+[group: "monitor"]
+logs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    PORT=$(ls /dev/cu.* 2>/dev/null | grep -E "(usbserial|SLAB|wchusbserial|usbmodem)" | head -1)
+    if [ -z "$PORT" ]; then
+        echo "No USB device found, trying OTA..."
+        esphome logs {{config_file}} --device {{device_name}}.local
+    else
+        echo "Monitoring $PORT"
+        esphome logs {{config_file}} --device "$PORT"
+    fi
+
+# View device logs via WiFi OTA
+[group: "monitor"]
+logs-wireless:
+    esphome logs {{config_file}} --device {{device_name}}.local
+
+# Alias for logs
+[group: "monitor"]
+monitor: logs
+
+# Display pin assignment reference
+[group: "info"]
+pins:
+    @echo "LD2410 mmWave sensor (UART):"
+    @echo "  RX → GPIO02 (ESP32-C6 TX)"
+    @echo "  TX → GPIO21 (ESP32-C6 RX)"
+    @echo "  Baud: 256000 8N1"
+    @echo ""
+    @echo "Board: Seeed Studio XIAO ESP32-C6 (4MB flash)"
+
+# Quick dev cycle: upload then watch logs
+[group: "device"]
+develop: upload logs

--- a/packages/sensors/presence-detector/presence-detector.yaml
+++ b/packages/sensors/presence-detector/presence-detector.yaml
@@ -1,0 +1,222 @@
+esphome:
+  name: presence-detector
+  friendly_name: "Presence Detector"
+  platformio_options:
+    board_build.f_flash: 40000000L
+    board_build.flash_mode: dio
+    board_build.flash_size: 4MB
+    board_build.variant: esp32c6
+
+esp32:
+  board: esp32-c6-devkitc-1
+  flash_size: 4MB
+  variant: esp32c6
+  framework:
+    type: esp-idf
+    version: "5.2.2"
+    platform_version: 6.7.0
+    sdkconfig_options:
+      CONFIG_OPENTHREAD_ENABLED: n
+      CONFIG_ENABLE_WIFI_STATION: y
+      CONFIG_USE_MINIMAL_MDNS: y
+      COMPILER_OPTIMIZATION_SIZE: y
+      CONFIG_ESPTOOLPY_FLASHSIZE_4MB: y
+
+logger:
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  ap:
+    ssid: "Presence-Detector Fallback"
+    password: !secret fallback_password
+
+captive_portal:
+
+# https://esphome.io/components/bluetooth_proxy.html
+bluetooth_proxy:
+  active: true
+
+esp32_ble_tracker:
+  scan_parameters:
+    interval: 1100ms
+    window: 1100ms
+
+uart:
+  rx_pin: GPIO02
+  tx_pin: GPIO21
+  baud_rate: 256000
+  stop_bits: 1
+  parity: NONE
+
+ld2410:
+
+switch:
+  - platform: ld2410
+    engineering_mode:
+      name: "engineering mode"
+    bluetooth:
+      name: "control bluetooth"
+
+binary_sensor:
+  - platform: ld2410
+    has_target:
+      name: Presence
+    has_moving_target:
+      name: Moving Target
+    has_still_target:
+      name: Still Target
+    out_pin_presence_status:
+      name: out pin presence status
+
+sensor:
+  - platform: ld2410
+    light:
+      name: light
+    moving_distance:
+      name: Moving Distance
+    still_distance:
+      name: Still Distance
+    moving_energy:
+      name: Move Energy
+    still_energy:
+      name: Still Energy
+    detection_distance:
+      name: Detection Distance
+    g0:
+      move_energy:
+        name: g0 move energy
+      still_energy:
+        name: g0 still energy
+    g1:
+      move_energy:
+        name: g1 move energy
+      still_energy:
+        name: g1 still energy
+    g2:
+      move_energy:
+        name: g2 move energy
+      still_energy:
+        name: g2 still energy
+    g3:
+      move_energy:
+        name: g3 move energy
+      still_energy:
+        name: g3 still energy
+    g4:
+      move_energy:
+        name: g4 move energy
+      still_energy:
+        name: g4 still energy
+    g5:
+      move_energy:
+        name: g5 move energy
+      still_energy:
+        name: g5 still energy
+    g6:
+      move_energy:
+        name: g6 move energy
+      still_energy:
+        name: g6 still energy
+    g7:
+      move_energy:
+        name: g7 move energy
+      still_energy:
+        name: g7 still energy
+    g8:
+      move_energy:
+        name: g8 move energy
+      still_energy:
+        name: g8 still energy
+
+number:
+  - platform: ld2410
+    timeout:
+      name: timeout
+    light_threshold:
+      name: light threshold
+    max_move_distance_gate:
+      name: max move distance gate
+    max_still_distance_gate:
+      name: max still distance gate
+    g0:
+      move_threshold:
+        name: g0 move threshold
+      still_threshold:
+        name: g0 still threshold
+    g1:
+      move_threshold:
+        name: g1 move threshold
+      still_threshold:
+        name: g1 still threshold
+    g2:
+      move_threshold:
+        name: g2 move threshold
+      still_threshold:
+        name: g2 still threshold
+    g3:
+      move_threshold:
+        name: g3 move threshold
+      still_threshold:
+        name: g3 still threshold
+    g4:
+      move_threshold:
+        name: g4 move threshold
+      still_threshold:
+        name: g4 still threshold
+    g5:
+      move_threshold:
+        name: g5 move threshold
+      still_threshold:
+        name: g5 still threshold
+    g6:
+      move_threshold:
+        name: g6 move threshold
+      still_threshold:
+        name: g6 still threshold
+    g7:
+      move_threshold:
+        name: g7 move threshold
+      still_threshold:
+        name: g7 still threshold
+    g8:
+      move_threshold:
+        name: g8 move threshold
+      still_threshold:
+        name: g8 still threshold
+
+button:
+  - platform: ld2410
+    factory_reset:
+      name: "factory reset"
+    restart:
+      name: "restart"
+    query_params:
+      name: query params
+
+text_sensor:
+  - platform: ld2410
+    version:
+      name: "firmware version"
+    mac_address:
+      name: "mac address"
+
+select:
+  - platform: ld2410
+    distance_resolution:
+      name: "distance resolution"
+    baud_rate:
+      name: "baud rate"
+    light_function:
+      name: light function
+    out_pin_level:
+      name: out pin level

--- a/packages/sensors/presence-detector/secrets.yaml.example
+++ b/packages/sensors/presence-detector/secrets.yaml.example
@@ -1,0 +1,14 @@
+# ESPHome Secrets Template
+# Copy this file to secrets.yaml and fill in your values
+
+wifi_ssid: "YourWiFiSSID"
+wifi_password: "YourWiFiPassword"
+
+# Generate encryption key with: esphome run presence-detector.yaml
+api_encryption_key: "your-generated-api-key-here"
+
+# OTA password for over-the-air updates
+ota_password: "your-ota-password-here"
+
+# Fallback AP password (when WiFi fails)
+fallback_password: "presence123"


### PR DESCRIPTION
## Summary

- Migrates the standalone `~/repos/laurigates/esp32c6` ESPHome project (XIAO ESP32-C6 + Hi-Link LD2410 24 GHz mmWave radar) into the monorepo as a new `packages/sensors/` domain.
- Adapts to monorepo conventions: hostname renamed to match the project dir (`presence-detector`), inline WiFi/API/OTA passwords replaced with `!secret` references plus a `secrets.yaml.example` template, justfile imports the shared `tools/esphome.just`.
- Registered as `mod presence-detector` in the root justfile and added to the project status listing.

## What's preserved from the original

Same hardware, same `ld2410:` component surface (presence / moving / still-target binary sensors, per-gate energy gates, switches, numbers, buttons, text sensors, selects, plus the Bluetooth proxy and ESP32 BLE tracker scan parameters). UART pins (RX=GPIO02, TX=GPIO21, 256000 8N1) unchanged.

## Test plan

- [ ] `just presence-detector::init` succeeds, creates `secrets.yaml`
- [ ] After populating `secrets.yaml`, `esphome config presence-detector.yaml` validates clean
- [ ] First USB flash reaches the device and Home Assistant API connects
- [ ] LD2410 readings (presence, distance, energies) appear in HA
- [ ] Bluetooth proxy advertises BLE devices to HA

🤖 Generated with [Claude Code](https://claude.com/claude-code)