### PR TITLE
fix(robocar-main): resolve I2C_NUM_1 driver-install conflict

### DIFF
--- a/packages/robocar/main/main/i2c_config.h
+++ b/packages/robocar/main/main/i2c_config.h
@@ -9,16 +9,27 @@
 #include "driver/i2c.h"
 
 // I2C Configuration for inter-board communication
+//
+// Bus assignment on this board (ESP32 has two I2C controllers):
+//   I2C_NUM_0 — PCA9685 master (pins 21/22), managed dynamically by i2cdev.
+//   I2C_NUM_1 — Camera-link slave (pins 26/27), this file.
+//
+// The integrated Heltec OLED also wants I2C_NUM_1 (master, pins 4/15) but
+// is mutually exclusive with the slave — same controller cannot be both
+// master and slave, and the pin sets differ. The slave wins because it is
+// the inter-controller link without which camera commands never reach the
+// main board; init_oled() in main.c skips OLED setup when the slave has
+// already claimed the controller.
 #define I2C_COMM_SCL_IO 26         // SCL pin for ESP32-CAM communication (bidirectional)
 #define I2C_COMM_SDA_IO 27         // SDA pin for ESP32-CAM communication (bidirectional)
-#define I2C_MASTER_NUM I2C_NUM_1   // Use I2C_NUM_1 to avoid conflict with PCA9685
+#define I2C_MASTER_NUM I2C_NUM_1   // Camera-link controller (see header note)
 #define I2C_MASTER_FREQ_HZ 100000  // 100kHz
 #define I2C_MASTER_TX_BUF_DISABLE 0
 #define I2C_MASTER_RX_BUF_DISABLE 0
 #define I2C_MASTER_TIMEOUT_MS 1000
 
 #define I2C_SLAVE_ADDRESS 0x42   // Main board slave address
-#define I2C_SLAVE_NUM I2C_NUM_1  // Use I2C_NUM_1 to avoid conflict with PCA9685
+#define I2C_SLAVE_NUM I2C_NUM_1  // Camera-link controller (see header note)
 #define I2C_SLAVE_TX_BUF_LEN 128
 #define I2C_SLAVE_RX_BUF_LEN 128
 

--- a/packages/robocar/main/main/main.c
+++ b/packages/robocar/main/main/main.c
@@ -183,6 +183,21 @@ void init_oled(void)
         return;
     }
 
+    // Hardware constraint: ESP32 has only two I2C controllers (I2C_NUM_0 and
+    // I2C_NUM_1). I2C_NUM_0 is held by i2cdev for PCA9685 (master, pins 21/22).
+    // I2C_NUM_1 must be reserved for the inter-controller slave link
+    // (slave mode, pins 26/27 — see i2c_slave.c). The OLED would also need
+    // I2C_NUM_1 in master mode on pins 4/15, which is mutually exclusive
+    // with slave mode. When the slave has already claimed the controller,
+    // skip OLED bring-up and run with oled_initialized = false (every OLED
+    // helper is guarded on that flag, so the rest of the firmware degrades
+    // gracefully to "no display").
+    if (i2c_slave_is_ready()) {
+        ESP_LOGW(TAG, "OLED skipped: I2C_NUM_1 is owned by the inter-controller slave link. "
+                      "OLED and the camera I2C link cannot share the bus on this board.");
+        return;
+    }
+
     ESP_LOGI(TAG, "Initializing OLED display using native ESP-IDF LCD driver");
 
     // Configure I2C master
@@ -1305,15 +1320,19 @@ void app_main(void)
         return;
     }
 
-    // Phase 3: Display and feedback systems
-    if (init_display_and_feedback() != ESP_OK) {
-        ESP_LOGE(TAG, "Display initialization failed");
+    // Phase 3: Inter-board communication (I2C slave). Must run before
+    // init_display_and_feedback() so the slave claims I2C_NUM_1 first;
+    // the OLED on this board would otherwise stomp the slave's pin
+    // configuration. See init_oled() for the constraint detail.
+    if (init_inter_board_communication() != ESP_OK) {
+        ESP_LOGE(TAG, "Inter-board communication initialization failed");
         return;
     }
 
-    // Phase 4: Inter-board communication (I2C slave)
-    if (init_inter_board_communication() != ESP_OK) {
-        ESP_LOGE(TAG, "Inter-board communication initialization failed");
+    // Phase 4: Display and feedback systems. Skipped automatically when
+    // the slave already owns I2C_NUM_1 — OLED degrades gracefully to off.
+    if (init_display_and_feedback() != ESP_OK) {
+        ESP_LOGE(TAG, "Display initialization failed");
         return;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #301, which flagged but did not fix the I2C_NUM_1 double-install. With OLED enabled the slave install in Phase 4 returned non-OK and `app_main` bailed before the camera link came up.

## Root cause

The legacy ESP-IDF I2C driver returns failure on a second `i2c_driver_install` for the same port. Both `init_oled()` (`packages/robocar/main/main/main.c:198,204`) and `i2c_slave_init()` (`packages/robocar/main/main/i2c_slave.c:74,82`) target `I2C_NUM_1` — OLED in master mode on pins 4/15, slave in slave mode on pins 26/27. ESP32 has only two I2C peripherals: `I2C_NUM_0` is already held by `i2cdev` for the PCA9685 (master, pins 21/22), so there is no third port and a single controller cannot be both master and slave.

## Fix

The slave is the inter-controller link without which camera commands never reach the main board — it has to win. The OLED is debug-only and every OLED helper already short-circuits on `oled_initialized = false`, so it can degrade gracefully.

- Reorder `app_main`: slave init is now Phase 3, OLED is Phase 4. The slave claims `I2C_NUM_1` first.
- `init_oled()` calls `i2c_slave_is_ready()` and skips the bus setup with a `WARN` log when the slave already owns the controller. Critical: this avoids the `i2c_param_config` call that would otherwise stomp the slave's pin configuration even though the subsequent `i2c_driver_install` would fail.
- Update the misleading "avoid PCA9685 conflict" note in `i2c_config.h` to document the actual bus assignment and the OLED-vs-slave constraint.

## Alternatives considered

- **Move OLED to `I2C_NUM_0` to share with PCA9685.** Doesn't work: `i2cdev` reconfigures the port (pins, mode) on every device call, which would delete the OLED's static install on the next PCA9685 access.
- **Move slave to `I2C_NUM_0`.** Doesn't work: `i2cdev` already owns NUM_0 in master mode for PCA9685; slave/master modes are mutually exclusive.
- **Software/bit-banged OLED.** ESP-IDF provides no software I2C, and `esp_lcd_panel_io_i2c` requires a real hardware bus. Out of scope.
- **Hardware re-wire** (e.g., put OLED on the same physical pins as PCA9685 21/22 so they can share NUM_0 via `i2cdev`). The Heltec V1 integrated OLED is fixed at 4/15/16; this is not feasible without a different board.

## Out of scope

- Dead-modules cleanup (`motor_controller.c`, `display_manager.c`, etc.) flagged in #301.
- `play_sound()` 1ms-yield issue flagged in #301.

## Test plan

- [ ] `just robocar::build-main` (containerized) succeeds — currently blocked by the pre-existing `fishwaldo/esp_ghota` dependency-resolution failure in CI, same as #301. Format check (`just format-check`) is clean locally.
- [ ] On hardware: boot the main controller, verify the log shows `I2C slave initialized and task started` followed by `OLED skipped: I2C_NUM_1 is owned by the inter-controller slave link.` and confirm that movement commands sent over I2C from the camera reach the main board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)