### PR TITLE
fix(thinkpack): code-quality fixes

### DIFF
--- a/packages/thinkpack/brainbox/main/main.c
+++ b/packages/thinkpack/brainbox/main/main.c
@@ -18,6 +18,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "group_mode.h"
+#include "mdns.h"
 #include "ota_handler.h"
 #include "sdkconfig.h"
 #include "standalone_mode.h"
@@ -136,6 +137,18 @@ void app_main(void)
     if (wifi_ret != ESP_OK) {
         ESP_LOGW(TAG, "WiFi connect returned %s — continuing (Improv may provision later)",
                  esp_err_to_name(wifi_ret));
+    }
+
+    /* mDNS hostname: every WiFi STA project must publish a brainbox.local
+     * record (per .claude/rules/mdns-hostname.md). ollama_discovery may also
+     * call mdns_init() later for SRV lookups; the second init is a no-op. */
+    esp_err_t mdns_ret = mdns_init();
+    if (mdns_ret == ESP_OK) {
+        (void)mdns_hostname_set("brainbox");
+        (void)mdns_instance_name_set("ThinkPack Brainbox");
+        ESP_LOGI(TAG, "mDNS initialised: brainbox.local");
+    } else {
+        ESP_LOGW(TAG, "mDNS init failed: %s", esp_err_to_name(mdns_ret));
     }
 
     /* --- Mesh ------------------------------------------------------- */

--- a/packages/thinkpack/brainbox/main/wifi_manager.c
+++ b/packages/thinkpack/brainbox/main/wifi_manager.c
@@ -824,6 +824,8 @@ static void notify_state_change(wifi_state_t new_state)
 /* ------------------------------------------------------------------ */
 
 #define IMPROV_PROVISIONED_BIT BIT0
+#define IMPROV_STOP_BIT BIT1
+#define IMPROV_EXITED_BIT BIT2
 static EventGroupHandle_t s_improv_event_group = NULL;
 
 /**
@@ -860,10 +862,16 @@ static void on_improv_credentials(const char *ssid, const char *password)
 /**
  * Task pumps UART0 bytes into the Improv parser and periodically
  * broadcasts the "authorized" state so ESP Web Tools can discover us.
+ *
+ * @p arg is the EventGroupHandle_t captured at task creation. Capturing
+ * locally avoids a use-after-free against the static @ref s_improv_event_group
+ * pointer when wifi_manager_start_improv_provisioning() races to delete it.
+ * The task signals @ref IMPROV_EXITED_BIT before vTaskDelete so the caller
+ * can wait for a clean exit before destroying the event group.
  */
 static void improv_uart_task(void *arg)
 {
-    (void)arg;
+    EventGroupHandle_t group = (EventGroupHandle_t)arg;
     TickType_t last_state_tx = 0;
     while (1) {
         uint8_t byte;
@@ -878,11 +886,12 @@ static void improv_uart_task(void *arg)
             last_state_tx = now;
         }
 
-        if (s_improv_event_group &&
-            (xEventGroupGetBits(s_improv_event_group) & IMPROV_PROVISIONED_BIT)) {
+        EventBits_t bits = xEventGroupGetBits(group);
+        if (bits & (IMPROV_PROVISIONED_BIT | IMPROV_STOP_BIT)) {
             break;
         }
     }
+    xEventGroupSetBits(group, IMPROV_EXITED_BIT);
     vTaskDelete(NULL);
 }
 
@@ -919,16 +928,30 @@ esp_err_t wifi_manager_start_improv_provisioning(uint32_t timeout_ms)
     if (!s_improv_event_group) {
         return ESP_ERR_NO_MEM;
     }
+    /* Capture handle locally so the task does not race against the static
+     * pointer when we tear down. */
+    EventGroupHandle_t group = s_improv_event_group;
 
     improv_wifi_init(on_improv_credentials);
-    xTaskCreate(improv_uart_task, "improv_uart", 4096, NULL, 5, NULL);
+    if (xTaskCreate(improv_uart_task, "improv_uart", 4096, group, 5, NULL) != pdPASS) {
+        ESP_LOGE(TAG, "Improv: task creation failed");
+        vEventGroupDelete(group);
+        s_improv_event_group = NULL;
+        return ESP_ERR_NO_MEM;
+    }
 
     TickType_t wait_ticks = (timeout_ms == 0) ? portMAX_DELAY : pdMS_TO_TICKS(timeout_ms);
-    EventBits_t bits = xEventGroupWaitBits(s_improv_event_group, IMPROV_PROVISIONED_BIT, pdFALSE,
-                                           pdFALSE, wait_ticks);
+    EventBits_t bits =
+        xEventGroupWaitBits(group, IMPROV_PROVISIONED_BIT, pdFALSE, pdFALSE, wait_ticks);
 
-    vEventGroupDelete(s_improv_event_group);
+    /* Tell the task to stop and wait for it to acknowledge. The task always
+     * sets IMPROV_EXITED_BIT before vTaskDelete(NULL), so once we see that
+     * bit it is safe to free the event group. */
+    xEventGroupSetBits(group, IMPROV_STOP_BIT);
+    (void)xEventGroupWaitBits(group, IMPROV_EXITED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
+
     s_improv_event_group = NULL;
+    vEventGroupDelete(group);
 
     if (bits & IMPROV_PROVISIONED_BIT) {
         ESP_LOGI(TAG, "Improv: provisioning successful");


### PR DESCRIPTION
## Summary

Two correctness fixes in `packages/thinkpack/brainbox/`. The other thinkpack apps (boombox, chatterbox, finderbox, glowbug, mesh-demo) were reviewed but do not have changes.

- `brainbox/main/wifi_manager.c:864-940` — improv UART task races against `vEventGroupDelete(s_improv_event_group)` (use-after-free) and never exits on timeout (task leak polling a freed handle). Capture the event group handle as a task argument, add `IMPROV_STOP_BIT` + `IMPROV_EXITED_BIT`, and join the task before freeing the group on every exit path.
- `brainbox/main/main.c:135` — only WiFi STA project in the thinkpack stack but never called `mdns_hostname_set` per `.claude/rules/mdns-hostname.md`. Initialise mDNS and publish `brainbox.local` after `wifi_manager_connect`. The `mdns` component is already in the brainbox CMakeLists `REQUIRES`, and `ollama_discovery`'s later `mdns_init()` call now becomes a benign `ESP_ERR_INVALID_STATE` no-op.

The other thinkpack apps connect WiFi only for ESP-NOW (no AP join, no IP), so the mDNS rule does not apply.

## Test plan

- [ ] `just brainbox::build` succeeds.
- [ ] On a brainbox without saved credentials, Improv provisioning task exits cleanly after both the success and timeout paths (no `LoadProhibited` panic, no stuck task in `xTaskGetHandleByTaskNumber`).
- [ ] After WiFi connects, `dns-sd -B _services._dns-sd._udp` (macOS) or `avahi-browse -a` (Linux) resolves `brainbox.local`.