### PR TITLE
fix(thinkpack): resolve ADC_UNIT_1 collision in boombox/glowbug power init

### DIFF
--- a/packages/components/thinkpack-power/Kconfig.projbuild
+++ b/packages/components/thinkpack-power/Kconfig.projbuild
@@ -1,0 +1,34 @@
+menu "ThinkPack Power Monitor"
+
+    config THINKPACK_POWER_ENABLE
+        bool "Enable battery voltage monitor"
+        default n
+        help
+            Enable the thinkpack-power runtime that periodically samples
+            Vbat through ADC1 and classifies battery state (OK / LOW /
+            CRITICAL).
+
+            Disabled by default because no thinkpack reference board
+            currently exposes a Vbat divider on a free ADC1 channel —
+            on boombox and glowbug the only ADC1 pins (GPIO1, GPIO2)
+            are already consumed by the pot_reader and light_sensor
+            drivers, so leaving the monitor on would either silently
+            fail (ADC unit collision) or read sensor input as battery
+            voltage.
+
+            Enable this once your board adds a Vbat divider on a free
+            ADC1 channel. When enabling on a board that already uses
+            ADC1 for sensors, supply the existing oneshot unit handle
+            via power_config_t::adc_handle so the monitor shares the
+            unit instead of trying to install a second driver.
+
+    config THINKPACK_POWER_LOG_DISABLED_ONCE
+        bool "Log a one-shot warning when init is called while disabled"
+        default y
+        depends on !THINKPACK_POWER_ENABLE
+        help
+            Emit a single ESP_LOGW from thinkpack_power_init() when the
+            runtime is gated off, so the call site (e.g. boombox/glowbug
+            main) doesn't appear silently unreachable in logs.
+
+endmenu

--- a/packages/components/thinkpack-power/include/thinkpack_power.h
+++ b/packages/components/thinkpack-power/include/thinkpack_power.h
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #ifdef ESP_PLATFORM
+#include "esp_adc/adc_oneshot.h"
 #include "esp_err.h"
 #else
 typedef int esp_err_t;
@@ -48,6 +49,10 @@ typedef int esp_err_t;
 #ifndef ESP_ERR_INVALID_ARG
 #define ESP_ERR_INVALID_ARG (-1)
 #endif
+/* Host shim — adc_oneshot_unit_handle_t is opaque on device; on host we
+ * never touch it, but the type must still be declared so power_config_t
+ * compiles in the host test build. */
+typedef void *adc_oneshot_unit_handle_t;
 #endif
 
 #ifdef __cplusplus
@@ -78,6 +83,21 @@ typedef struct {
     int adc_gpio;               /**< GPIO number to read Vbat from (ADC1 channel). */
     uint32_t tick_interval_ms;  /**< Periodic classifier tick (default 5000). */
     uint16_t divider_ratio_x10; /**< Vbat / Vadc * 10 (e.g. 20 for a 1:2 divider). 0 => 20. */
+    /**
+     * Optional ADC1 oneshot unit handle owned by the caller.
+     *
+     * When non-NULL, thinkpack_power_init() configures @ref adc_gpio as
+     * an additional channel on the supplied unit and shares it for
+     * sampling. Use this on boards where another driver (e.g. a
+     * potentiometer reader or light sensor) already installed the ADC1
+     * oneshot driver — calling adc_oneshot_new_unit() a second time on
+     * the same unit returns ESP_ERR_INVALID_STATE and silently disables
+     * the power monitor.
+     *
+     * When NULL, the component creates its own ADC1 oneshot unit and
+     * owns its lifecycle.
+     */
+    adc_oneshot_unit_handle_t adc_handle;
 } power_config_t;
 
 /* ------------------------------------------------------------------ */

--- a/packages/components/thinkpack-power/power_mgr.c
+++ b/packages/components/thinkpack-power/power_mgr.c
@@ -22,11 +22,13 @@
 #include "esp_log.h"
 #include "esp_sleep.h"
 #include "esp_timer.h"
