### PR TITLE
fix(simulation): code-quality fixes

### DIFF
--- a/packages/robocar/simulation/src/ai_command_processor.py
+++ b/packages/robocar/simulation/src/ai_command_processor.py
@@ -368,6 +368,22 @@ Recent commands: {", ".join(context.last_commands[-3:]) if context.last_commands
         await self.http_client.aclose()
 
 
+def _compute_drive_duration(robot, pwm: int, distance: float) -> float | None:
+    """Estimate seconds needed to travel ``distance`` metres at the given PWM.
+
+    Returns ``None`` when the speed is non-positive (motor commanded to stop or
+    reverse), so the caller can skip the sleep instead of dividing by zero.
+    """
+    pwm_magnitude = abs(pwm)
+    if pwm_magnitude == 0 or distance <= 0:
+        return None
+    max_speed_ms = robot.motor_left.max_rpm * 2 * np.pi / 60 * robot.wheel_radius
+    actual_speed_ms = (pwm_magnitude / 255.0) * max_speed_ms
+    if actual_speed_ms <= 0:
+        return None
+    return distance / actual_speed_ms
+
+
 async def execute_ai_command(command: AICommand, robot) -> bool:
     """
     Execute AI command on robot
@@ -405,20 +421,20 @@ async def execute_ai_command(command: AICommand, robot) -> bool:
             speed = params.get("speed", 0.5)
             pwm = int(speed * 100)
             robot.set_motor_commands(pwm, pwm)
-            max_speed_ms = robot.motor_left.max_rpm * 2 * np.pi / 60 * robot.wheel_radius
-            duration = distance / (speed * max_speed_ms)
-            await asyncio.sleep(duration)
-            robot.set_motor_commands(0, 0)
+            duration = _compute_drive_duration(robot, pwm, distance)
+            if duration is not None:
+                await asyncio.sleep(duration)
+                robot.set_motor_commands(0, 0)
 
         elif action == "backward":
             distance = params.get("distance_meters", 1.0)
             speed = params.get("speed", 0.5)
             pwm = int(speed * 100)
             robot.set_motor_commands(-pwm, -pwm)
-            max_speed_ms = robot.motor_left.max_rpm * 2 * np.pi / 60 * robot.wheel_radius
-            duration = distance / (speed * max_speed_ms)
-            await asyncio.sleep(duration)
-            robot.set_motor_commands(0, 0)
+            duration = _compute_drive_duration(robot, pwm, distance)
+            if duration is not None:
+                await asyncio.sleep(duration)
+                robot.set_motor_commands(0, 0)
 
         elif action == "turn":
             angle = params.get("angle_degrees", 90.0)

--- a/packages/robocar/simulation/src/camera_simulation.py
+++ b/packages/robocar/simulation/src/camera_simulation.py
@@ -278,7 +278,7 @@ class CameraSimulation:
         self._render_objects(img, cam_pos, cam_forward, cam_up)
 
         # Add some basic lighting effects
-        self._apply_lighting(img, cam_pos)
+        img = self._apply_lighting(img, cam_pos)
 
         # Add camera distortion to simulate ESP32-CAM lens characteristics
         img = self._apply_camera_distortion(img)
@@ -346,7 +346,6 @@ class CameraSimulation:
     ):
         """Render a box object"""
         box_pos = np.array(box["position"])
-        np.array(box["size"])
         color = box["color"]
 
         # Simple box rendering - just check if objects are in view
@@ -467,14 +466,16 @@ class CameraSimulation:
 
         return None
 
-    def _apply_lighting(self, img: np.ndarray, cam_pos: np.ndarray):
-        """Apply basic lighting effects"""
-        # Simple ambient lighting with distance-based attenuation
-        height, width = img.shape[:2]
+    def _apply_lighting(self, img: np.ndarray, cam_pos: np.ndarray) -> np.ndarray:
+        """Apply basic lighting effects.
 
+        Returns the brightness-adjusted image. The previous implementation
+        rebound the local ``img`` name without returning it, so the caller
+        always saw the unmodified image.
+        """
         # Add some brightness variation based on viewing angle
         brightness_factor = 0.8 + 0.2 * np.random.random()
-        img = cv2.convertScaleAbs(img, alpha=brightness_factor, beta=10)
+        return cv2.convertScaleAbs(img, alpha=brightness_factor, beta=10)
 
     def _apply_camera_distortion(self, img: np.ndarray) -> np.ndarray:
         """Apply camera lens distortion to simulate ESP32-CAM characteristics"""

--- a/packages/robocar/simulation/src/communication_bridge.py
+++ b/packages/robocar/simulation/src/communication_bridge.py
@@ -124,6 +124,10 @@ class ESP32CommunicationBridge:
         self.update_thread = None
         self.lock = threading.Lock()
 
+        # Event loop captured when start() runs, used to dispatch async
+        # message handlers (AI command) from the serial-reader thread.
+        self._event_loop: asyncio.AbstractEventLoop | None = None
+
     def _load_config(self, config_path: str) -> dict:
         """Load configuration from YAML file"""
         with open(config_path) as f:
@@ -291,10 +295,21 @@ class ESP32CommunicationBridge:
 
     def _handle_i2c_message(self, message: I2CMessage):
         """Handle I2C protocol messages"""
-        if message.message_type in self.message_handlers:
-            self.message_handlers[message.message_type](message)
-        else:
+        handler = self.message_handlers.get(message.message_type)
+        if handler is None:
             print(f"Unknown message type: {message.message_type}")
+            return
+
+        result = handler(message)
+        if asyncio.iscoroutine(result):
+            # Async handlers (e.g. AI command) cannot be awaited from this
+            # sync serial-reader thread. Dispatch them onto the bridge's
+            # event loop if one is captured, otherwise run them in a fresh
+            # loop so the coroutine is not silently discarded.
+            if self._event_loop is not None and self._event_loop.is_running():
+                asyncio.run_coroutine_threadsafe(result, self._event_loop)
+            else:
+                asyncio.run(result)
 
     def _handle_move_command(self, message: I2CMessage):
         """Handle move command from ESP32"""
@@ -454,6 +469,10 @@ class ESP32CommunicationBridge:
     async def start(self, serial_port: str | None = None):
         """Start the communication bridge"""
         self.running = True
+
+        # Capture the running event loop so async message handlers invoked
+        # from the serial-reader thread can be dispatched back onto it.
+        self._event_loop = asyncio.get_running_loop()
 
         # Start WebSocket server
         await self.start_websocket_server()


### PR DESCRIPTION
Three real bugs found while reviewing `packages/robocar/simulation/`. Each is fixed in its own commit so they can be reverted individually if needed.

## Findings

- `src/communication_bridge.py:106,295` — `_handle_ai_command` is async but registered in the synchronous handler dispatch dict invoked from the serial-reader thread. Calling an async function from a sync context returns a coroutine that is silently discarded → the AI command path over serial never executed. Fixed by capturing the bridge's event loop in `start()` and dispatching coroutines via `run_coroutine_threadsafe`.

- `src/ai_command_processor.py:408-409,418-419` — `execute_ai_command` `forward`/`backward` actions: `pwm = int(speed*100)` but duration was computed as `distance / (speed * max_speed_ms)`. Actual speed at that PWM is `(speed*100/255) * max_speed_ms`, so the sleep was ~2.55× too short and the robot under-travelled by ~60%. Also `speed=0` would have raised `ZeroDivisionError`. Fixed by deriving speed from real PWM magnitude in a small helper that guards against the divide-by-zero.

- `src/camera_simulation.py:476-477` — `_apply_lighting` rebound the local `img` via `cv2.convertScaleAbs` but returned `None`, so the caller's image was unchanged and the lighting contribution was silently dropped on every frame. Fixed by returning the adjusted image and assigning at the call site. Also removed a dead `np.array(box["size"])` expression at line 349 whose result was computed and immediately discarded.

## Test plan

- [x] `uv run pytest --collect-only -q` — tests still collect (70 tests)
- [x] `uv run pytest tests/ -q` — same 4 pre-existing physics-calibration failures, no new regressions
- [x] `uv run ruff check src/` on changed files — clean