### PR TITLE
fix(llm-telegram): plug llm_client HTTP buffer leak and stale-body re-read

### DIFF
--- a/packages/camera-vision/llm-telegram/main/llm_client.c
+++ b/packages/camera-vision/llm-telegram/main/llm_client.c
@@ -26,45 +26,48 @@ static char *base64_encode(const uint8_t *data, size_t len)
     return encoded;
 }
 
-// HTTP event handler
+// Per-request response accumulator passed via esp_http_client config.user_data.
+// Avoids the static-buffer leak the previous handler had: the buffer's lifetime
+// is now bound to a single request and freed by the caller before return.
+typedef struct {
+    char *buffer;  // malloc'd, NUL-terminated by caller after perform
+    int capacity;  // current allocation size (excluding NUL terminator)
+    int length;    // bytes written so far
+} llm_response_buffer_t;
+
+// HTTP event handler — accumulates the response body into a caller-owned
+// buffer pointed to by evt->user_data. The handler does no allocation that
+// outlives a single request, so HTTP_EVENT_ON_FINISH / DISCONNECTED do not
+// need to free anything; the caller owns and frees the buffer.
 static esp_err_t http_event_handler(esp_http_client_event_t *evt)
 {
-    static char *output_buffer;
-    static int output_len;
-
-    switch (evt->event_id) {
-        case HTTP_EVENT_ON_DATA:
-            if (!esp_http_client_is_chunked_response(evt->client)) {
-                if (output_buffer == NULL) {
-                    output_buffer = (char *)malloc(esp_http_client_get_content_length(evt->client));
-                    output_len = 0;
-                    if (output_buffer == NULL) {
-                        ESP_LOGE(TAG, "Failed to allocate memory for output buffer");
-                        return ESP_FAIL;
-                    }
-                }
-                memcpy(output_buffer + output_len, evt->data, evt->data_len);
-                output_len += evt->data_len;
-            }
-            break;
-        case HTTP_EVENT_ON_FINISH:
-            if (output_buffer != NULL) {
-                evt->data = output_buffer;
-                evt->data_len = output_len;
-                output_buffer = NULL;
-                output_len = 0;
-            }
-            break;
-        case HTTP_EVENT_DISCONNECTED:
-            if (output_buffer != NULL) {
-                free(output_buffer);
-                output_buffer = NULL;
-                output_len = 0;
-            }
-            break;
-        default:
-            break;
+    if (evt->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
     }
+
+    llm_response_buffer_t *acc = (llm_response_buffer_t *)evt->user_data;
+    if (acc == NULL || evt->data_len <= 0) {
+        return ESP_OK;
+    }
+
+    // Grow on demand — handles both content-length and chunked responses.
+    int needed = acc->length + evt->data_len;
+    if (needed > acc->capacity) {
+        int new_capacity = acc->capacity > 0 ? acc->capacity : 1024;
+        while (new_capacity < needed) {
+            new_capacity *= 2;
+        }
+        char *resized = realloc(acc->buffer, new_capacity + 1);
+        if (resized == NULL) {
+            ESP_LOGE(TAG, "Failed to grow response buffer to %d bytes", new_capacity);
+            return ESP_FAIL;
+        }
+        acc->buffer = resized;
+        acc->capacity = new_capacity;
+    }
+
+    memcpy(acc->buffer + acc->length, evt->data, evt->data_len);
+    acc->length += evt->data_len;
     return ESP_OK;
 }
 
@@ -110,12 +113,18 @@ static esp_err_t send_claude_request(const char *prompt, const char *image_base6
     char *json_str = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
 
+    // Per-request response accumulator. The body is delivered to the event
+    // handler during esp_http_client_perform; reading from the client after
+    // perform returns no useful data because the stream is already consumed.
+    llm_response_buffer_t acc = {0};
+
     // Configure HTTP client
     esp_http_client_config_t config = {
         .url = CLAUDE_API_URL,
         .method = HTTP_METHOD_POST,
         .timeout_ms = llm_config.timeout_ms,
         .event_handler = http_event_handler,
+        .user_data = &acc,
         .buffer_size = HTTP_BUFFER_SIZE,
     };
 
@@ -128,42 +137,36 @@ static esp_err_t send_claude_request(const char *prompt, const char *image_base6
 
     esp_http_client_set_post_field(client, json_str, strlen(json_str));
 
-    // Perform request
+    // Perform request — the event handler fills `acc` while this runs.
     err = esp_http_client_perform(client);
 
     if (err == ESP_OK) {
         int status_code = esp_http_client_get_status_code(client);
-        if (status_code == 200) {
-            int content_length = esp_http_client_get_content_length(client);
-            char *buffer = malloc(content_length + 1);
+        if (status_code == 200 && acc.buffer != NULL && acc.length > 0) {
+            acc.buffer[acc.length] = '\0';
 
-            if (buffer) {
-                esp_http_client_read(client, buffer, content_length);
-                buffer[content_length] = '\0';
-
-                // Parse response
-                cJSON *response = cJSON_Parse(buffer);
-                if (response) {
-                    cJSON *content_item = cJSON_GetObjectItem(response, "content");
-                    if (content_item && cJSON_IsArray(content_item)) {
-                        cJSON *first = cJSON_GetArrayItem(content_item, 0);
-                        if (first) {
-                            cJSON *text = cJSON_GetObjectItem(first, "text");
-                            if (text && cJSON_IsString(text)) {
-                                *response_text = strdup(text->valuestring);
-                            }
+            // Parse response
+            cJSON *response = cJSON_Parse(acc.buffer);
+            if (response) {
+                cJSON *content_item = cJSON_GetObjectItem(response, "content");
+                if (content_item && cJSON_IsArray(content_item)) {
+                    cJSON *first = cJSON_GetArrayItem(content_item, 0);
+                    if (first) {
+                        cJSON *text = cJSON_GetObjectItem(first, "text");
+                        if (text && cJSON_IsString(text)) {
+                            *response_text = strdup(text->valuestring);
                         }
                     }
-                    cJSON_Delete(response);
                 }
-                free(buffer);
+                cJSON_Delete(response);
             }
-        } else {
+        } else if (status_code != 200) {
             ESP_LOGE(TAG, "HTTP request failed with status: %d", status_code);
             err = ESP_FAIL;
         }
     }
 
+    free(acc.buffer);
     free(json_str);
     esp_http_client_cleanup(client);
 
@@ -196,11 +199,16 @@ static esp_err_t send_ollama_request(const char *prompt, const char *image_base6
     char url[256];
     snprintf(url, sizeof(url), "%s/api/generate", llm_config.server_url);
 
+    // Per-request response accumulator (see send_claude_request for rationale).
+    llm_response_buffer_t acc = {0};
+
     // Configure HTTP client
     esp_http_client_config_t config = {
         .url = url,
         .method = HTTP_METHOD_POST,
         .timeout_ms = llm_config.timeout_ms,
+        .event_handler = http_event_handler,
+        .user_data = &acc,
         .buffer_size = HTTP_BUFFER_SIZE,
     };
 
@@ -211,27 +219,21 @@ static esp_err_t send_ollama_request(const char *prompt, const char *image_base6
 
     err = esp_http_client_perform(client);
 
-    if (err == ESP_OK) {
-        int content_length = esp_http_client_get_content_length(client);
-        char *buffer = malloc(content_length + 1);
+    if (err == ESP_OK && acc.buffer != NULL && acc.length > 0) {
+        acc.buffer[acc.length] = '\0';
 
-        if (buffer) {
-            esp_http_client_read(client, buffer, content_length);
-            buffer[content_length] = '\0';
-
-            // Parse response
-            cJSON *response = cJSON_Parse(buffer);
-            if (response) {
-                cJSON *response_field = cJSON_GetObjectItem(response, "response");
-                if (response_field && cJSON_IsString(response_field)) {
-                    *response_text = strdup(response_field->valuestring);
-                }
-                cJSON_Delete(response);
+        // Parse response
+        cJSON *response = cJSON_Parse(acc.buffer);
+        if (response) {
+            cJSON *response_field = cJSON_GetObjectItem(response, "response");
+            if (response_field && cJSON_IsString(response_field)) {
+                *response_text = strdup(response_field->valuestring);
             }
-            free(buffer);
+            cJSON_Delete(response);
         }
     }
 
+    free(acc.buffer);
     free(json_str);
     esp_http_client_cleanup(client);
 


### PR DESCRIPTION
## Summary

Follows up the camera-vision code-quality PR (#306), which flagged but
did not fix two bugs in `packages/camera-vision/llm-telegram/main/llm_client.c`:

1. **Static-buffer leak.** The HTTP event handler accumulated body
   chunks into a `static char *output_buffer` malloc'd in
   `HTTP_EVENT_ON_DATA`. In `HTTP_EVENT_ON_FINISH` the handler set
   `output_buffer = NULL` without freeing it — so every successful
   request leaked the response body. The handler attempted to
   "publish" the buffer by writing to `evt->data` / `evt->data_len`,
   but those fields are inspected only by the event loop and were
   never read by the caller, so the contents were also silently
   discarded.

2. **Stale-body re-read.** Both `send_claude_request` and
   `send_ollama_request` called `esp_http_client_read()` *after*
   `esp_http_client_perform()` returned. With ESP-IDF's default
   (non-async) perform, the body has already been consumed by the
   event loop and dispatched to the event handler before `perform`
   returns. The post-perform read returned zero bytes, so cJSON
   parsed an uninitialized `malloc`'d buffer.

## Fix

Minimal change — keep the event-handler model but make the
accumulator per-request and freed by the caller:

- Replace the static accumulator with a `llm_response_buffer_t`
  struct passed through `esp_http_client_config_t.user_data`.
- Handler grows a caller-owned buffer on demand in
  `HTTP_EVENT_ON_DATA` (works for both content-length and chunked
  responses).
- No state outlives a single request, so `_ON_FINISH` /
  `_DISCONNECTED` need no cleanup paths.
- Caller `free(acc.buffer)` before return on every path —
  eliminates the leak.
- Drop the post-perform `esp_http_client_read()` in both request
  functions; the body is already in `acc.buffer` when `perform`
  returns.

Public `llm_client` API (header) is unchanged. Call sites in
`main.c` and `vision_interpreter.c` are unaffected.

## Alternatives considered

- **Stream via `esp_http_client_open` + `fetch_headers` + `read`.**
  Avoids the event handler entirely; cleaner conceptually but
  doubles the diff and changes how chunked transfer encoding is
  handled by the lower layers. The accumulator fix removes both
  bugs without changing the request lifecycle, so it wins on
  diff size.
- **Free the static buffer in `_ON_FINISH` and copy out via a
  global pointer.** Smaller still, but leaves the global state
  smell and the dispatched-by-`evt->data` pattern that the caller
  never reads. Not worth keeping.

## Test plan

- [ ] `just camera-vision::llm-telegram::build` (containerized
      ESP-IDF v5.4) compiles cleanly.
- [ ] `clang-format --dry-run --Werror` and `cppcheck` pass on
      `llm_client.c` (verified locally).
- [ ] On hardware: exercise both the Claude and Ollama backends
      with a sample image and confirm the parsed `response_text`
      matches the API's response body, and that heap usage is
      stable across repeated requests (`heap_caps_get_free_size`
      before/after a batch of N requests should not trend down by
      `content_length` per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)