### PR TITLE
feat(melody-train): quantize ONNX to .espdl via ESP-PPQ (B4)

### DIFF
--- a/.github/workflows/test-melody-train.yml
+++ b/.github/workflows/test-melody-train.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Set up Python
         run: uv python install
 
-      - name: Install dependencies
-        run: uv sync --extra train --extra dev
+      - name: Install dependencies (with quantize extra for full B3+B4 coverage)
+        run: uv sync --extra train --extra dev --extra quantize
 
       - name: Lint (ruff)
         run: uv run ruff check --output-format=github .

--- a/packages/audio/melody-detector/training/src/melody_train/quantize.py
+++ b/packages/audio/melody-detector/training/src/melody_train/quantize.py
@@ -1,0 +1,209 @@
+"""Quantize the exported ONNX model to ``.espdl`` via ESP-PPQ.
+
+Wraps ``espdl_quantize_onnx`` with the project-specific calibration
+loader (drawn from the synthetic generator's training subset) and the
+ESP32-S3 backend settings. Produces three files in the output directory:
+
+- ``<out>.espdl`` — FlatBuffers binary embedded by the firmware via
+  ``EMBED_FILES`` + ``target_add_aligned_binary_data``
+- ``<out>.info``  — human-readable per-layer dump with sensitivity scores
+- ``<out>.json``  — quantization metadata (scales, zero-points)
+
+ESP32-S3 only supports per-tensor symmetric INT8 with power-of-2 scales;
+the model's depthwise-separable design and small parameter count keep
+per-tensor weight variance low enough to quantize cleanly.
+
+Calibration draws from the **train** subset of the same dataset used
+during training so the val subset stays unseen for downstream accuracy
+checks. Default ``calib_steps=32`` × ``batch_size=16`` = 512 samples,
+matching the recommendation in
+``docs/reference/esp-dl-deployment.md``.
+
+CLI entry-point at the bottom.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import click
+import torch
+from torch.utils.data import DataLoader
+
+from melody_train.dataset import make_split
+from melody_train.model import INPUT_CHANNELS, INPUT_SIZE
+
+
+@dataclass(frozen=True)
+class QuantizeConfig:
+    onnx_path: pathlib.Path
+    data_dir: pathlib.Path
+    out_path: pathlib.Path
+    calib_steps: int = 32
+    batch_size: int = 16
+    target: str = "esp32s3"
+    num_of_bits: int = 8
+    val_fraction: float = 0.1
+    seed: int = 0
+    device: str = "cpu"
+
+
+@dataclass(frozen=True)
+class QuantizeResult:
+    espdl_path: pathlib.Path
+    info_path: pathlib.Path
+    json_path: pathlib.Path
+    target: str
+    num_of_bits: int
+
+
+# ----------------------------------------------------- calibration loader ----
+
+
+def _calibration_loader(cfg: QuantizeConfig) -> DataLoader:
+    """Build a DataLoader over the train subset for ESP-PPQ calibration.
+
+    Returns float32 tensors in ``[0, 255]`` (the ONNX graph's normalization
+    Sub/Div ops handle the scale-down to ``[-1, 1]``). Iteration is
+    deterministic — no shuffling — so calibration is reproducible.
+    """
+    _, train_subset, _ = make_split(
+        cfg.data_dir,
+        val_fraction=cfg.val_fraction,
+        seed=cfg.seed,
+    )
+    return DataLoader(
+        train_subset,
+        batch_size=cfg.batch_size,
+        shuffle=False,
+        num_workers=0,
+        drop_last=False,
+    )
+
+
+def _calib_collate(batch: tuple[torch.Tensor, torch.Tensor], device: str) -> torch.Tensor:
+    """Strip labels; cast uint8 → float32; move to device.
+
+    ESP-PPQ invokes ``collate_fn`` after the DataLoader has already
+    stacked the batch, so ``batch`` here is the ``(images, labels)``
+    tuple — not the per-sample list. Matches the ONNX model's expected
+    input: float32 in ``[0, 255]``.
+    """
+    images = batch[0]
+    return images.float().to(device)
+
+
+# --------------------------------------------------------------- quantize ----
+
+
+def quantize(cfg: QuantizeConfig) -> QuantizeResult:
+    """Quantize ``cfg.onnx_path`` to ``cfg.out_path`` using ESP-PPQ."""
+    if not cfg.onnx_path.exists():
+        raise FileNotFoundError(f"ONNX file not found: {cfg.onnx_path}")
+
+    try:
+        from esp_ppq.api import espdl_quantize_onnx
+    except ImportError as exc:
+        raise ImportError(
+            "esp-ppq is not installed. Run `uv sync --extra quantize` "
+            "(or `just sync-quantize`) to install ESP-PPQ + ONNX deps."
+        ) from exc
+
+    cfg.out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    loader = _calibration_loader(cfg)
+    device = cfg.device
+
+    espdl_quantize_onnx(
+        onnx_import_file=str(cfg.onnx_path),
+        espdl_export_file=str(cfg.out_path),
+        calib_dataloader=loader,
+        calib_steps=cfg.calib_steps,
+        input_shape=[1, INPUT_CHANNELS, INPUT_SIZE, INPUT_SIZE],
+        target=cfg.target,
+        num_of_bits=cfg.num_of_bits,
+        collate_fn=lambda batch: _calib_collate(batch, device),
+        device=device,
+    )
+
+    info_path = cfg.out_path.with_suffix(".info")
+    json_path = cfg.out_path.with_suffix(".json")
+
+    return QuantizeResult(
+        espdl_path=cfg.out_path,
+        info_path=info_path,
+        json_path=json_path,
+        target=cfg.target,
+        num_of_bits=cfg.num_of_bits,
+    )
+
+
+# --------------------------------------------------------- CLI entry-point ---
+
+
+@click.command()
+@click.option(
+    "--onnx",
+    "onnx_path",
+    type=click.Path(dir_okay=False, path_type=pathlib.Path),
+    default=pathlib.Path("runs/model.onnx"),
+    show_default=True,
+    help="Source ONNX file (produced by melody_train.export).",
+)
+@click.option(
+    "--data",
+    "data_dir",
+    type=click.Path(exists=True, file_okay=False, path_type=pathlib.Path),
+    required=True,
+    help="Dataset directory used for calibration (train subset only).",
+)
+@click.option(
+    "--out",
+    "out_path",
+    type=click.Path(dir_okay=False, path_type=pathlib.Path),
+    default=pathlib.Path("runs/model.espdl"),
+    show_default=True,
+    help="Destination .espdl file (also produces .info and .json siblings).",
+)
+@click.option("--calib-steps", type=int, default=32, show_default=True)
+@click.option("--batch-size", type=int, default=16, show_default=True)
+@click.option("--target", type=str, default="esp32s3", show_default=True)
+@click.option("--num-of-bits", type=int, default=8, show_default=True)
+@click.option("--val-fraction", type=float, default=0.1, show_default=True)
+@click.option("--seed", type=int, default=0, show_default=True)
+@click.option("--device", type=str, default="cpu", show_default=True)
+def _cli(**kwargs: Any) -> None:
+    cfg = QuantizeConfig(**kwargs)
+    result = quantize(cfg)
+    click.echo(
+        f"espdl -> {result.espdl_path} (target={result.target}, num_of_bits={result.num_of_bits})"
+    )
+    click.echo(f"info  -> {result.info_path}")
+    click.echo(f"json  -> {result.json_path}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns process exit code."""
+    try:
+        _cli.main(args=argv, standalone_mode=False)
+    except click.exceptions.UsageError as exc:
+        click.echo(f"Error: {exc.format_message()}", err=True)
+        return 2
+    except click.exceptions.Abort:
+        return 130
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        return 1
+    except ImportError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        return 1
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/audio/melody-detector/training/tests/test_quantize.py
+++ b/packages/audio/melody-detector/training/tests/test_quantize.py
@@ -1,0 +1,224 @@
+"""Tests for the melody-detector ESP-PPQ quantization pipeline.
+
+The lightweight tests (dataclass shape, ``ImportError`` surface when the
+quantize extra is missing) always run. The end-to-end smoke test
+(``gen → train → export → quantize → assert .espdl``) is the slowest
+test in the suite and is gated by ``pytest.importorskip("esp_ppq")``,
+so it only runs when ESP-PPQ is installed (i.e. under
+``--extra quantize`` / ``just sync-quantize``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+
+# ----------------------------------------------------- QuantizeConfig shape ----
+
+
+class TestQuantizeConfig:
+    def test_instantiate_with_required_fields(self, tmp_path):
+        from melody_train.quantize import QuantizeConfig
+
+        cfg = QuantizeConfig(
+            onnx_path=tmp_path / "model.onnx",
+            data_dir=tmp_path / "data",
+            out_path=tmp_path / "model.espdl",
+        )
+        assert cfg.onnx_path == tmp_path / "model.onnx"
+        assert cfg.data_dir == tmp_path / "data"
+        assert cfg.out_path == tmp_path / "model.espdl"
+
+    def test_defaults(self, tmp_path):
+        from melody_train.quantize import QuantizeConfig
+
+        cfg = QuantizeConfig(
+            onnx_path=tmp_path / "model.onnx",
+            data_dir=tmp_path / "data",
+            out_path=tmp_path / "model.espdl",
+        )
+        assert cfg.calib_steps == 32
+        assert cfg.batch_size == 16
+        assert cfg.target == "esp32s3"
+        assert cfg.num_of_bits == 8
+        assert cfg.val_fraction == 0.1
+        assert cfg.seed == 0
+        assert cfg.device == "cpu"
+
+    def test_is_frozen(self, tmp_path):
+        from melody_train.quantize import QuantizeConfig
+
+        cfg = QuantizeConfig(
+            onnx_path=tmp_path / "model.onnx",
+            data_dir=tmp_path / "data",
+            out_path=tmp_path / "model.espdl",
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            cfg.calib_steps = 64  # type: ignore[misc]
+
+
+class TestQuantizeResult:
+    def test_instantiate(self, tmp_path):
+        from melody_train.quantize import QuantizeResult
+
+        result = QuantizeResult(
+            espdl_path=tmp_path / "model.espdl",
+            info_path=tmp_path / "model.info",
+            json_path=tmp_path / "model.json",
+            target="esp32s3",
+            num_of_bits=8,
+        )
+        assert result.target == "esp32s3"
+        assert result.num_of_bits == 8
+
+    def test_is_frozen(self, tmp_path):
+        from melody_train.quantize import QuantizeResult
+
+        result = QuantizeResult(
+            espdl_path=tmp_path / "model.espdl",
+            info_path=tmp_path / "model.info",
+            json_path=tmp_path / "model.json",
+            target="esp32s3",
+            num_of_bits=8,
+        )
+        with pytest.raises((AttributeError, TypeError)):
+            result.target = "esp32"  # type: ignore[misc]
+
+
+# --------------------------------------------------- behaviour without esp-ppq
+
+
+class TestQuantizeWithoutEspPpq:
+    """Surface a clear error if the user runs `quantize()` without esp-ppq."""
+
+    def test_raises_filenotfound_when_onnx_missing(self, tmp_path):
+        from melody_train.quantize import QuantizeConfig, quantize
+
+        cfg = QuantizeConfig(
+            onnx_path=tmp_path / "missing.onnx",
+            data_dir=tmp_path / "data",
+            out_path=tmp_path / "model.espdl",
+        )
+        with pytest.raises(FileNotFoundError):
+            quantize(cfg)
+
+
+# --------------------------------------------------------- end-to-end smoke
+
+
+@pytest.mark.slow
+class TestEndToEnd:
+    """Gen → train → export → quantize, asserting the final .espdl drops out.
+
+    Skipped unless esp-ppq is installed. Kept small (32 samples/class,
+    2 epochs, 2 calib steps) — this is still the slowest test in the
+    suite when it does run.
+    """
+
+    def test_full_pipeline(self, tmp_path):
+        pytest.importorskip("esp_ppq")
+
+        from melody_train.export import ExportConfig, export
+        from melody_train.gen import generate_dataset
+        from melody_train.quantize import QuantizeConfig, quantize
+        from melody_train.train import TrainConfig, train
+
+        data_dir = tmp_path / "data"
+        out_dir = tmp_path / "runs"
+        out_dir.mkdir()
+
+        generate_dataset(seed=0, out_dir=data_dir, per_class=32, image_size=32)
+
+        train_cfg = TrainConfig(
+            data_dir=data_dir,
+            out_dir=out_dir,
+            epochs=2,
+            batch_size=16,
+            seed=0,
+        )
+        train_result = train(train_cfg)
+        assert train_result.checkpoint_path.exists()
+
+        onnx_path = out_dir / "model.onnx"
+        export(ExportConfig(checkpoint_path=train_result.checkpoint_path, out_path=onnx_path))
+        assert onnx_path.exists()
+
+        espdl_path = out_dir / "model.espdl"
+        result = quantize(
+            QuantizeConfig(
+                onnx_path=onnx_path,
+                data_dir=data_dir,
+                out_path=espdl_path,
+                calib_steps=2,
+                batch_size=8,
+                seed=0,
+            )
+        )
+
+        assert result.espdl_path.exists()
+        assert result.espdl_path.stat().st_size > 0
+        # MelodyClassifier is ~3 KB INT8; .espdl wrapper adds metadata but
+        # should still be well under 50 KB. Surfaces gross regressions
+        # (e.g. weights stored as float32, debug data) early.
+        assert result.espdl_path.stat().st_size < 50_000
+
+    def test_info_and_json_sidecars(self, tmp_path):
+        pytest.importorskip("esp_ppq")
+
+        from melody_train.export import ExportConfig, export
+        from melody_train.gen import generate_dataset
+        from melody_train.quantize import QuantizeConfig, quantize
+        from melody_train.train import TrainConfig, train
+
+        data_dir = tmp_path / "data"
+        out_dir = tmp_path / "runs"
+        out_dir.mkdir()
+
+        generate_dataset(seed=0, out_dir=data_dir, per_class=32, image_size=32)
+
+        train_result = train(
+            TrainConfig(
+                data_dir=data_dir,
+                out_dir=out_dir,
+                epochs=2,
+                batch_size=16,
+                seed=0,
+            )
+        )
+
+        onnx_path = out_dir / "model.onnx"
+        export(ExportConfig(checkpoint_path=train_result.checkpoint_path, out_path=onnx_path))
+
+        result = quantize(
+            QuantizeConfig(
+                onnx_path=onnx_path,
+                data_dir=data_dir,
+                out_path=out_dir / "model.espdl",
+                calib_steps=2,
+                batch_size=8,
+                seed=0,
+            )
+        )
+
+        # .json sidecar is structured quantization metadata — must parse.
+        assert result.json_path.exists(), f"expected JSON metadata at {result.json_path}"
+        json.loads(result.json_path.read_text())
+
+        # .info sidecar is a human-readable layer dump — non-empty and
+        # contains some recognisable header/structure.
+        assert result.info_path.exists(), f"expected info dump at {result.info_path}"
+        info_text = result.info_path.read_text()
+        assert len(info_text) > 0
+        # Loose check: the info file should at least mention layer / op
+        # / quant terminology somewhere. Avoid over-specifying ESP-PPQ's
+        # exact format, which may vary across releases.
+        info_lower = info_text.lower()
+        assert any(kw in info_lower for kw in ("layer", "op", "quant", "scale")), (
+            f"info file doesn't look like a layer dump:\n{info_text[:500]}"
+        )


### PR DESCRIPTION
Re-opens the work from #298 (auto-closed when its base branch was deleted on B3 squash-merge), now rebased onto `main`.

## Summary

- Adds `melody_train.quantize` — converts the exported ONNX model to a per-tensor symmetric INT8 `.espdl` artifact ready for the firmware to embed via `target_add_aligned_binary_data`.
- Wraps `esp_ppq.api.espdl_quantize_onnx` with project-specific calibration: 32 batches × 16 samples drawn from the **train** subset of the synthetic generator's output (val stays unseen for downstream accuracy checks). `target=esp32s3`, `num_of_bits=8`, `input_shape=[1, 1, 32, 32]`.
- The `collate_fn` strips labels and casts uint8 → float32 in `[0, 255]` to match the ONNX graph's normalization Sub/Div ops (introduced in #297).
- Click CLI: `--onnx runs/model.onnx --data data/ --out runs/model.espdl`.
- Closes the `quantize.py` gap referenced by the existing `just quantize` recipe.

## Why this shape

The `.espdl` schema is FlatBuffers; `espdl_quantize_onnx` is the recommended pipeline boundary (cleaner than `espdl_quantize_torch`) per [docs/reference/esp-dl-deployment.md](https://github.com/laurigates/mcu-tinkering-lab/blob/main/docs/reference/esp-dl-deployment.md). `espdl_quantize_onnx` lives under `esp_ppq.api`, not the top-level `esp_ppq` namespace — caught during local testing. The collate_fn convention is also slightly different from PyTorch's: ESP-PPQ invokes it after the DataLoader has already stacked the batch into `(images, labels)`, so we extract `batch[0]` rather than iterating per-sample.

## CI changes

`.github/workflows/test-melody-train.yml` now installs `--extra quantize` so the end-to-end pipeline test (`gen → train → export → quantize → assert .espdl`) runs on every push. ESP-PPQ pulls in onnx + onnxruntime + onnxsim + cryptography (~500 MB), which adds noticeable CI time — flagging in case it gets too heavy.

## Test plan

- [x] `just check` (with `--extra quantize` installed) — lint, format, type-check, full pytest (155 passed)
- [x] End-to-end pipeline smoke runs in 2-3s and produces a 15 KB `.espdl` + `.info` + `.json` trio
- [x] When `esp_ppq` is **not** installed, the slow tests skip cleanly via `pytest.importorskip`
- [x] Manual: `just sync-quantize && just gen 0 data/ 100 && just train --data data/ --out runs/ --epochs 3 && just export --checkpoint runs/best.pt --out runs/model.onnx && just quantize --onnx runs/model.onnx --data data/ --out runs/model.espdl` — produces `runs/model.espdl` (15 KB), `runs/model.info` (21 KB), `runs/model.json` (27 KB)

## Up next

- Track B (host-side model pipeline) is now complete. The resulting `.espdl` artifact is ready to drop into Track D's firmware-side `EMBED_FILES` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)