### PR TITLE
ci(perf): cache ESP-IDF toolchain across workflow runs

### DIFF
--- a/.github/workflows/_build-esp32-firmware.yml
+++ b/.github/workflows/_build-esp32-firmware.yml
@@ -55,6 +55,39 @@ jobs:
           submodules: recursive
           ref: ${{ inputs.release_tag }}
 
+      # Cache the espressif/idf Docker image as a tarball so subsequent jobs
+      # skip the multi-GB `docker pull`. Keyed strictly on IDF_VERSION since
+      # the image tag is immutable once published.
+      - name: Cache ESP-IDF Docker image
+        id: idf-image-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/esp-idf-docker
+          key: esp-idf-docker-${{ runner.os }}-${{ env.IDF_VERSION }}
+
+      - name: Load ESP-IDF Docker image from cache
+        if: steps.idf-image-cache.outputs.cache-hit == 'true'
+        run: docker load --input ~/.cache/esp-idf-docker/espressif-idf-${{ env.IDF_VERSION }}.tar
+
+      - name: Pull and save ESP-IDF Docker image
+        if: steps.idf-image-cache.outputs.cache-hit != 'true'
+        run: |
+          docker pull espressif/idf:${{ env.IDF_VERSION }}
+          mkdir -p ~/.cache/esp-idf-docker
+          docker save espressif/idf:${{ env.IDF_VERSION }} \
+            -o ~/.cache/esp-idf-docker/espressif-idf-${{ env.IDF_VERSION }}.tar
+
+      # Cache IDF Component Manager downloads (managed_components/ inside the
+      # project) keyed on the lockfile. Falls back to the latest cache for this
+      # project on lockfile change.
+      - name: Cache IDF managed components
+        uses: actions/cache@v4
+        with:
+          path: packages/${{ inputs.project_path }}/managed_components
+          key: idf-components-${{ runner.os }}-${{ env.IDF_VERSION }}-${{ inputs.project }}-${{ hashFiles(format('packages/{0}/dependencies.lock', inputs.project_path), format('packages/{0}/main/idf_component.yml', inputs.project_path)) }}
+          restore-keys: |
+            idf-components-${{ runner.os }}-${{ env.IDF_VERSION }}-${{ inputs.project }}-
+
       - name: Fetch bluepad32 dependencies
         if: inputs.fetch_bluepad32
         working-directory: packages/${{ inputs.project_path }}

--- a/.github/workflows/_ci-build-esp32.yml
+++ b/.github/workflows/_ci-build-esp32.yml
@@ -34,6 +34,39 @@ jobs:
         with:
           submodules: recursive
 
+      # Cache the espressif/idf Docker image as a tarball so subsequent jobs
+      # skip the multi-GB `docker pull`. Keyed strictly on IDF_VERSION since
+      # the image tag is immutable once published.
+      - name: Cache ESP-IDF Docker image
+        id: idf-image-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/esp-idf-docker
+          key: esp-idf-docker-${{ runner.os }}-${{ env.IDF_VERSION }}
+
+      - name: Load ESP-IDF Docker image from cache
+        if: steps.idf-image-cache.outputs.cache-hit == 'true'
+        run: docker load --input ~/.cache/esp-idf-docker/espressif-idf-${{ env.IDF_VERSION }}.tar
+
+      - name: Pull and save ESP-IDF Docker image
+        if: steps.idf-image-cache.outputs.cache-hit != 'true'
+        run: |
+          docker pull espressif/idf:${{ env.IDF_VERSION }}
+          mkdir -p ~/.cache/esp-idf-docker
+          docker save espressif/idf:${{ env.IDF_VERSION }} \
+            -o ~/.cache/esp-idf-docker/espressif-idf-${{ env.IDF_VERSION }}.tar
+
+      # Cache IDF Component Manager downloads (~/managed_components inside each
+      # project) keyed on the lockfile. Falls back to the latest cache for this
+      # project on lockfile change.
+      - name: Cache IDF managed components
+        uses: actions/cache@v4
+        with:
+          path: packages/${{ inputs.project_path }}/managed_components
+          key: idf-components-${{ runner.os }}-${{ env.IDF_VERSION }}-${{ inputs.project }}-${{ hashFiles(format('packages/{0}/dependencies.lock', inputs.project_path), format('packages/{0}/main/idf_component.yml', inputs.project_path)) }}
+          restore-keys: |
+            idf-components-${{ runner.os }}-${{ env.IDF_VERSION }}-${{ inputs.project }}-
+
       - name: Fetch bluepad32 dependencies
         if: inputs.fetch_bluepad32
         working-directory: packages/${{ inputs.project_path }}


