### PR TITLE
feat(melody-train): export trained checkpoint to ONNX (B3)

### DIFF
--- a/packages/audio/melody-detector/training/pyproject.toml
+++ b/packages/audio/melody-detector/training/pyproject.toml
@@ -36,6 +36,8 @@ dev = [
     "pytest-cov>=4.1",
     "ruff>=0.5",
     "ty",
+    "onnx>=1.16",
+    "onnxscript>=0.1",
 ]
 
 [project.scripts]

--- a/packages/audio/melody-detector/training/src/melody_train/export.py
+++ b/packages/audio/melody-detector/training/src/melody_train/export.py
@@ -1,0 +1,201 @@
+"""Export the trained ROI classifier from PyTorch to ONNX.
+
+Wraps :class:`MelodyClassifier` in a small shim that takes float32
+input in ``[0, 255]`` and applies the same ``(x - 128) / 128``
+normalization as ``MelodyClassifier._normalize`` — but as explicit
+``Sub``/``Div`` ops on float32 input so they survive ONNX export. ESP-PPQ
+folds those ops into the first Conv weights during INT8 quantization, so
+the on-device runtime can pass raw camera bytes (cast to float on the
+host side of ESP-DL) straight into ``model->run()`` without any C++
+pre-processing.
+
+ONNX export uses ``opset_version=17`` (ESP-PPQ requirement) and
+``training=torch.onnx.TrainingMode.EVAL`` so BatchNorm folds into the
+preceding Conv in the exported graph. ``dynamic_axes`` flexes the batch
+dimension so ESP-PPQ can run calibration with a different batch size.
+
+CLI entry-point at the bottom.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import click
+import torch
+from torch import nn
+
+from melody_train.model import INPUT_CHANNELS, INPUT_SIZE, MelodyClassifier
+
+
+@dataclass(frozen=True)
+class ExportConfig:
+    checkpoint_path: pathlib.Path
+    out_path: pathlib.Path
+    opset_version: int = 17
+    input_name: str = "input"
+    output_name: str = "output"
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    onnx_path: pathlib.Path
+    opset_version: int
+    input_name: str
+    output_name: str
+
+
+# ----------------------------------------------------------------- shim ----
+
+
+class _ExportShim(nn.Module):
+    """Wrap a trained MelodyClassifier for ONNX export with in-graph normalization.
+
+    Accepts float32 input in ``[0, 255]`` (the natural representation for
+    raw camera bytes) and applies ``(x - 128) / 128`` as explicit Sub/Div
+    ops before the model body. These ops fold into the first Conv weights
+    during ESP-PPQ quantization.
+
+    The shim bypasses :meth:`MelodyClassifier._normalize` because that
+    branch only triggers for uint8 input, and ONNX export with uint8
+    inputs emits Cast ops that ESP-PPQ does not handle uniformly across
+    versions.
+    """
+
+    def __init__(self, model: MelodyClassifier) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = (x - 128.0) / 128.0
+        x = self.model.block1(x)
+        x = self.model.block2(x)
+        x = self.model.block3(x)
+        x = self.model.pool(x)
+        x = torch.flatten(x, 1)
+        x = self.model.classifier(x)
+        return x
+
+
+# --------------------------------------------------------------- export ----
+
+
+def _load_checkpoint(checkpoint_path: pathlib.Path) -> MelodyClassifier:
+    if not checkpoint_path.exists():
+        raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+    payload = torch.load(checkpoint_path, weights_only=True, map_location="cpu")
+    if "model_state" not in payload:
+        raise ValueError(
+            f"Checkpoint at {checkpoint_path} missing 'model_state' key — "
+            "expected the dict format saved by melody_train.train"
+        )
+    model = MelodyClassifier()
+    model.load_state_dict(payload["model_state"])
+    model.eval()
+    return model
+
+
+def export(cfg: ExportConfig) -> ExportResult:
+    """Export the checkpoint at ``cfg.checkpoint_path`` to ONNX."""
+    model = _load_checkpoint(cfg.checkpoint_path)
+    shim = _ExportShim(model).eval()
+
+    cfg.out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    dummy = torch.randint(
+        0,
+        256,
+        (1, INPUT_CHANNELS, INPUT_SIZE, INPUT_SIZE),
+        dtype=torch.float32,
+    )
+
+    with torch.no_grad():
+        # dynamo=False selects the legacy TorchScript-based exporter, which
+        # natively emits opset 17 — the new dynamo exporter targets opset 18
+        # and fails when asked to downgrade to 17 because of a Reshape node
+        # without a constant `axes` initializer. ESP-PPQ pins opset 17, so
+        # the legacy path is the right one here.
+        torch.onnx.export(
+            shim,
+            (dummy,),
+            str(cfg.out_path),
+            opset_version=cfg.opset_version,
+            training=torch.onnx.TrainingMode.EVAL,
+            input_names=[cfg.input_name],
+            output_names=[cfg.output_name],
+            dynamic_axes={
+                cfg.input_name: {0: "batch"},
+                cfg.output_name: {0: "batch"},
+            },
+            do_constant_folding=True,
+            dynamo=False,
+        )
+
+    return ExportResult(
+        onnx_path=cfg.out_path,
+        opset_version=cfg.opset_version,
+        input_name=cfg.input_name,
+        output_name=cfg.output_name,
+    )
+
+
+# --------------------------------------------------------- CLI entry-point ---
+
+
+@click.command()
+@click.option(
+    "--checkpoint",
+    "checkpoint_path",
+    type=click.Path(dir_okay=False, path_type=pathlib.Path),
+    default=pathlib.Path("runs/best.pt"),
+    show_default=True,
+    help="Trained checkpoint produced by melody_train.train.",
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(dir_okay=False, path_type=pathlib.Path),
+    default=pathlib.Path("runs/model.onnx"),
+    show_default=True,
+    help="Destination ONNX file.",
+)
+@click.option(
+    "--opset",
+    "opset_version",
+    type=int,
+    default=17,
+    show_default=True,
+    help="ONNX opset version (ESP-PPQ requires 17).",
+)
+def _cli(**kwargs: Any) -> None:
+    cfg = ExportConfig(**kwargs)
+    result = export(cfg)
+    click.echo(
+        f"onnx -> {result.onnx_path} "
+        f"(opset={result.opset_version}, "
+        f"input={result.input_name}, output={result.output_name})"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns process exit code."""
+    try:
+        _cli.main(args=argv, standalone_mode=False)
+    except click.exceptions.UsageError as exc:
+        click.echo(f"Error: {exc.format_message()}", err=True)
+        return 2
+    except click.exceptions.Abort:
+        return 130
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        return 1
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/audio/melody-detector/training/tests/test_export.py
+++ b/packages/audio/melody-detector/training/tests/test_export.py
@@ -1,0 +1,319 @@
+"""Tests for the melody-detector ONNX export pipeline.
+
+Covers:
+- ``ExportConfig`` / ``ExportResult`` dataclass shape
+- ``export()`` produces a loadable ONNX file at the requested opset
+- BatchNorm is folded into the preceding Conv (no standalone
+  ``BatchNormalization`` op in the graph)
+- The normalization Sub/Div ops appear in the graph (so ESP-PPQ has
+  something to fold into the first Conv weights)
+- Forward parity between the PyTorch model and the exported ONNX (only
+  runs when ``onnxruntime`` is installed; ``[quantize]`` extra brings
+  it in)
+- CLI surface — ``main([...])`` returns 0 on success, nonzero on bad args
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+
+# ----------------------------------------------------------------- helpers ----
+
+
+def _save_dummy_checkpoint(out_dir: Path, seed: int = 0) -> Path:
+    """Save an untrained MelodyClassifier checkpoint in train.py's format."""
+    from melody_train.model import MelodyClassifier
+
+    torch.manual_seed(seed)
+    model = MelodyClassifier()
+    out_path = out_dir / "best.pt"
+    torch.save(
+        {
+            "model_state": model.state_dict(),
+            "epoch": 1,
+            "val_accuracy": 0.5,
+            "config": {},
+        },
+        out_path,
+    )
+    return out_path
+
+
+@pytest.fixture
+def dummy_checkpoint(tmp_path: Path) -> Path:
+    return _save_dummy_checkpoint(tmp_path, seed=0)
+
+
+@pytest.fixture
+def exported_onnx(tmp_path: Path, dummy_checkpoint: Path) -> Path:
+    """Export the dummy checkpoint to ONNX and return the path."""
+    from melody_train.export import ExportConfig, export
+
+    out = tmp_path / "model.onnx"
+    cfg = ExportConfig(checkpoint_path=dummy_checkpoint, out_path=out)
+    export(cfg)
+    return out
+
+
+# ------------------------------------------------------- ExportConfig shape ----
+
+
+class TestExportConfig:
+    def test_instantiate_with_required_fields(self, tmp_path):
+        from melody_train.export import ExportConfig
+
+        cfg = ExportConfig(
+            checkpoint_path=tmp_path / "best.pt",
+            out_path=tmp_path / "model.onnx",
+        )
+        assert cfg.checkpoint_path == tmp_path / "best.pt"
+        assert cfg.out_path == tmp_path / "model.onnx"
+
+    def test_defaults(self, tmp_path):
+        from melody_train.export import ExportConfig
+
+        cfg = ExportConfig(
+            checkpoint_path=tmp_path / "best.pt",
+            out_path=tmp_path / "model.onnx",
+        )
+        assert cfg.opset_version == 17
+        assert cfg.input_name == "input"
+        assert cfg.output_name == "output"
+
+    def test_is_frozen(self, tmp_path):
+        from melody_train.export import ExportConfig
+
+        cfg = ExportConfig(
+            checkpoint_path=tmp_path / "best.pt",
+            out_path=tmp_path / "model.onnx",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            cfg.opset_version = 18  # type: ignore[misc]
+
+
+class TestExportResult:
+    def test_instantiate(self, tmp_path):
+        from melody_train.export import ExportResult
+
+        result = ExportResult(
+            onnx_path=tmp_path / "model.onnx",
+            opset_version=17,
+            input_name="input",
+            output_name="output",
+        )
+        assert result.onnx_path == tmp_path / "model.onnx"
+        assert result.opset_version == 17
+
+    def test_is_frozen(self, tmp_path):
+        from melody_train.export import ExportResult
+
+        result = ExportResult(
+            onnx_path=tmp_path / "model.onnx",
+            opset_version=17,
+            input_name="input",
+            output_name="output",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            result.opset_version = 18  # type: ignore[misc]
+
+
+# ----------------------------------------------------- export() behaviour ----
+
+
+class TestExportFile:
+    def test_export_creates_file(self, tmp_path, dummy_checkpoint):
+        from melody_train.export import ExportConfig, export
+
+        out = tmp_path / "model.onnx"
+        result = export(ExportConfig(checkpoint_path=dummy_checkpoint, out_path=out))
+
+        assert out.exists()
+        assert out.stat().st_size > 0
+        assert result.onnx_path == out
+
+    def test_export_creates_parent_dirs(self, tmp_path, dummy_checkpoint):
+        from melody_train.export import ExportConfig, export
+
+        out = tmp_path / "nested" / "subdir" / "model.onnx"
+        export(ExportConfig(checkpoint_path=dummy_checkpoint, out_path=out))
+
+        assert out.exists()
+
+    def test_export_size_under_50kb(self, exported_onnx):
+        # MelodyClassifier is ~2.5K params (~10 KB float32 ONNX), well under 50 KB.
+        # If this trips, something has gone very wrong (extra weights, debug data).
+        assert exported_onnx.stat().st_size < 50_000
+
+    def test_missing_checkpoint_raises(self, tmp_path):
+        from melody_train.export import ExportConfig, export
+
+        with pytest.raises(FileNotFoundError):
+            export(
+                ExportConfig(
+                    checkpoint_path=tmp_path / "nope.pt",
+                    out_path=tmp_path / "model.onnx",
+                )
+            )
+
+
+class TestExportGraphInvariants:
+    def test_loadable_via_onnx(self, exported_onnx):
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        onnx.checker.check_model(model)
+
+    def test_opset_version_is_17(self, exported_onnx):
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        # The default ONNX domain ('') carries the opset version.
+        default_opsets = [o.version for o in model.opset_import if o.domain in ("", "ai.onnx")]
+        assert default_opsets, "no default-domain opset import"
+        assert default_opsets[0] == 17, f"expected opset 17, got {default_opsets[0]}"
+
+    def test_no_standalone_batchnorm(self, exported_onnx):
+        """EVAL-mode export folds BatchNorm into the preceding Conv."""
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        op_types = {n.op_type for n in model.graph.node}
+        assert "BatchNormalization" not in op_types, (
+            f"BN should be folded; graph contains: {sorted(op_types)}"
+        )
+
+    def test_normalization_sub_div_present(self, exported_onnx):
+        """The (x-128)/128 normalization survives as Sub/Div ops in the graph."""
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        op_types = {n.op_type for n in model.graph.node}
+        assert "Sub" in op_types, "Sub op missing — normalization not in graph"
+        assert "Div" in op_types, "Div op missing — normalization not in graph"
+
+    def test_first_meaningful_op_is_normalization(self, exported_onnx):
+        """The first op operating on the input tensor is the Sub of (x-128)."""
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        # Walk the graph topologically starting at "input"; the first node
+        # that consumes "input" should be Sub (the normalization), not Conv.
+        consumers = [n for n in model.graph.node if "input" in list(n.input)]
+        assert consumers, "no node consumes the 'input' tensor"
+        assert consumers[0].op_type == "Sub", (
+            f"first consumer of 'input' should be Sub (normalization), got {consumers[0].op_type}"
+        )
+
+    def test_io_names(self, exported_onnx):
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        assert [i.name for i in model.graph.input] == ["input"]
+        assert [o.name for o in model.graph.output] == ["output"]
+
+    def test_input_shape_is_dynamic_batch(self, exported_onnx):
+        """Batch dim should be a symbolic 'batch'; channels/H/W fixed at 1/32/32."""
+        import onnx
+
+        model = onnx.load(str(exported_onnx))
+        input_proto = model.graph.input[0]
+        dims = input_proto.type.tensor_type.shape.dim
+        assert len(dims) == 4
+        # Batch dim is symbolic
+        assert dims[0].dim_param == "batch" or dims[0].dim_value == 0
+        assert dims[1].dim_value == 1
+        assert dims[2].dim_value == 32
+        assert dims[3].dim_value == 32
+
+
+class TestForwardParity:
+    """Numerical parity between PyTorch shim and ONNX runtime.
+
+    Skipped when onnxruntime isn't installed (it's only in the [quantize]
+    extra). The graph-inspection invariants above already catch structural
+    breakage; this test is the belt-and-braces numerical check.
+    """
+
+    def test_pytorch_onnx_outputs_match(self, tmp_path, dummy_checkpoint, exported_onnx):
+        ort = pytest.importorskip("onnxruntime")
+        import numpy as np
+
+        from melody_train.export import _ExportShim
+        from melody_train.model import MelodyClassifier
+
+        # Reload the same checkpoint into a fresh model + shim
+        payload = torch.load(dummy_checkpoint, weights_only=True)
+        model = MelodyClassifier()
+        model.load_state_dict(payload["model_state"])
+        model.eval()
+        shim = _ExportShim(model).eval()
+
+        x = torch.rand(2, 1, 32, 32) * 255.0
+        with torch.no_grad():
+            torch_out = shim(x).numpy()
+
+        sess = ort.InferenceSession(str(exported_onnx), providers=["CPUExecutionProvider"])
+        onnx_out = sess.run(None, {"input": x.numpy()})[0]
+
+        np.testing.assert_allclose(torch_out, onnx_out, rtol=1e-4, atol=1e-5)
+
+
+# ------------------------------------------------------------------- CLI ----
+
+
+class TestMainCLI:
+    def test_export_main_cli_smoke(self, tmp_path, dummy_checkpoint):
+        from melody_train.export import main
+
+        out = tmp_path / "model.onnx"
+        rc = main(
+            [
+                "--checkpoint",
+                str(dummy_checkpoint),
+                "--out",
+                str(out),
+            ]
+        )
+        assert rc == 0
+        assert out.exists()
+
+    def test_export_main_cli_respects_opset(self, tmp_path, dummy_checkpoint):
+        import onnx
+
+        from melody_train.export import main
+
+        out = tmp_path / "model.onnx"
+        rc = main(
+            [
+                "--checkpoint",
+                str(dummy_checkpoint),
+                "--out",
+                str(out),
+                "--opset",
+                "17",
+            ]
+        )
+        assert rc == 0
+        model = onnx.load(str(out))
+        default_opsets = [o.version for o in model.opset_import if o.domain in ("", "ai.onnx")]
+        assert default_opsets[0] == 17
+
+    def test_export_main_cli_missing_checkpoint(self, tmp_path):
+        from melody_train.export import main
+
+        rc = main(
+            [
+                "--checkpoint",
+                str(tmp_path / "missing.pt"),
+                "--out",
+                str(tmp_path / "model.onnx"),
+            ]
+        )
+        assert rc != 0

--- a/packages/audio/melody-detector/training/uv.lock
+++ b/packages/audio/melody-detector/training/uv.lock
@@ -390,6 +390,8 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "onnx" },
+    { name = "onnxscript" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
@@ -411,8 +413,10 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "esp-ppq", marker = "extra == 'quantize'" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "onnx", marker = "extra == 'dev'", specifier = ">=1.16" },
     { name = "onnx", marker = "extra == 'quantize'", specifier = ">=1.16" },
     { name = "onnxruntime", marker = "extra == 'quantize'", specifier = ">=1.17" },
+    { name = "onnxscript", marker = "extra == 'dev'", specifier = ">=0.1" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
@@ -422,6 +426,27 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'" },
 ]
 provides-extras = ["train", "quantize", "dev"]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+]
 
 [[package]]
 name = "mpmath"
