### PR TITLE
chore: add .editorconfig + SECURITY.md, remove stale cppcheck-report.txt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,46 @@
+# EditorConfig — cross-editor formatting baseline for MCU Tinkering Lab.
+# Settings here mirror what `.clang-format` (C/C++) and `ruff.toml` (Python)
+# enforce on commit; this file just gets editors to do the right thing
+# before pre-commit ever runs.
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# YAML / JSON / TOML — 2-space is the community norm.
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+# Markdown — preserve trailing whitespace (hard-break syntax).
+[*.md]
+trim_trailing_whitespace = false
+
+# Makefiles require tab indentation.
+[Makefile]
+indent_style = tab
+
+# C / C++ / headers — 4 spaces, matches `.clang-format` (IndentWidth: 4).
+[*.{c,cpp,h,hpp}]
+indent_size = 4
+
+# Python — 4 spaces, matches ruff defaults.
+[*.py]
+indent_size = 4
+
+# Justfiles — recipe bodies are indented with spaces in this repo's
+# shebang recipes; just itself is whitespace-tolerant.
+[justfile]
+indent_style = space
+indent_size = 4
+
+# Shell scripts.
+[*.{sh,bash}]
+indent_style = space
+indent_size = 4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Supported Versions
+
+This is an active hobbyist / lab monorepo. Only the current `main` branch
+of each firmware project receives security fixes. Pinned release tags
+(`v*.*.*`) are not patched — re-flash from the latest `main` to pick up
+fixes.
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | Yes       |
+| Tagged releases | No (re-flash from `main`) |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities **privately** via GitHub Security Advisories:
+
+https://github.com/laurigates/mcu-tinkering-lab/security/advisories/new
+
+Do not file a public issue, open a PR with the fix, or discuss the
+problem in public channels until a fix has landed on `main`.
+
+When reporting, please include:
+
+- The affected project (e.g. `packages/robocar/main`, `packages/networking/wireguard-ha`).
+- The commit SHA or release tag you tested against.
+- Reproduction steps or a proof-of-concept, where possible.
+- Your assessment of impact (credential exposure, RCE on the device,
+  unauthenticated OTA, etc.).
+
+## Response Expectations
+
+- **Acknowledgement**: within ~7 days of receipt.
+- **Triage and remediation timeline**: communicated after triage; expect
+  best-effort rather than enterprise SLA — this is a personal project.
+- **Disclosure**: coordinated. Once a fix is on `main`, the advisory
+  will be published with credit to the reporter (unless anonymity is
+  requested).
+
+## Scope
+
+In scope:
+
+- Firmware vulnerabilities in this repository's projects (memory safety,
+  command injection, auth bypass, etc.).
+- Leaked credentials or secrets in committed code or build artifacts.
+- Insecure OTA update flows (downgrade, MITM, unsigned images).
+- Insecure transport defaults (plaintext MQTT/HTTP where TLS is
+  expected, weak TLS configuration).
+- Web flasher (`docs/flasher/`) issues that could push malicious
+  firmware to a user's device.
+
+Out of scope:
+
+- Third-party silicon errata (ESP32, STM32, NRF, etc.) — report to the
+  vendor.
+- Denial-of-service via radio interference (jamming, 2.4 GHz noise).
+- Vulnerabilities in upstream dependencies (ESP-IDF, Bluepad32, vendored
+  components) — report upstream, then open a tracking issue here once
+  the upstream advisory is public.
+- Physical attacks requiring direct hardware access (e.g. JTAG/UART
+  probing of an unprotected dev board).
+- Issues that require the user to flash an attacker-controlled binary
+  themselves.


### PR DESCRIPTION
## Summary

Three small repo-hygiene items in one PR.

- **`.editorconfig`** (Closes #316): cross-editor formatting baseline that mirrors what `.clang-format` (C/C++, 4-space) and `ruff.toml` (Python, 4-space) already enforce on commit. YAML/JSON/TOML get 2 spaces; Makefile gets tabs; Markdown preserves trailing whitespace (hard-break syntax).
- **`SECURITY.md`** (Closes #317): one-screen vulnerability disclosure policy. Reporting via GitHub private security advisories (`/security/advisories/new`), ~7-day acknowledgement, `main`-only support for firmware. Scope: firmware vulns, credential leaks, OTA/transport security. Out of scope: third-party silicon errata, radio-interference DoS.
- **`cppcheck-report.txt`** (Closes #319): 14MB tracked-as-ignored file removed from the working tree. CI regenerates it on demand.

## Test plan

- [x] `git status` after deletion shows no attempt to add `cppcheck-report.txt` (it's correctly gitignored)
- [x] `.editorconfig` settings cross-checked against `.clang-format` (`IndentWidth: 4`) and `ruff.toml` (`indent-style = "space"`, py311 default 4-space)
- [ ] CI passes (pre-commit, format check, ESP32 builds)

Closes #316
Closes #317
Closes #319