### PR DESCRIPTION
Closes #323

## Summary

Adds two complementary caches to the reusable ESP-IDF build workflows
to eliminate redundant downloads on every CI run.

## Research findings

`espressif/esp-idf-ci-action@v1` runs `idf.py build` **inside the
`espressif/idf:<version>` Docker container** with the workspace
bind-mounted at `/app/<repo>`:

```yaml
docker run -t ... -v "${GITHUB_WORKSPACE}:/app/${{ github.repository }}" \
  espressif/idf:v5.4 /bin/bash -c '... idf.py build ...'
```

Nothing lands in `~/.espressif` on the host, so the conventional
"cache the host toolchain" pattern documented for local ESP-IDF
installs does not apply here. The real cost drivers on each job are:

1. `docker pull espressif/idf:v5.4` — multi-GB image pull.
2. IDF Component Manager re-fetching every dependency into the
   project's `managed_components/` directory (gitignored, ephemeral
   under `GITHUB_WORKSPACE`).

The action takes no `path` input; it does not set `IDF_PATH` on the
host. The single workflow input identifying the IDF version is the
`IDF_VERSION` env var already defined in both reusable workflows
(`v5.4`).

## Cache paths chosen

| Path | Why | Key |
|---|---|---|
| `~/.cache/esp-idf-docker/espressif-idf-<ver>.tar` | `docker save`/`docker load` of the `espressif/idf:<ver>` image — replaces multi-GB Docker Hub pull with a local tarball restore | `esp-idf-docker-<os>-<IDF_VERSION>` (image tag is immutable, so no extra dimensions needed) |
| `packages/<project>/managed_components` | IDF Component Manager downloads, persisted via the bind-mounted workspace | `idf-components-<os>-<IDF_VERSION>-<project>-<hash(dependencies.lock, main/idf_component.yml)>` with project-level `restore-keys` fallback |

The cache step lands in the **two reusable workflows** that actually
invoke the action — `_ci-build-esp32.yml` and `_build-esp32-firmware.yml`.
The 20+ thin caller workflows (`build-*.yml`) delegate to these so
benefit automatically without duplication.

## Caveats

- The Docker image cache pays its first-run pull-and-save cost the
  same as today. Steady-state runs skip the pull entirely.
- `managed_components/` is only present for projects with an
  `idf_component.yml`. The cache step is unconditional but the
  directory may not exist on cache-save; `actions/cache` no-ops on
  missing paths.
- `dependencies.lock` may not exist for projects that haven't run
  `idf.py reconfigure` locally. `hashFiles()` returns empty on
  missing files, which simply degrades the cache key to "any
  components for this project" — still a usable fallback via
  `restore-keys`.

## Conflict heads-up

**Agent 4 (`ci/workflows-hygiene-pass`, PRs related to #320/#321/#322/
#324) is editing the same workflow files in parallel** (separate
worktree, so no live conflict). Expect a merge conflict at PR landing
— resolve when both PRs are reviewed.

## Test plan

- [ ] First post-merge CI run pulls and saves the Docker image (cold
      cache, no change in build time).
- [ ] Second run on `main` (or a follow-up PR) confirms cache hit on
      both `esp-idf-docker-*` and `idf-components-*` keys and shows
      meaningful wall-time reduction on the build step.
- [ ] Verify `Cache restored from key: esp-idf-docker-Linux-v5.4`
      appears in the build logs.