@@ -650,6 +675,22 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx-ir"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/e6/672fefb2f108d077f58181a7babf4c0f8d1182a30353ffc9c79c63afc5ee/onnx_ir-0.2.1.tar.gz", hash = "sha256:8b8b10a93f43e65962104de6070c43c5dacb0e3cdfefc7c8059dd83c9db64f35", size = 144279, upload-time = "2026-04-20T20:21:47.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/aa/f7a53321c60b9ad9ee184b6018292ed6b5389947592a2c8c09c736bb7f9e/onnx_ir-0.2.1-py3-none-any.whl", hash = "sha256:c7285da889312f91882de2092e298a9eeeefbfc1d1951c49d983992967eb09a7", size = 166792, upload-time = "2026-04-20T20:21:46.357Z" },
+]
+
+[[package]]
 name = "onnxruntime"
 version = "1.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -670,6 +711,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/55/7819e64c515f17c86005447ede8122b974ca851255a94125e2119376f0f8/onnxruntime-1.25.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:905409e9eb2ef87f8226e073f56e71faf731c3e480ebd34952cf953730e4a4ff", size = 18024586, upload-time = "2026-04-27T22:00:05.359Z" },
     { url = "https://files.pythonhosted.org/packages/89/36/b4f3eb5e95c66389aafd490950b5255e87c9333742cf90516eb50898e1dc/onnxruntime-1.25.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4097b75b77486bb45835a8ed25b9a67976040ec6c258aeabae6aadfbdd1201c", size = 12905112, upload-time = "2026-04-27T22:00:36.478Z" },
     { url = "https://files.pythonhosted.org/packages/38/fa/e5c43397632a399f542663ed3e3e37763ee203ba845b10b266cd2ede8925/onnxruntime-1.25.1-cp312-cp312-win_arm64.whl", hash = "sha256:b6c7aa5cae606d5c90a392679fac074b60f80025a2e83e1e90fdf882bd2a97f0", size = 12634433, upload-time = "2026-04-27T22:00:25.918Z" },
