### PR TITLE
fix(robocar-unified): code-quality fixes in mqtt_logger, servo, OTA orchestration

### DIFF
--- a/packages/robocar/unified/main/mqtt_logger.c
+++ b/packages/robocar/unified/main/mqtt_logger.c
@@ -68,12 +68,34 @@ esp_err_t mqtt_logger_init(const mqtt_logger_config_t *config)
     // Copy configuration
     memcpy(&s_context.config, config, sizeof(mqtt_logger_config_t));
 
+    // Required topic/uri fields must be present in the caller's config —
+    // strdup(NULL) is undefined behavior and a NULL broker URI passed to the
+    // MQTT client below would crash inside esp-mqtt.
+    if (!config->broker_uri || !config->client_id || !config->log_topic || !config->status_topic ||
+        !config->command_topic) {
+        ESP_LOGE(TAG, "Required config string is NULL");
+        return ESP_ERR_INVALID_ARG;
+    }
+
     // Allocate strings
     s_context.config.broker_uri = strdup(config->broker_uri);
     s_context.config.client_id = strdup(config->client_id);
     s_context.config.log_topic = strdup(config->log_topic);
     s_context.config.status_topic = strdup(config->status_topic);
     s_context.config.command_topic = strdup(config->command_topic);
+
+    if (!s_context.config.broker_uri || !s_context.config.client_id ||
+        !s_context.config.log_topic || !s_context.config.status_topic ||
+        !s_context.config.command_topic) {
+        ESP_LOGE(TAG, "Failed to duplicate config strings (out of memory)");
+        free((void *)s_context.config.broker_uri);
+        free((void *)s_context.config.client_id);
+        free((void *)s_context.config.log_topic);
+        free((void *)s_context.config.status_topic);
+        free((void *)s_context.config.command_topic);
+        memset(&s_context.config, 0, sizeof(s_context.config));
+        return ESP_ERR_NO_MEM;
+    }
 
     if (config->username) {
         s_context.config.username = strdup(config->username);
@@ -379,8 +401,12 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
             break;
 
         case MQTT_EVENT_DATA:
-            // Handle remote commands
-            if (strncmp(event->topic, s_context.config.command_topic, event->topic_len) == 0) {
+            // Handle remote commands. event->topic is NOT NUL-terminated; the
+            // received length must match the configured topic exactly,
+            // otherwise "robocar" would match "robocar/cmd" via strncmp.
+            if (s_context.config.command_topic && event->topic && event->topic_len > 0 &&
+                (size_t)event->topic_len == strlen(s_context.config.command_topic) &&
+                strncmp(event->topic, s_context.config.command_topic, event->topic_len) == 0) {
                 ESP_LOGI(TAG, "Received command: %.*s", event->data_len, event->data);
                 // TODO: Implement command processing
             }
@@ -516,9 +542,10 @@ static char *create_log_json(const mqtt_log_message_t *log_msg)
 
     cJSON_AddNumberToObject(json, "timestamp", log_msg->timestamp);
     cJSON_AddNumberToObject(json, "level", log_msg->level);
-    cJSON_AddStringToObject(json, "tag", log_msg->tag);
-    cJSON_AddStringToObject(json, "message", log_msg->message);
-    cJSON_AddStringToObject(json, "component", log_msg->component);
+    /* cJSON_AddStringToObject dereferences the value pointer; substitute "" when NULL. */
+    cJSON_AddStringToObject(json, "tag", log_msg->tag ? log_msg->tag : "");
+    cJSON_AddStringToObject(json, "message", log_msg->message ? log_msg->message : "");
+    cJSON_AddStringToObject(json, "component", log_msg->component ? log_msg->component : "");
     cJSON_AddNumberToObject(json, "heap_free", log_msg->heap_free);
     cJSON_AddNumberToObject(json, "wifi_rssi", log_msg->wifi_rssi);
 
@@ -544,6 +571,10 @@ static esp_err_t queue_log_message(esp_log_level_t level, const char *tag, const
 {
     if (!s_context.initialized) {
         return ESP_ERR_INVALID_STATE;
+    }
+    /* strdup(NULL) is undefined behavior in glibc/newlib; guard at the boundary. */
+    if (!tag || !message) {
+        return ESP_ERR_INVALID_ARG;
     }
 
     log_buffer_entry_t entry = {.message = strdup(message),

--- a/packages/robocar/unified/main/ota_manager.c
+++ b/packages/robocar/unified/main/ota_manager.c
@@ -302,9 +302,18 @@ static void orchestrate_main_controller_update(void *pvParameters)
     }
     vTaskDelay(pdMS_TO_TICKS(OTA_MAINTENANCE_SETTLE_MS));
 
-    // Step 6: Send OTA begin with release tag (e.g., "v0.2.0")
+    // Step 6: Send OTA begin with release tag (e.g., "v0.2.0").
+    // OTA_TAG_MAX_LEN = 20; the receiver looks the tag up against the GitHub
+    // release name, so silent truncation here would point the main controller
+    // at the wrong (or no) release. Abort instead of sending a partial tag.
     char release_tag[OTA_TAG_MAX_LEN];
-    snprintf(release_tag, sizeof(release_tag), "v%s", latest_str);
+    int written = snprintf(release_tag, sizeof(release_tag), "v%s", latest_str);
+    if (written < 0 || (size_t)written >= sizeof(release_tag)) {
+        ESP_LOGE(TAG, "Release tag '%s' would exceed %u-byte limit — aborting main OTA", latest_str,
+                 (unsigned)sizeof(release_tag));
+        semver_free(&mc_version);
+        goto done;
+    }
 
     ret = i2c_send_begin_ota(release_tag, NULL);
     if (ret != ESP_OK) {

--- a/packages/robocar/unified/main/servo_controller.c
+++ b/packages/robocar/unified/main/servo_controller.c
@@ -225,6 +225,9 @@ esp_err_t servo_move_smooth(servo_id_t servo_id, int16_t target_angle, uint8_t s
         return ESP_ERR_INVALID_STATE;
     if (!servo_is_angle_valid(servo_id, target_angle))
         return ESP_ERR_INVALID_ARG;
+    /* step_size = 0 would never advance current and the loop would never exit. */
+    if (step_size == 0)
+        return ESP_ERR_INVALID_ARG;
 
     int16_t current;
     esp_err_t ret = servo_get_angle(servo_id, &current);


### PR DESCRIPTION
## Summary

Three small, targeted fixes surfaced while reviewing `packages/robocar/unified/` for memory-safety and protocol-correctness bugs. Each is in its own commit.

## Findings

- `main/mqtt_logger.c:69-78` — `mqtt_logger_init` did `strdup(config->broker_uri)` without a NULL guard; passing a config with any required string NULL is `strdup(NULL)` UB on newlib, and a NULL broker URI would also crash inside esp-mqtt. → validate up front, free partial allocations on OOM.
- `main/mqtt_logger.c:543-546` — `queue_log_message` called `strdup(tag)` and `strdup(message)` unconditionally; if either was NULL the dup is UB. → reject NULL inputs before duplicating.
- `main/mqtt_logger.c:519-521` — `cJSON_AddStringToObject` was called with potentially NULL `tag`/`message`/`component` pointers, which dereferences inside cJSON. → substitute `""` when NULL.
- `main/mqtt_logger.c:383` — `MQTT_EVENT_DATA` matched the command topic with `strncmp(event->topic, command_topic, event->topic_len) == 0`, which let a 7-byte topic `"robocar"` accept a configured `"robocar/cmd"` command topic (only 7 bytes are compared). → require exact-length match before strncmp.
- `main/servo_controller.c:234-242` — `servo_move_smooth` with `step_size == 0` never advances `current`, so the loop with `vTaskDelay` per iteration never terminates. → return `ESP_ERR_INVALID_ARG`.
- `main/ota_manager.c:307` — `snprintf(release_tag, 20, "v%s", latest_str)` silently truncated semvers longer than 18 chars (e.g. pre-release / build-metadata tags). The truncated tag is then sent to the main controller, which looks it up against GitHub release names — a partial tag points the main board at the wrong (or no) release. → detect truncation via the snprintf return and abort orchestration cleanly.

## Out of scope (noted but not changed)

- `OTA_TAG_MAX_LEN = 20` is borderline narrow for full semver tags. Widening it is an i2c-protocol change with sender/receiver impact; left for a separate decision.
- The unified-board's `ota_manager.c` references `mqtt_logger_publish` / `mqtt_logger_subscribe` under `MQTT_LOGGING_ENABLED=1` but those symbols are not defined in `mqtt_logger.c` / `mqtt_logger.h`. That looks like a pre-existing build issue separate from this review's scope.
- I2C protocol layer in `packages/robocar/components/i2c-protocol/` (incl. `prepare_begin_ota_command` truncation handling and the host tests) is correct given the documented contract that receivers honour `tag_length` rather than treating `tag` as a C string.

## Test plan

- [ ] `just robocar-unified::build` (containerized ESP-IDF) succeeds
- [ ] `make -C packages/robocar/components/i2c-protocol/test test` still green (no protocol changes here, sanity check)
- [ ] Manual: confirm normal MQTT logging path still publishes; pass an oversize semver to the OTA orchestrator path and verify the abort log fires