### PR TITLE
ci(security): pass MQTT secrets via env vars instead of shell interpolation

### DIFF
--- a/.github/workflows/_build-esp32-firmware.yml
+++ b/.github/workflows/_build-esp32-firmware.yml
@@ -141,16 +141,20 @@ jobs:
       - name: Notify devices of new firmware via MQTT
         if: inputs.mqtt_ota_notify && vars.MQTT_ENABLED == 'true' && inputs.mqtt_notify_topic != ''
         continue-on-error: true
+        env:
+          MQTT_BROKER_HOST: ${{ secrets.MQTT_BROKER_HOST }}
+          MQTT_BROKER_PORT: ${{ secrets.MQTT_BROKER_PORT }}
+          MQTT_NOTIFY_TOPIC: ${{ inputs.mqtt_notify_topic }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq mosquitto-clients
 
-          BROKER_PORT="${{ secrets.MQTT_BROKER_PORT }}"
           mosquitto_pub \
-            -h "${{ secrets.MQTT_BROKER_HOST }}" \
-            -p "${BROKER_PORT:-1883}" \
-            -t "${{ inputs.mqtt_notify_topic }}" \
-            -m "${{ inputs.release_tag }}" \
+            -h "$MQTT_BROKER_HOST" \
+            -p "${MQTT_BROKER_PORT:-1883}" \
+            -t "$MQTT_NOTIFY_TOPIC" \
+            -m "$RELEASE_TAG" \
             -q 1
 
       - name: Generate build summary

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -204,16 +204,19 @@ jobs:
       - name: Notify robots of new firmware via MQTT
         if: github.event_name == 'release' && vars.MQTT_ENABLED == 'true'
         continue-on-error: true
+        env:
+          MQTT_BROKER_HOST: ${{ secrets.MQTT_BROKER_HOST }}
+          MQTT_BROKER_PORT: ${{ secrets.MQTT_BROKER_PORT }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq mosquitto-clients
 
-          BROKER_PORT="${{ secrets.MQTT_BROKER_PORT }}"
           mosquitto_pub \
-            -h "${{ secrets.MQTT_BROKER_HOST }}" \
-            -p "${BROKER_PORT:-1883}" \
+            -h "$MQTT_BROKER_HOST" \
+            -p "${MQTT_BROKER_PORT:-1883}" \
             -t "robocar/ota/notify" \
-            -m "${{ github.event.release.tag_name }}" \
+            -m "$RELEASE_TAG" \
             -q 1
 
       - name: Generate build summary


### PR DESCRIPTION
Closes #325

## Summary

Refactor MQTT secret usage in the firmware build workflows so secrets flow through `env:` blocks rather than being interpolated directly into shell commands via `${{ secrets.* }}`.

Files changed:
- `.github/workflows/build-firmware.yml` (Notify robots step)
- `.github/workflows/_build-esp32-firmware.yml` (Notify devices step)

## Why

Direct `${{ secrets.X }}` interpolation places the secret value into the shell as an unquoted literal at template-expansion time. A hostname like `host;rm -rf /` would execute as a command rather than be treated as a string. Low risk for an internal MQTT host today, but the standard hardening pattern is to indirect via `env:` and use a quoted shell variable at the usage site so the value is always treated as data.

## Heads-up: expected conflict at landing

A parallel branch (`ci/workflows-hygiene-pass`) is editing the same two workflow files (adding permissions/concurrency blocks). The two changes touch different parts of each file so a textual conflict is unlikely, but whichever lands second may need a trivial rebase.

## Test plan

- [x] YAML parses cleanly on both workflow files (`python3 -c "import yaml; yaml.safe_load(open(<file>))"`)
- [ ] CI passes on the PR
- [ ] On the next release, the MQTT notify step still publishes correctly