### PR TITLE
chore(docker): run ESP-IDF container as non-root user matching host UID/GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,46 @@ RUN pip install --no-cache-dir --break-system-packages \
     mypy \
     uv
 
+# Create a non-root user matching the host UID/GID so build outputs in the
+# bind-mounted workspace are owned by the developer, not root. See issue #318.
+#
+# Common collisions to handle:
+#   * macOS `id -g` returns 20, which collides with Debian's `dialout` group.
+#   * On Linux hosts, UID/GID 1000 may already be claimed by a base-image user.
+# When the requested GID/UID already exists we reuse that group/user instead
+# of failing the build.
+ARG USER_UID=1000
+ARG USER_GID=1000
+RUN set -eux; \
+    if getent group "${USER_GID}" >/dev/null; then \
+        groupmod --new-name dev "$(getent group "${USER_GID}" | cut -d: -f1)" || true; \
+    else \
+        groupadd --gid "${USER_GID}" dev; \
+    fi; \
+    if getent passwd "${USER_UID}" >/dev/null; then \
+        existing_user="$(getent passwd "${USER_UID}" | cut -d: -f1)"; \
+        usermod --login dev --home /home/dev --move-home --shell /bin/bash --gid "${USER_GID}" "${existing_user}" 2>/dev/null \
+            || usermod --home /home/dev --shell /bin/bash --gid "${USER_GID}" "${existing_user}"; \
+    else \
+        useradd --create-home --uid "${USER_UID}" --gid "${USER_GID}" --shell /bin/bash dev; \
+    fi; \
+    install -d -o "${USER_UID}" -g "${USER_GID}" /home/dev /home/dev/.cache; \
+    # ESP-IDF's entrypoint sources export.sh which writes into /opt/esp
+    # (deactivate scripts, tool detection, ccache). Give dev ownership so the
+    # toolchain can initialize without root.
+    chown -R "${USER_UID}:${USER_GID}" /opt/esp /home/dev
+
 # Set working directory
 WORKDIR /workspace
 
-# Configure git to trust the workspace directory (for pre-commit)
+# Configure git to trust the workspace directory for both root (image build)
+# and the dev user (runtime).
+RUN git config --global --add safe.directory /workspace
+USER dev
 RUN git config --global --add safe.directory /workspace
 
 # Set environment variables
+ENV HOME=/home/dev
 ENV IDF_PATH=/opt/esp/idf
 ENV IDF_TOOLS_PATH=/opt/esp
 ENV PATH="${IDF_PATH}/tools:${PATH}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Match the host UID/GID so build outputs in the bind-mounted
+        # workspace are owned by the developer, not root. See issue #318.
+        USER_UID: ${USER_UID:-1000}
+        USER_GID: ${USER_GID:-1000}
     image: mcu-tinkering-lab/esp-idf:v5.4
     volumes:
       # Mount the entire workspace (build output stays on host for flashing)


### PR DESCRIPTION
## Summary

Fixes the root-owned `build/` artifacts that `docker-compose.yml` was supposed to prevent.

`docker-compose.yml` already plumbed `USER_UID`/`USER_GID` env vars, but the `Dockerfile` never created a user or applied `USER`, so the container ran as root and produced root-owned outputs in the bind-mounted workspace. Masked on macOS by Docker Desktop UID remapping, painful on Linux/Podman.

**Option A (preferred)** chosen: add a non-root `dev` user in the Dockerfile, give it ownership of `/opt/esp` so ESP-IDF's entrypoint can source `export.sh` without root, and wire `USER_UID`/`USER_GID` from compose through to Docker build args.

## Changes

- `Dockerfile`: Add `ARG USER_UID`/`USER_GID`, create `dev` user, `chown -R` `/opt/esp` and `/home/dev`, switch to `USER dev`. Handles existing-user/group collisions defensively (macOS uid 501 / gid 20 vs Debian defaults) by reusing the existing entry rather than failing the build.
- `docker-compose.yml`: Pass `USER_UID`/`USER_GID` as build args (in addition to runtime env vars) so the image is baked with the developer's UID/GID.

## Smoke test (local, macOS)

```
USER_UID=$(id -u) USER_GID=$(id -g) docker compose build esp-idf
USER_UID=$(id -u) USER_GID=$(id -g) docker compose run --rm esp-idf bash -c 'id && idf.py --version && touch /workspace/.t && ls -la /workspace/.t'
```

Result:
- `uid=502(dev) gid=20(dev) groups=20(dev)`
- `ESP-IDF v5.4`
- `/workspace/.t` owned by host user, not root

## Notes for review

- The compose `environment:` entries for `USER_UID`/`USER_GID` are now redundant for the build, but kept so they're available at runtime if any project tooling reads them. Happy to drop them in a follow-up if preferred.
- The default `USER_UID=1000`/`USER_GID=1000` matches the most common Linux developer case. macOS users (and CI) should export their own.
- CI will need to verify on a Linux runner — local smoke test confirms macOS path.

Closes #318