+#include "sdkconfig.h"
 
 static const char *TAG = "tp_power";
 
 typedef struct {
     bool initialised;
+    bool owns_adc; /**< true => destroy s_ctx.adc on teardown; false => caller-owned */
     power_config_t config;
     adc_oneshot_unit_handle_t adc;
     adc_cali_handle_t cali;
@@ -82,6 +84,23 @@ static void periodic_tick(void *arg)
 
 esp_err_t thinkpack_power_init(const power_config_t *config)
 {
+#if !CONFIG_THINKPACK_POWER_ENABLE
+    /* Runtime gated off via Kconfig. The default state on every reference
+     * board today: no Vbat divider is wired, and on boombox/glowbug the
+     * obvious ADC1 channels (GPIO1/GPIO2) are already owned by other
+     * drivers. Returning ESP_OK here keeps the call site non-fatal but
+     * makes the disabled state explicit in logs. */
+    (void)config;
+#if CONFIG_THINKPACK_POWER_LOG_DISABLED_ONCE
+    static bool logged = false;
+    if (!logged) {
+        logged = true;
+        ESP_LOGW(TAG, "thinkpack_power_init: runtime disabled "
+                      "(CONFIG_THINKPACK_POWER_ENABLE=n); skipping ADC setup");
+    }
+#endif
+    return ESP_OK;
+#else
     if (!config || config->adc_gpio < 0) {
         return ESP_ERR_INVALID_ARG;
     }
@@ -98,23 +117,36 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
         s_ctx.config.divider_ratio_x10 = 20u; /* 1:2 divider by default */
     }
 
-    adc_oneshot_unit_init_cfg_t init_cfg = {.unit_id = ADC_UNIT_1};
-    esp_err_t err = adc_oneshot_new_unit(&init_cfg, &s_ctx.adc);
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "adc_oneshot_new_unit failed: %d", err);
-        return err;
+    esp_err_t err;
+    if (config->adc_handle != NULL) {
+        /* Caller already owns an ADC1 oneshot unit (e.g. pot_reader or
+         * light_sensor). Share it instead of installing a second driver,
+         * which would return ESP_ERR_INVALID_STATE and silently disable
+         * the power monitor. */
+        s_ctx.adc = config->adc_handle;
+        s_ctx.owns_adc = false;
+    } else {
+        adc_oneshot_unit_init_cfg_t init_cfg = {.unit_id = ADC_UNIT_1};
+        err = adc_oneshot_new_unit(&init_cfg, &s_ctx.adc);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "adc_oneshot_new_unit failed: %d", err);
+            return err;
+        }
+        s_ctx.owns_adc = true;
     }
 
     adc_oneshot_chan_cfg_t chan_cfg = {.atten = ADC_ATTEN_DB_12, .bitwidth = ADC_BITWIDTH_DEFAULT};
     /* ADC1 channel from GPIO lookup is target-specific; for the ESP32-S3
-     * SuperMini we default to the GPIO1/CH0 wiring documented in WIRING.md.
+     * SuperMini the GPIO->channel mapping is GPIO1->CH0, GPIO2->CH1, etc.
      * Caller supplies adc_gpio in power_config_t; we trust the pinout. */
-    s_ctx.channel = (adc_channel_t)(config->adc_gpio - 1); /* GPIO1 -> CH0, GPIO2 -> CH1, ... */
+    s_ctx.channel = (adc_channel_t)(config->adc_gpio - 1);
     err = adc_oneshot_config_channel(s_ctx.adc, s_ctx.channel, &chan_cfg);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "adc_oneshot_config_channel failed: %d", err);
-        adc_oneshot_del_unit(s_ctx.adc);
-        s_ctx.adc = NULL;
+        if (s_ctx.owns_adc && s_ctx.adc) {
+            adc_oneshot_del_unit(s_ctx.adc);
+            s_ctx.adc = NULL;
+        }
         return err;
     }
 
@@ -140,7 +172,9 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
             adc_cali_delete_scheme_curve_fitting(s_ctx.cali);
             s_ctx.cali = NULL;
         }
-        adc_oneshot_del_unit(s_ctx.adc);
+        if (s_ctx.owns_adc && s_ctx.adc) {
+            adc_oneshot_del_unit(s_ctx.adc);
+        }
         s_ctx.adc = NULL;
         return err;
     }
@@ -155,7 +189,9 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
             adc_cali_delete_scheme_curve_fitting(s_ctx.cali);
             s_ctx.cali = NULL;
         }
-        adc_oneshot_del_unit(s_ctx.adc);
+        if (s_ctx.owns_adc && s_ctx.adc) {
+            adc_oneshot_del_unit(s_ctx.adc);
+        }
         s_ctx.adc = NULL;
         return err;
     }
@@ -165,6 +201,7 @@ esp_err_t thinkpack_power_init(const power_config_t *config)
     ESP_LOGI(TAG, "power monitor started — gpio=%d tick=%u ms", config->adc_gpio,
              (unsigned)s_ctx.config.tick_interval_ms);
     return ESP_OK;
+#endif /* CONFIG_THINKPACK_POWER_ENABLE */
 }
 
 uint16_t thinkpack_power_read_voltage_mv(void)

--- a/packages/thinkpack/boombox/main/main.c
+++ b/packages/thinkpack/boombox/main/main.c
@@ -108,10 +108,20 @@ void app_main(void)
     ESP_ERROR_CHECK(thinkpack_ota_receiver_init(BOX_BOOMBOX));
     ESP_ERROR_CHECK(thinkpack_mesh_start());
 
