### PR TITLE
fix(robocar-camera): code-quality fixes (capture-task wakeup, NULL guards)

### DIFF
--- a/packages/robocar/camera/main/camera.c
+++ b/packages/robocar/camera/main/camera.c
@@ -113,11 +113,13 @@ camera_fb_t *camera_capture(void)
     return fb;
 }
 
-void camera_return_fb(camera_fb_t *fb)
+esp_err_t camera_return_fb(camera_fb_t *fb)
 {
-    if (fb) {
-        esp_camera_fb_return(fb);
+    if (!fb) {
+        return ESP_ERR_INVALID_ARG;
     }
+    esp_camera_fb_return(fb);
+    return ESP_OK;
 }
 
 void camera_deinit(void)

--- a/packages/robocar/camera/main/camera.h
+++ b/packages/robocar/camera/main/camera.h
@@ -24,8 +24,9 @@ camera_fb_t *camera_capture(void);
 /**
  * @brief Return the camera frame buffer
  * @param fb Frame buffer to return
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG if fb is NULL
  */
-void camera_return_fb(camera_fb_t *fb);
+esp_err_t camera_return_fb(camera_fb_t *fb);
 
 /**
  * @brief Deinitialize the camera

--- a/packages/robocar/camera/main/main.c
+++ b/packages/robocar/camera/main/main.c
@@ -47,6 +47,7 @@ static const char *TAG = "esp32-cam-robocar";
 // Global state (now managed by centralized state manager)
 static TimerHandle_t capture_timer = NULL;
 static TimerHandle_t status_led_timer = NULL;
+static TaskHandle_t capture_task_handle = NULL;
 static const ai_backend_t *g_ai_backend = NULL;
 static SemaphoreHandle_t g_ai_backend_mutex = NULL;
 
@@ -457,7 +458,8 @@ static void create_and_start_tasks(void)
                                     NULL, status_led_timer_callback);
 
     // Create tasks - use named constant for capture task stack size
-    xTaskCreate(capture_and_analyze_task, "capture_task", CAPTURE_TASK_STACK_SIZE, NULL, 5, NULL);
+    xTaskCreate(capture_and_analyze_task, "capture_task", CAPTURE_TASK_STACK_SIZE, NULL, 5,
+                &capture_task_handle);
     xTaskCreate(status_led_task, "status_led_task", 2048, NULL, 1, NULL);
 
     // Start timers
@@ -473,8 +475,7 @@ static void create_and_start_tasks(void)
 
 static void capture_timer_callback(TimerHandle_t xTimer)
 {
-    // Signal capture task to run
-    static TaskHandle_t capture_task_handle = NULL;
+    // Signal capture task to run (handle is set in create_and_start_tasks)
     if (capture_task_handle) {
         xTaskNotifyGive(capture_task_handle);
     }

--- a/packages/robocar/camera/main/ollama_backend.c
+++ b/packages/robocar/camera/main/ollama_backend.c
@@ -348,16 +348,21 @@ static esp_err_t ollama_analyze_image(const uint8_t *image_data, size_t image_si
             cJSON *response_json = cJSON_GetObjectItem(root, "response");
             if (cJSON_IsString(response_json)) {
                 const char *response_str = cJSON_GetStringValue(response_json);
-                size_t len = strlen(response_str);
-                response->response_text = malloc(len + 1);
-                if (response->response_text) {
-                    strcpy(response->response_text, response_str);
-                    response->response_length = len;
-                    ESP_LOGI(TAG, "Successfully extracted Ollama response");
-                    err = ESP_OK;
+                if (!response_str) {
+                    ESP_LOGE(TAG, "Null string value in Ollama response field");
+                    err = ESP_FAIL;
                 } else {
-                    ESP_LOGE(TAG, "Failed to allocate memory for response text");
-                    err = ESP_ERR_NO_MEM;
+                    size_t len = strlen(response_str);
+                    response->response_text = malloc(len + 1);
+                    if (response->response_text) {
+                        memcpy(response->response_text, response_str, len + 1);
+                        response->response_length = len;
+                        ESP_LOGI(TAG, "Successfully extracted Ollama response");
+                        err = ESP_OK;
+                    } else {
+                        ESP_LOGE(TAG, "Failed to allocate memory for response text");
+                        err = ESP_ERR_NO_MEM;
+                    }
                 }
             } else {
                 ESP_LOGE(TAG, "Failed to parse 'response' field from Ollama JSON");

--- a/packages/robocar/camera/main/wifi_manager.c
+++ b/packages/robocar/camera/main/wifi_manager.c
@@ -86,6 +86,11 @@ esp_err_t wifi_init(void)
 
 esp_err_t wifi_connect(const char *ssid, const char *password)
 {
+    if (!ssid) {
+        ESP_LOGE(TAG, "wifi_connect: SSID is NULL");
+        return ESP_ERR_INVALID_ARG;
+    }
+
     ESP_LOGI(TAG, "Connecting to WiFi SSID: %s", ssid);
 
     wifi_config_t wifi_config = {
@@ -99,7 +104,10 @@ esp_err_t wifi_connect(const char *ssid, const char *password)
     };
 
     strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
-    strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
+    // password may be NULL (open network); leave the buffer zeroed in that case
+    if (password) {
+        strncpy((char *)wifi_config.sta.password, password, sizeof(wifi_config.sta.password) - 1);
+    }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));


### PR DESCRIPTION
## Summary

Four fixes in `packages/robocar/camera/main/`. The original review agent was rate-limited mid-flight; staged edits were salvaged from its worktree, verified, and split into per-concern commits.

## Findings

| File | Issue | Fix |
|------|-------|-----|
| `main.c:478-484` (formerly) | `capture_task_handle` was a **`static` local inside `capture_timer_callback`**, never assigned. `xTaskCreate()` passed `NULL` as the handle out-parameter. The timer fired every period and called `xTaskNotifyGive(NULL)`. The capture task ran only via the free-running iteration in `capture_and_analyze_task`; the timer wake-up path was effectively dead. | Move `capture_task_handle` to file scope and pass its address into `xTaskCreate` |
| `wifi_manager.c:88-110` | `wifi_connect()` deref'd `ssid` and `password` without NULL checks; `password` is allowed to be NULL on open networks but `strncpy(NULL, ...)` would crash | Add NULL guard returning `ESP_ERR_INVALID_ARG` for SSID; treat NULL password as open network (zeroed buffer) |
| `ollama_backend.c:347-368` | `cJSON_GetStringValue()` can return NULL after a parser allocation failure even when `cJSON_IsString()` is true. The result was passed straight to `strlen()` / `strcpy()` | Guard the value and log on NULL |
| `camera.c/h` (already committed in 1st commit) | `camera_return_fb()` returned `void` with no error signal | Return `esp_err_t` for caller diagnostics |

## Notes
- The capture-task fix is the highest-impact: previously the periodic capture-trigger path was a no-op, leaving the system reliant on free-running fallback iteration.
- All changes are minimal and behaviour-preserving on the happy path.

## Test plan
- [ ] CI builds for `robocar-camera`
- [ ] Manual smoke test: confirm `xTaskNotifyTake()` in `capture_and_analyze_task` actually wakes from the timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)