+]
+
+[[package]]
+name = "onnxscript"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "onnx-ir" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/99/fd948eba63ba65b52265a4cd09a14f96bb9f5b730fcef58876c4358bf406/onnxscript-0.7.0.tar.gz", hash = "sha256:c95ed7b339b02cface56ee27689565c46612e1fc542c562298dddfdad5268dc5", size = 612032, upload-time = "2026-04-20T17:09:19.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/ce/2ed92575cc3be4ea1db5f38f16f20765f9b20b69b14d6c1d9972658a8ee9/onnxscript-0.7.0-py3-none-any.whl", hash = "sha256:5b356907d4501e9919f8599c91d8da967406a37b1fac2b40caa55a49acf242ea", size = 714842, upload-time = "2026-04-20T17:09:22.089Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds \`melody_train.export\` — converts the trained \`MelodyClassifier\` checkpoint to an opset-17 ONNX file ready for ESP-PPQ quantization.
- Wraps the model in an export shim that takes float32 input in \`[0, 255]\` and applies \`(x - 128) / 128\` as explicit Sub/Div ops, so the normalization survives ONNX export and folds into the first Conv weights during INT8 quantization.
- Uses the legacy TorchScript-based exporter (\`dynamo=False\`) because the new dynamo exporter targets opset 18 and fails to downgrade. \`training=EVAL\` folds BatchNorm into the preceding Conv automatically.
- Click CLI matching \`train.py\`'s style: \`--checkpoint runs/best.pt --out runs/model.onnx --opset 17\`.
- Closes the \`export.py\` gap referenced by the existing \`just export\` recipe — running the full \`just gen\` / \`just train\` / \`just export\` pipeline now produces a ~13 KB ONNX file.

## Why this shape

\`MelodyClassifier._normalize\` only triggers for uint8 input, and exporting with uint8 inputs emits \`Cast\` ops that ESP-PPQ does not handle uniformly across versions. Bringing the normalization into the graph as float32 ops gives ESP-PPQ a clean target to fold into the first Conv weights, per the patterns in [docs/reference/esp-dl-deployment.md](https://github.com/laurigates/mcu-tinkering-lab/blob/main/docs/reference/esp-dl-deployment.md).

## Test plan

- [x] \`just check\` — lint, format, type-check, full pytest (146 passed, 1 skipped)
- [x] \`just gen 0 data/ 50 && just train --data data/ --out runs/ --epochs 2 && just export --checkpoint runs/best.pt --out runs/model.onnx\` — produces \`runs/model.onnx\` at 13 KB, opset 17
- [x] Forward parity test passes when \`onnxruntime\` is installed (skipped in dev/CI; runs under \`--extra quantize\`)

## Up next

- B4 — \`quantize.py\` (\`onnx → .espdl\` via ESP-PPQ \`espdl_quantize_onnx\`); will extend \`.github/workflows/test-melody-train.yml\` to install \`--extra quantize\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)