-    /* Power monitor — after mesh.  GPIO1/ADC1_CH0 by default: verify against
-     * WIRING.md before committing to a real board. */
-    (void)thinkpack_power_init(
-        &(power_config_t){.adc_gpio = 1, .tick_interval_ms = 5000, .divider_ratio_x10 = 20});
+    /* Power monitor — gated off by default (CONFIG_THINKPACK_POWER_ENABLE=n)
+     * because boombox has no Vbat divider in WIRING.md and the only ADC1
+     * channels (GPIO1/GPIO2) are already owned by pot_reader. When a future
+     * revision adds a Vbat divider on a free ADC1 channel, set the Kconfig
+     * option, change adc_gpio to that pin, and the shared adc_handle below
+     * lets thinkpack-power configure the new channel without re-installing
+     * the ADC1 oneshot driver (which would fail with ESP_ERR_INVALID_STATE
+     * and silently disable the monitor). */
+    (void)thinkpack_power_init(&(power_config_t){
+        .adc_gpio = 1, /* placeholder — replace once a real Vbat pin is wired */
+        .tick_interval_ms = 5000,
+        .divider_ratio_x10 = 20,
+        .adc_handle = pot_reader_get_adc_handle(),
+    });
 
     ESP_LOGI(TAG, "Mesh started — spawning tone task on Core 1");
 

--- a/packages/thinkpack/boombox/main/pot_reader.c
+++ b/packages/thinkpack/boombox/main/pot_reader.c
@@ -140,3 +140,8 @@ int8_t pot_pitch_to_semitones(uint16_t raw)
         shift = SEMITONE_MAX;
     return (int8_t)shift;
 }
+
+adc_oneshot_unit_handle_t pot_reader_get_adc_handle(void)
+{
+    return s_adc_handle;
+}

--- a/packages/thinkpack/boombox/main/pot_reader.h
+++ b/packages/thinkpack/boombox/main/pot_reader.h
@@ -15,6 +15,8 @@
 
 #include <stdint.h>
 
+#include "esp_adc/adc_oneshot.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -65,6 +67,20 @@ uint16_t pot_tempo_to_bpm(uint16_t raw);
  * @return     Semitone shift in [-12, +12].
  */
 int8_t pot_pitch_to_semitones(uint16_t raw);
+
+/**
+ * @brief Borrow the ADC1 oneshot unit handle owned by pot_reader.
+ *
+ * Returned handle is valid for the lifetime of the program after
+ * pot_reader_init() succeeds. Other modules (e.g. thinkpack-power) may
+ * configure additional channels on this handle to share the unit
+ * instead of re-installing the driver, which would silently fail with
+ * ESP_ERR_INVALID_STATE.
+ *
+ * @return Shared handle, or NULL if pot_reader_init() has not yet
+ *         completed successfully.
+ */
+adc_oneshot_unit_handle_t pot_reader_get_adc_handle(void);
 
 #ifdef __cplusplus
 }

--- a/packages/thinkpack/glowbug/main/light_sensor.c
+++ b/packages/thinkpack/glowbug/main/light_sensor.c
@@ -49,3 +49,8 @@ esp_err_t light_sensor_read(int *out_raw)
 {
     return adc_oneshot_read(s_adc, LIGHT_SENSOR_ADC_CHANNEL, out_raw);
 }
+
+adc_oneshot_unit_handle_t light_sensor_get_adc_handle(void)
+{
+    return s_adc;
+}

--- a/packages/thinkpack/glowbug/main/light_sensor.h
+++ b/packages/thinkpack/glowbug/main/light_sensor.h
@@ -13,6 +13,7 @@
 
 #include <stdint.h>
 
+#include "esp_adc/adc_oneshot.h"
 #include "esp_err.h"
 
 #ifdef __cplusplus
@@ -41,6 +42,20 @@ esp_err_t light_sensor_init(void);
  * @return ESP_OK on success.
  */
 esp_err_t light_sensor_read(int *out_raw);
+
+/**
+ * @brief Borrow the ADC1 oneshot unit handle owned by light_sensor.
+ *
+ * Returned handle is valid for the lifetime of the program after
+ * light_sensor_init() succeeds. Other modules (e.g. thinkpack-power) may
+ * configure additional channels on this handle to share the unit
+ * instead of re-installing the driver, which would silently fail with
+ * ESP_ERR_INVALID_STATE.
+ *
+ * @return Shared handle, or NULL if light_sensor_init() has not yet
+ *         completed successfully.
+ */
+adc_oneshot_unit_handle_t light_sensor_get_adc_handle(void);
 
 #ifdef __cplusplus
 }

--- a/packages/thinkpack/glowbug/main/main.c
+++ b/packages/thinkpack/glowbug/main/main.c
@@ -105,12 +105,20 @@ void app_main(void)
     ESP_ERROR_CHECK(thinkpack_ota_receiver_init(BOX_GLOWBUG));
     ESP_ERROR_CHECK(thinkpack_mesh_start());
 
