### PR TITLE
fix(camera-vision): code-quality fixes

### DIFF
--- a/packages/camera-vision/llm-telegram/main/config_manager.c
+++ b/packages/camera-vision/llm-telegram/main/config_manager.c
@@ -336,11 +336,12 @@ void config_print(const app_config_t *config)
 
     ESP_LOGI(TAG, "=== Configuration ===");
     ESP_LOGI(TAG, "WiFi SSID: %s", config->wifi_ssid);
-    ESP_LOGI(TAG, "Telegram Bot Token: %s...%s",
-             config->telegram_bot_token[0] != 0 ? "***" : "NOT SET",
-             config->telegram_bot_token[0] != 0
-                 ? config->telegram_bot_token + strlen(config->telegram_bot_token) - 4
-                 : "");
+    // Show last 4 chars of the token (or "NOT SET"). Guard against tokens
+    // shorter than 4 chars: pointer arithmetic `token + len - 4` would
+    // underflow into stack memory before the buffer.
+    size_t token_len = strlen(config->telegram_bot_token);
+    const char *token_tail = (token_len >= 4) ? config->telegram_bot_token + token_len - 4 : "";
+    ESP_LOGI(TAG, "Telegram Bot Token: %s...%s", token_len > 0 ? "***" : "NOT SET", token_tail);
     ESP_LOGI(TAG, "Telegram Chat ID: %lld", config->telegram_chat_id);
     ESP_LOGI(TAG, "LLM Backend: %s", config->llm_backend_type ? "Claude" : "Ollama");
     if (config->llm_backend_type) {

--- a/packages/camera-vision/llm-telegram/main/main.c
+++ b/packages/camera-vision/llm-telegram/main/main.c
@@ -244,7 +244,8 @@ static void process_telegram_command(const char *command, const char *args)
     } else if (strcmp(command, "auto") == 0) {
         if (strcmp(args, "on") == 0) {
             app_config.auto_capture_enabled = true;
-            if (!cam_status.is_capturing) {
+            camera_status_t auto_cam_status = camera_get_status();
+            if (!auto_cam_status.is_capturing) {
                 camera_start_capture(app_config.capture_interval_ms, camera_capture_callback, NULL);
             }
             telegram_send_text(&telegram_bot, "✅ Auto capture enabled");

--- a/packages/camera-vision/llm-telegram/main/telegram_bot.c
+++ b/packages/camera-vision/llm-telegram/main/telegram_bot.c
@@ -37,8 +37,13 @@ static esp_err_t telegram_http_request(const char *url, const char *post_data,
 
     if (err == ESP_OK) {
         int content_length = esp_http_client_get_content_length(client);
-        if (content_length > 0 && content_length < buffer_size && response_buffer) {
+        if (content_length > 0 && (size_t)content_length < buffer_size && response_buffer) {
             int read_len = esp_http_client_read(client, response_buffer, content_length);
+            // esp_http_client_read can return -1 on error; clamp to 0 before
+            // null-terminating to avoid writing to response_buffer[-1].
+            if (read_len < 0) {
+                read_len = 0;
+            }
             response_buffer[read_len] = '\0';
         }
     }
@@ -177,9 +182,15 @@ esp_err_t telegram_send_photo(const telegram_bot_t *bot, const uint8_t *photo_da
 
     char response[1024];
     int content_length = esp_http_client_fetch_headers(client);
-    if (content_length > 0 && content_length < sizeof(response)) {
-        esp_http_client_read(client, response, content_length);
-        response[content_length] = '\0';
+    if (content_length > 0 && (size_t)content_length < sizeof(response)) {
+        int read_len = esp_http_client_read(client, response, content_length);
+        // esp_http_client_read returns the bytes read or -1 on error; clamp to 0
+        // before null-terminating, and use read_len (not content_length) so the
+        // terminator goes after the data we actually received.
+        if (read_len < 0) {
+            read_len = 0;
+        }
+        response[read_len] = '\0';
         ESP_LOGD(TAG, "Photo send response: %s", response);
     }
 
@@ -240,8 +251,13 @@ esp_err_t telegram_poll_updates(telegram_bot_t *bot, telegram_message_t *msg)
                         cJSON *chat = cJSON_GetObjectItem(message, "chat");
                         const cJSON *message_id = cJSON_GetObjectItem(message, "message_id");
 
-                        if (text && chat) {
+                        if (text && cJSON_IsString(text) && text->valuestring && chat) {
                             msg->text = strdup(text->valuestring);
+                            if (!msg->text) {
+                                cJSON_Delete(root);
+                                free(response);
+                                return ESP_ERR_NO_MEM;
+                            }
                             msg->type = TELEGRAM_MSG_TEXT;
 
                             const cJSON *chat_id = cJSON_GetObjectItem(chat, "id");
@@ -271,7 +287,9 @@ esp_err_t telegram_poll_updates(telegram_bot_t *bot, telegram_message_t *msg)
     return err;
 }
 
-// Parse incoming command
+// Parse incoming command. Both `command` and `args` are expected to be sized
+// per the TELEGRAM_*_BUF_SIZE macros in the header; long Telegram messages
+// otherwise overflow the caller's stack buffers.
 bool telegram_parse_command(const char *text, char *command, char *args)
 {
     if (!text || text[0] != '/') {
@@ -282,12 +300,17 @@ bool telegram_parse_command(const char *text, char *command, char *args)
     if (space) {
         // Command with arguments
         size_t cmd_len = space - text - 1;  // Exclude '/'
-        strncpy(command, text + 1, cmd_len);
+        if (cmd_len >= TELEGRAM_COMMAND_BUF_SIZE) {
+            cmd_len = TELEGRAM_COMMAND_BUF_SIZE - 1;
+        }
+        memcpy(command, text + 1, cmd_len);
         command[cmd_len] = '\0';
-        strcpy(args, space + 1);
+        strncpy(args, space + 1, TELEGRAM_ARGS_BUF_SIZE - 1);
+        args[TELEGRAM_ARGS_BUF_SIZE - 1] = '\0';
     } else {
         // Command without arguments
-        strcpy(command, text + 1);  // Skip '/'
+        strncpy(command, text + 1, TELEGRAM_COMMAND_BUF_SIZE - 1);  // Skip '/'
+        command[TELEGRAM_COMMAND_BUF_SIZE - 1] = '\0';
         args[0] = '\0';
     }
 

--- a/packages/camera-vision/llm-telegram/main/telegram_bot.h
+++ b/packages/camera-vision/llm-telegram/main/telegram_bot.h
@@ -43,7 +43,11 @@ esp_err_t telegram_send_status(telegram_bot_t *bot, const char *format, ...);
 // Poll for updates (commands from user)
 esp_err_t telegram_poll_updates(telegram_bot_t *bot, telegram_message_t *msg);
 
-// Parse incoming command
+// Parse incoming command. The caller MUST size `command` to at least
+// TELEGRAM_COMMAND_BUF_SIZE bytes and `args` to at least TELEGRAM_ARGS_BUF_SIZE
+// bytes; the parser truncates inputs to those bounds to prevent overflow.
+#define TELEGRAM_COMMAND_BUF_SIZE 32
+#define TELEGRAM_ARGS_BUF_SIZE 256
 bool telegram_parse_command(const char *text, char *command, char *args);
 
 // Free message resources

--- a/packages/camera-vision/llm-telegram/main/vision_interpreter.c
+++ b/packages/camera-vision/llm-telegram/main/vision_interpreter.c
@@ -163,8 +163,9 @@ esp_err_t vision_parse_llm_response(const llm_response_t *llm_response, vision_r
     // Parse objects detected
     if (llm_response->objects_detected) {
         result->objects_detected = strdup(llm_response->objects_detected);
-    } else {
-        // Try to extract from text
+    } else if (llm_response->text) {
+        // Try to extract from text — guard against a NULL text field, which
+        // strstr() would dereference and crash on.
         const char *objects_marker = strstr(llm_response->text, "objects:");
         if (!objects_marker) {
             objects_marker = strstr(llm_response->text, "see:");
@@ -202,13 +203,17 @@ esp_err_t vision_parse_llm_response(const llm_response_t *llm_response, vision_r
     // Set duration (default 2 seconds for movements)
     result->suggested_duration_ms = (result->suggested_action == MOTOR_CMD_STOP) ? 0 : 2000;
 
-    // Extract reasoning
-    const char *because = strstr(llm_response->text, "because");
-    if (!because) {
-        because = strstr(llm_response->text, "since");
-    }
-    if (!because) {
-        because = strstr(llm_response->text, "due to");
+    // Extract reasoning — guard against a NULL text field; strstr() would
+    // crash if dereferenced on NULL.
+    const char *because = NULL;
+    if (llm_response->text) {
+        because = strstr(llm_response->text, "because");
+        if (!because) {
+            because = strstr(llm_response->text, "since");
+        }
+        if (!because) {
+            because = strstr(llm_response->text, "due to");
+        }
     }
     if (because) {
         result->reasoning = strdup(because);


### PR DESCRIPTION
Code-quality review of `packages/camera-vision/`. Reviewed all four projects (cam-webserver, cam-i2s-audio, llm-telegram, gemini-vision); fixes target genuine memory-safety and correctness bugs in `llm-telegram`, which is the only project with substantive defects. The other three look clean.

## Findings & fixes

- `llm-telegram/main/main.c:247` — `cam_status` was referenced from the `/auto on` branch but declared inside the unrelated `/status` branch. This is a hard compile error masked only because the reusable CI build script chains `idf.py build && ... ; true`, swallowing every error. Declared a fresh `auto_cam_status` local in the correct branch.
- `llm-telegram/main/telegram_bot.c:42` and `:182` — `esp_http_client_read` may return `-1` on error, after which the code wrote `response_buffer[read_len] = '\0'`. That is `response_buffer[-1]` — off-by-one underflow into adjacent stack memory. Clamped `read_len` to 0 before null-terminating, and the photo handler now uses `read_len` rather than the requested length so the terminator goes after data we actually received.
- `llm-telegram/main/telegram_bot.c:244` — `strdup(text->valuestring)` was called without verifying the cJSON node was a string with a non-NULL value. Photo / sticker / location updates have no `text` field; the bot would crash on the first such message. Added a `cJSON_IsString` + non-NULL guard and an OOM check on `strdup`.
- `llm-telegram/main/telegram_bot.c:285-291` — `telegram_parse_command` used `strcpy` into caller-supplied buffers with no length context. The polling loop sizes them at 32 / 256 bytes; long Telegram messages overflowed onto the stack. Documented the expected sizes via `TELEGRAM_COMMAND_BUF_SIZE` / `TELEGRAM_ARGS_BUF_SIZE` and switched to bounded copies.
- `llm-telegram/main/config_manager.c:342` — `config_print` indexed the bot token via `token + strlen(token) - 4` to display the last 4 chars. For tokens of length 1–3 this underflows the buffer. Compute the tail only when length >= 4.
- `llm-telegram/main/vision_interpreter.c:168` and `:206` — `vision_parse_llm_response` called `strstr(llm_response->text, ...)` without checking whether `text` was NULL. The LLM client only populates `text` on success; on a failed/malformed response the field stays NULL and these calls would crash. Hoisted the NULL check.

## Out of scope

- The HTTP event handler in `llm_client.c` has a real memory leak (`output_buffer` allocated in `HTTP_EVENT_ON_DATA`, leaked in `HTTP_EVENT_ON_FINISH`) and an unsafe redo of `esp_http_client_read` against an already-consumed body. Fixing it cleanly requires switching the whole module to a `user_data` accumulator like `gemini-vision` does. Too invasive for a code-quality pass; flagged here for follow-up.
- `cam-webserver`, `gemini-vision`, `cam-i2s-audio` (which is still a stub) have no significant defects worth a fix in this PR.

## Test plan

- [ ] `just llm-telegram::build` — confirm the project now compiles (the cam_status fix was the blocker).
- [ ] On-device smoke: send `/auto on`, `/auto off`, a non-text Telegram message, and a long-text command after flashing.