### PR TITLE
fix(networking): code-quality fixes

### DIFF
--- a/packages/games/nfc-scavenger-hunt/main/wifi_manager.c
+++ b/packages/games/nfc-scavenger-hunt/main/wifi_manager.c
@@ -32,6 +32,12 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
                  : disconnected->reason == WIFI_REASON_HANDSHAKE_TIMEOUT ? "Handshake timeout"
                                                                          : "Other");
 
+        /* Clear the connected bit so wifi_manager_is_connected() reflects reality
+         * after the link drops. Without this, the bit remains set forever from the
+         * first IP_EVENT_STA_GOT_IP — callers keep firing HTTPS requests against a
+         * dead link and never play the offline error tone. */
+        xEventGroupClearBits(wifi_event_group, WIFI_CONNECTED_BIT);
+
         if (retry_count < WIFI_MAXIMUM_RETRY) {
             retry_count++;
             ESP_LOGI(TAG, "Retry %d/%d to connect to the AP", retry_count, WIFI_MAXIMUM_RETRY);


### PR DESCRIPTION
## Summary

Code-quality review of `packages/networking/**` and `packages/games/**`. One genuine bug found and fixed; the other reviewed projects are clean.

## Findings

- `packages/games/nfc-scavenger-hunt/main/wifi_manager.c:26-49` — `WIFI_CONNECTED_BIT` was set on `IP_EVENT_STA_GOT_IP` but never cleared on `WIFI_EVENT_STA_DISCONNECTED`. After the first successful connect, `wifi_manager_is_connected()` returned true forever, so `handle_new_find()` skipped its offline-error-tone fallback and instead issued HTTPS requests against a dead link. → Clear the bit alongside the retry/log path.

## Reviewed but clean

- `packages/networking/it-troubleshooter/` — main + components (claude_client, wifi_manager, state_machine, status_led, usb_composite). WiFi reconnect is timer-driven with exponential backoff per the project's own no-blocking-in-event-handlers rule. mDNS init present. Credentials gated by `credentials.h.example` template. HTTP cleanup paths balanced.
- `packages/networking/wifitest/` — AP-only test fixture; hardcoded SSID/PSK is intentional documentation of the test AP, not a real credential leak.
- `packages/networking/wireguard-ha/` — ESPHome YAML uses `!secret` for every credential including `api.encryption.key`, `ota.password`, WG keys; `secrets.yaml.example` ships dummy values only.
- `packages/games/nfc-scavenger-hunt/` — gemini_tts HTTP cleanup balanced on every path; PSRAM buffer freed by audio task; NFC RC522 driver bounds-checks FIFO reads; mDNS init present after WiFi connect.

## Test plan

- [ ] `just nfc-scavenger-hunt::build` succeeds (containerized ESP-IDF v5.4)
- [ ] On hardware: power-cycle the AP after a successful connect; confirm `wifi_manager_is_connected()` returns false during the outage and the device plays the local error tone instead of stalling on HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)