### PR TITLE
fix(components): code-quality fixes across shared + thinkpack components

### DIFF
--- a/packages/components/improv-wifi/improv_wifi.c
+++ b/packages/components/improv-wifi/improv_wifi.c
@@ -266,10 +266,18 @@ void improv_wifi_send_provisioned_result(const char *redirect_url)
     uint8_t idx = 0;
     data[idx++] = CMD_SEND_WIFI_CREDS;  // RPC result ID
     if (redirect_url != NULL && redirect_url[0] != '\0') {
-        uint8_t url_len = (uint8_t)strlen(redirect_url);
-        data[idx++] = url_len;
+        // Clamp the URL to the remaining buffer (data[] minus the cmd + len bytes
+        // already reserved). Without this clamp, any redirect_url longer than
+        // ~125 bytes would overflow the 128-byte data[] buffer.
+        size_t url_full_len = strlen(redirect_url);
+        size_t max_url = sizeof(data) - idx - 1;
+        size_t url_len = url_full_len < max_url ? url_full_len : max_url;
+        if (url_full_len > max_url) {
+            ESP_LOGW(TAG, "redirect_url truncated from %zu to %zu bytes", url_full_len, url_len);
+        }
+        data[idx++] = (uint8_t)url_len;
         memcpy(data + idx, redirect_url, url_len);
-        idx += url_len;
+        idx += (uint8_t)url_len;
     } else {
         data[idx++] = 0;  // Empty redirect URL
     }

--- a/packages/components/thinkpack-behaviors/command_executor.c
+++ b/packages/components/thinkpack-behaviors/command_executor.c
@@ -89,9 +89,20 @@ void command_executor_dispatch(const thinkpack_packet_t *packet)
     const thinkpack_command_data_t *cmd =
         (const thinkpack_command_data_t *)(const void *)packet->data;
 
+    /* The command envelope's `payload` array is a fixed 48 bytes (see
+     * thinkpack_command_data_t). A remote sender could set `cmd->length`
+     * larger than that, which would cause the handler to read past the
+     * payload buffer. Clamp before dispatch. */
+    uint8_t payload_len = cmd->length;
+    if (payload_len > sizeof(cmd->payload)) {
+        ESP_LOGW(TAG, "command 0x%02x payload length %u clamped to %zu", cmd->command_id,
+                 payload_len, sizeof(cmd->payload));
+        payload_len = (uint8_t)sizeof(cmd->payload);
+    }
+
     for (int i = 0; i < EXECUTOR_MAX_HANDLERS; i++) {
         if (s_registry[i].active && s_registry[i].command_id == cmd->command_id) {
-            s_registry[i].handler(cmd->command_id, cmd->payload, cmd->length,
+            s_registry[i].handler(cmd->command_id, cmd->payload, payload_len,
                                   s_registry[i].user_ctx);
             return;
         }

--- a/packages/components/thinkpack-mesh/include/group_manager.h
+++ b/packages/components/thinkpack-mesh/include/group_manager.h
@@ -117,6 +117,11 @@ const thinkpack_peer_t *group_manager_get(size_t index);
 /**
  * @brief Find a peer by its MAC address.
  *
+ * The returned pointer is into the internal static table. It remains
+ * valid until the next call to group_manager_upsert() or
+ * group_manager_prune() — copy the data if you need to retain it across
+ * any further group_manager_* call from another task.
+ *
  * @param mac  6-byte MAC to look up.
  * @return Pointer to the matching descriptor, or NULL if not found.
  */

--- a/packages/components/thinkpack-power/power_mgr.c
+++ b/packages/components/thinkpack-power/power_mgr.c
@@ -113,6 +113,8 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
     err = adc_oneshot_config_channel(s_ctx.adc, s_ctx.channel, &chan_cfg);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "adc_oneshot_config_channel failed: %d", err);
+        adc_oneshot_del_unit(s_ctx.adc);
+        s_ctx.adc = NULL;
         return err;
     }
 
@@ -134,6 +136,12 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
     err = esp_timer_create(&timer_args, &s_ctx.tick_timer);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_timer_create failed: %d", err);
+        if (s_ctx.cali) {
+            adc_cali_delete_scheme_curve_fitting(s_ctx.cali);
+            s_ctx.cali = NULL;
+        }
+        adc_oneshot_del_unit(s_ctx.adc);
+        s_ctx.adc = NULL;
         return err;
     }
 