-    /* Power monitor — started after mesh so the mesh is up before the first
-     * classifier tick fires (classifier state transitions log, eventually
-     * reconfiguring beacon rate).  GPIO1/ADC1_CH0: verify against WIRING.md
-     * before committing to a real board. */
-    (void)thinkpack_power_init(
-        &(power_config_t){.adc_gpio = 1, .tick_interval_ms = 5000, .divider_ratio_x10 = 20});
+    /* Power monitor — gated off by default (CONFIG_THINKPACK_POWER_ENABLE=n)
+     * because glowbug has no Vbat divider in WIRING.md and GPIO1/ADC1_CH0
+     * is already owned by light_sensor. When a future revision adds a Vbat
+     * divider on a free ADC1 channel, set the Kconfig option, change
+     * adc_gpio to that pin, and the shared adc_handle below lets
+     * thinkpack-power configure the new channel without re-installing the
+     * ADC1 oneshot driver (which would fail with ESP_ERR_INVALID_STATE and
+     * silently disable the monitor). */
+    (void)thinkpack_power_init(&(power_config_t){
+        .adc_gpio = 1, /* placeholder — replace once a real Vbat pin is wired */
+        .tick_interval_ms = 5000,
+        .divider_ratio_x10 = 20,
+        .adc_handle = light_sensor_get_adc_handle(),
+    });
 
     ESP_LOGI(TAG, "Mesh started — spawning animation task on Core 1");
 


### PR DESCRIPTION
## Background

PR #308 (code-quality follow-up) flagged but did not fix this:

> `boombox` and `glowbug` configure `thinkpack_power_init({.adc_gpio=1})` after `pot_reader` / `light_sensor` already grabbed `ADC_UNIT_1` — collision silently disables the power monitor.

## Investigation

- `pot_reader.c` (boombox) calls `adc_oneshot_new_unit({.unit_id = ADC_UNIT_1})` for GPIO1=tempo, GPIO2=pitch (per [`boombox/WIRING.md`](../blob/main/packages/thinkpack/boombox/WIRING.md)).
- `light_sensor.c` (glowbug) calls the same for GPIO1=LDR (per [`glowbug/WIRING.md`](../blob/main/packages/thinkpack/glowbug/WIRING.md)).
- `thinkpack_power_init()` in `power_mgr.c` then calls `adc_oneshot_new_unit({.unit_id = ADC_UNIT_1})` again. Per ESP-IDF, the second call returns `ESP_ERR_INVALID_STATE`. Both call sites cast the error away with `(void)`, so the failure is invisible.
- No board's WIRING.md documents a Vbat divider on a free ADC1 channel — the `adc_gpio=1` is a placeholder ("verify against WIRING.md before committing to a real board").

## Fix

The hardware doesn't have a real Vbat-on-ADC pin yet *and* the architectural flaw is real, so this PR addresses both:

1. **`thinkpack-power`**: gate the runtime behind `CONFIG_THINKPACK_POWER_ENABLE` (Kconfig.projbuild, default `n`). When disabled, `thinkpack_power_init` logs a one-shot WARN and returns ESP_OK so existing call sites stay non-fatal but the disabled state is no longer silent.
2. **`thinkpack-power`**: extend `power_config_t` with an optional `adc_handle`. When non-NULL, the component shares the caller's ADC1 oneshot unit instead of trying to install a second driver. `owns_adc` tracks lifecycle so cleanup paths don't destroy a borrowed handle.
3. **`boombox`** & **`glowbug`**: expose `pot_reader_get_adc_handle()` / `light_sensor_get_adc_handle()`, and pass that handle through `power_config_t::adc_handle`. With the Kconfig default-off this is a no-op today, but flipping the Kconfig on a future board with a real Vbat divider Just Works.

The placeholder `adc_gpio=1` stays — runtime is gated off, so it can't cause a mis-reading. When a real Vbat pin arrives, set the Kconfig and update `adc_gpio` in main.c.

## Test plan

- [x] Host unit tests still pass (31/31, no regressions): `make -C packages/components/thinkpack-power/test test`.
- [ ] CI esp32-build matrix succeeds for boombox + glowbug (the local containerized build is blocked by an unrelated `fishwaldo/esp_ghota` component-registry resolution issue; CI uses the lockfile).
- [ ] Manual: when `CONFIG_THINKPACK_POWER_ENABLE=y` is set on a board with a Vbat divider on (e.g.) GPIO3/ADC1_CH2, the monitor reads voltage without disturbing the existing pot/light sensor.

## Out of scope

- The standalone_mode tearing race (benign per agent review).
- chatterbox's pre-`abort()` boot leak.
- The placeholder `adc_gpio=1` value — kept as-is until WIRING.md gains a real Vbat pin.