### PR TITLE
fix(audio): code-quality fixes

### DIFF
--- a/packages/sensors/presence-detector/.gitignore
+++ b/packages/sensors/presence-detector/.gitignore
@@ -1,0 +1,8 @@
+# ESPHome secrets — never commit (contains WiFi creds, API key, OTA password)
+secrets.yaml
+
+# ESPHome build artifacts
+.esphome/
+*.bin
+*.elf
+*.map

--- a/packages/sensors/presence-detector/justfile
+++ b/packages/sensors/presence-detector/justfile
@@ -77,8 +77,8 @@ monitor: logs
 [group: "info"]
 pins:
     @echo "LD2410 mmWave sensor (UART):"
-    @echo "  RX → GPIO02 (ESP32-C6 TX)"
-    @echo "  TX → GPIO21 (ESP32-C6 RX)"
+    @echo "  LD2410 TX → GPIO02 (ESP32-C6 RX)"
+    @echo "  LD2410 RX → GPIO21 (ESP32-C6 TX)"
     @echo "  Baud: 256000 8N1"
     @echo ""
     @echo "Board: Seeed Studio XIAO ESP32-C6 (4MB flash)"


### PR DESCRIPTION
Code-quality review pass over `packages/audio/**` and `packages/sensors/**`. Two genuine defects in the recently-imported `presence-detector` project; the rest of the audio packages reviewed clean.

## Findings

- `packages/sensors/presence-detector/` — no `.gitignore` → following the README (`just config` copies `secrets.yaml.example` → `secrets.yaml` with WiFi creds, API encryption key, OTA password) would silently stage `secrets.yaml` for commit. Sibling ESPHome projects (`audiobook-player`, `wireguard-ha`) gitignore it; mirror that.
- `packages/sensors/presence-detector/justfile:80-82` — `just pins` printed labels swapped vs. the YAML and README. YAML has `rx_pin: GPIO02` / `tx_pin: GPIO21`, README correctly says `LD2410 TX → GPIO02` / `LD2410 RX → GPIO21`, but the justfile claimed `RX → GPIO02 (ESP32-C6 TX)` / `TX → GPIO21 (ESP32-C6 RX)` — exactly inverted. A user following `just pins` would wire LD2410 backwards.

## Reviewed clean (no PR)

- `packages/audio/gamepad-synth/` — Bluepad32 console rule already applied (UART primary, USB-Serial-JTAG secondary in `sdkconfig.defaults`). I2S/DMA wiring, SVF stability, drum esp_timer dispatch (TASK not ISR), TTS upsampling, and gamepad-state shared-volatile pattern all look correct.
- `packages/audio/melody-detector/` — Phase 1 `audio_test_init`/`tone` lifecycle matches the project's own `Don't` notes; pin map (I2S on GPIO6/43/44 with USB-Serial-JTAG console) is consistent with `pin_config.h` / `camera_pins.h`. mDNS rule does not apply (offline-by-spec per PRD-011 + project CLAUDE.md).
- `packages/audio/kids-audio-toy/` — straightforward LEDC + ADC; no WiFi so mDNS rule N/A.
- `packages/audio/audiobook-player/` — secrets handled via `!secret`, OTA password and API encryption key in place, deep-sleep + `extend_wake` semantics intact.

No hardcoded credentials in any tracked file across scope.

## Test plan

- [ ] `just validate` in `packages/sensors/presence-detector` still passes (no YAML touched)
- [ ] `just pins` now prints labels matching the YAML's `rx_pin`/`tx_pin`
- [ ] Confirm `git status` after `just config` no longer offers `secrets.yaml` for commit