@@ -141,6 +149,14 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
                                    (uint64_t)s_ctx.config.tick_interval_ms * 1000ULL);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_timer_start_periodic failed: %d", err);
+        esp_timer_delete(s_ctx.tick_timer);
+        s_ctx.tick_timer = NULL;
+        if (s_ctx.cali) {
+            adc_cali_delete_scheme_curve_fitting(s_ctx.cali);
+            s_ctx.cali = NULL;
+        }
+        adc_oneshot_del_unit(s_ctx.adc);
+        s_ctx.adc = NULL;
         return err;
     }
 

--- a/packages/components/thinkpack-protocol/thinkpack_protocol.c
+++ b/packages/components/thinkpack-protocol/thinkpack_protocol.c
@@ -99,7 +99,7 @@ uint32_t thinkpack_priority_for_capabilities(uint16_t capabilities, const uint8_
 void thinkpack_prepare_beacon(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
                               const thinkpack_beacon_data_t *beacon)
 {
-    if (!p || !beacon) {
+    if (!p || !src_mac || !beacon) {
         return;
     }
 
@@ -115,7 +115,7 @@ void thinkpack_prepare_beacon(thinkpack_packet_t *p, uint8_t seq, const uint8_t 
 void thinkpack_prepare_election_bid(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
                                     uint32_t priority)
 {
-    if (!p) {
+    if (!p || !src_mac) {
         return;
     }
 
@@ -136,7 +136,7 @@ void thinkpack_prepare_election_bid(thinkpack_packet_t *p, uint8_t seq, const ui
 void thinkpack_prepare_leader_claim(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
                                     uint32_t priority, uint8_t channel)
 {
-    if (!p) {
+    if (!p || !src_mac) {
         return;
     }
 
@@ -158,7 +158,7 @@ void thinkpack_prepare_leader_claim(thinkpack_packet_t *p, uint8_t seq, const ui
 void thinkpack_prepare_sync_pulse(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
                                   uint32_t timestamp_ms, uint8_t phase)
 {
-    if (!p) {
+    if (!p || !src_mac) {
         return;
     }
 
@@ -179,7 +179,7 @@ void thinkpack_prepare_sync_pulse(thinkpack_packet_t *p, uint8_t seq, const uint
 void thinkpack_prepare_fragment(thinkpack_packet_t *p, uint8_t seq, const uint8_t src_mac[6],
                                 const thinkpack_fragment_data_t *fragment)
 {
-    if (!p || !fragment) {
+    if (!p || !src_mac || !fragment) {
         return;
     }
 


### PR DESCRIPTION
## Summary

Five fixes across `packages/components/` surfaced during an in-depth review (the original review agent was rate-limited mid-flight; the staged edits were salvaged from its worktree, verified, and split into per-component commits).

## Findings

| File | Issue | Fix |
|------|-------|-----|
| `improv-wifi/improv_wifi.c:266-275` | `improv_wifi_send_provisioned_result()` copied full `strlen(redirect_url)` into a fixed 128-byte `data[]` buffer, overflowing for `redirect_url > ~125 bytes` | Clamp to remaining capacity, log warning on truncation |
| `thinkpack-behaviors/command_executor.c:89-105` | `command_executor_dispatch()` passed unclamped `cmd->length` to handlers; remote sender setting `length > 48` (the fixed `payload[]` size) caused OOB read | Clamp before dispatch, warn on truncation |
| `thinkpack-power/power_mgr.c:113-150` | `thinkpack_power_init()` leaked the ADC unit (and on the timer-start failure path, the calibration scheme + `esp_timer` handle) on intermediate failures | Free what was allocated, NULL the context fields |
| `thinkpack-protocol/thinkpack_protocol.c:99-180` | Five `thinkpack_prepare_*` functions `memcpy(6, src_mac)` without checking `src_mac` for NULL | Add the missing NULL guards |
| `thinkpack-mesh/include/group_manager.h:117-122` | `group_manager_find_by_mac()` returns a pointer into a static table invalidated by `upsert`/`prune`, but the contract was undocumented | Document pointer-lifetime contract |

## Test plan
- [ ] CI builds across the matrix (these are reusable components consumed by `thinkpack/*` apps and `improv-wifi` is consumed broadly)
- [ ] No behavioural changes on the happy path — only error-path hardening + length clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)