### PR TITLE
fix(robocar-main): code-quality fixes

### DIFF
--- a/packages/robocar/main/main/i2c_slave.c
+++ b/packages/robocar/main/main/i2c_slave.c
@@ -5,7 +5,6 @@
 
 #include "i2c_slave.h"
 #include <string.h>
-#include "display_manager.h"
 #include "driver/i2c.h"
 #include "esp_app_desc.h"
 #include "esp_log.h"
@@ -15,7 +14,6 @@
 #include "freertos/task.h"
 #include "freertos/timers.h"
 #include "i2c_config.h"
-#include "motor_controller.h"
 #include "ota_handler.h"
 
 static const char *TAG = "i2c_slave";
@@ -34,6 +32,8 @@ extern void process_i2c_movement_command(movement_command_t movement, uint8_t sp
 extern void process_i2c_sound_command(sound_command_t sound);
 extern void process_i2c_servo_command(servo_command_t servo, uint8_t angle);
 extern void process_i2c_display_command(uint8_t line, const char *message);
+extern void stop_motors(void);
+extern void oled_show_claude_message(int line, const char *message);
 
 // Internal functions
 static void i2c_slave_task(void *pvParameters);
@@ -350,11 +350,10 @@ static void handle_ota_commands(const i2c_command_packet_t *command,
     switch (command->command_type) {
         case CMD_TYPE_ENTER_MAINTENANCE_MODE: {
             ESP_LOGI(TAG, "Entering maintenance mode — stopping motors");
-            motor_stop();
+            stop_motors();
             s_maintenance_mode = true;
-            display_clear();
-            display_show_message(0, "OTA UPDATE");
-            display_show_message(1, "Do not power off");
+            oled_show_claude_message(0, "OTA UPDATE");
+            oled_show_claude_message(1, "Do not power off");
             prepare_response(response, 0x00, command->sequence_number, NULL, 0);
             break;
         }


### PR DESCRIPTION
## Summary

In-depth review of `packages/robocar/main/` surfaced one genuine link-time bug: the I2C maintenance-mode path in `i2c_slave.c` calls into modules that were never added to the build.

## Findings

- `packages/robocar/main/main/i2c_slave.c:353` — `motor_stop()` resolves to `motor_controller.c::motor_stop`, but `motor_controller.c` is not in `main/CMakeLists.txt` SRCS → unresolved symbol at link time. Fixed by calling `stop_motors()` from `main.c` (already in SRCS).
- `packages/robocar/main/main/i2c_slave.c:355,356,357` — `display_clear()` and `display_show_message()` resolve to `display_manager.c`, also missing from SRCS. Fixed by calling `oled_show_claude_message()` from `main.c`. The `display_clear()` call was redundant since `oled_show_claude_message()` overwrites the target line.

The link failure has been masked recently by an unrelated CMake configure error in CI (`fishwaldo/esp_ghota` component dependency). Once that is resolved, the link would have failed without this fix.

## Notes (NOT fixed in this PR — flagged for awareness)

- `motor_controller.{c,h}`, `display_manager.{c,h}`, `led_controller.{c,h}`, `servo_controller.{c,h}`, `command_handler.{c,h}` are all dead code (not referenced anywhere now and not in SRCS). Worth a follow-up cleanup, but out of scope for "minimal fixes."
- `init_oled()` (main.c) and `i2c_slave_init()` (i2c_slave.c) both call `i2c_param_config`/`i2c_driver_install` on `I2C_NUM_1`. Phase 4 will fail driver install when OLED is enabled, causing `app_main` to return without starting the I2C slave. This is an architectural conflict that likely warrants its own PR.
- `play_sound()` (main.c:940) does an unconditional `vTaskDelay(pdMS_TO_TICKS(1))` per cycle, which dominates the timing for higher frequencies. Sound output is therefore lower-pitched than requested. Quality issue, not a memory/correctness bug.

## Test plan

- [ ] `just robocar::build-main` (containerized) confirms the link step succeeds (once the `esp_ghota` dependency is resolved).
- [ ] On hardware, send `CMD_TYPE_ENTER_MAINTENANCE_MODE` over I2C from the camera and verify motors stop and the OLED shows "OTA UPDATE / Do not power off".

🤖 Generated with [Claude Code](https://claude.com/claude-code)