### PR TITLE
ci: workflow hygiene pass — concurrency, permissions, versions, rename

### DIFF
--- a/.github/workflows/_ci-build-esp32.yml
+++ b/.github/workflows/_ci-build-esp32.yml
@@ -21,6 +21,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 env:
   IDF_VERSION: 'v5.4'
 

--- a/.github/workflows/_ci-build-esphome.yml
+++ b/.github/workflows/_ci-build-esphome.yml
@@ -16,6 +16,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build ${{ inputs.project }}

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -2,7 +2,7 @@ name: Claude Auto-fix CI Failures
 
 on:
   workflow_run:
-    workflows: ["Test Suite", "ESP32 Build Pipeline"]
+    workflows: ["Test Suite", "Build Python Simulation"]
     types: [completed]
 
   workflow_dispatch:

--- a/.github/workflows/build-audiobook-player.yml
+++ b/.github/workflows/build-audiobook-player.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-esp32-cam-i2s-audio.yml
+++ b/.github/workflows/build-esp32-cam-i2s-audio.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-esp32-cam-webserver.yml
+++ b/.github/workflows/build-esp32-cam-webserver.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-esp32-wifitest.yml
+++ b/.github/workflows/build-esp32-wifitest.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-esp32-wireguard-ha.yml
+++ b/.github/workflows/build-esp32-wireguard-ha.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-esp32cam-llm-telegram.yml
+++ b/.github/workflows/build-esp32cam-llm-telegram.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-gamepad-synth.yml
+++ b/.github/workflows/build-gamepad-synth.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-it-troubleshooter.yml
+++ b/.github/workflows/build-it-troubleshooter.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-kids-audio-toy.yml
+++ b/.github/workflows/build-kids-audio-toy.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-melody-detector.yml
+++ b/.github/workflows/build-melody-detector.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-nfc-scavenger-hunt.yml
+++ b/.github/workflows/build-nfc-scavenger-hunt.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-python-simulation.yml
+++ b/.github/workflows/build-python-simulation.yml
@@ -5,13 +5,20 @@ on:
     branches: [main, develop, 'claude/**']
     paths:
       - 'packages/robocar/simulation/**'
-      - '.github/workflows/esp32-build.yml'
+      - '.github/workflows/build-python-simulation.yml'
   pull_request:
     branches: [main, develop]
     paths:
       - 'packages/robocar/simulation/**'
-      - '.github/workflows/esp32-build.yml'
+      - '.github/workflows/build-python-simulation.yml'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
   build-simulation:

--- a/.github/workflows/build-robocar-camera.yml
+++ b/.github/workflows/build-robocar-camera.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-robocar-main.yml
+++ b/.github/workflows/build-robocar-main.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-robocar-unified.yml
+++ b/.github/workflows/build-robocar-unified.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-switch-usb-proxy.yml
+++ b/.github/workflows/build-switch-usb-proxy.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-thinkpack-chatterbox.yml
+++ b/.github/workflows/build-thinkpack-chatterbox.yml
@@ -26,6 +26,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-thinkpack-finderbox.yml
+++ b/.github/workflows/build-thinkpack-finderbox.yml
@@ -24,6 +24,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/build-xbox-switch-bridge.yml
+++ b/.github/workflows/build-xbox-switch-bridge.yml
@@ -22,6 +22,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   ci-build:
     if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.release_tag == '')

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -13,6 +13,10 @@ on:
       - '.clang-format'
       - 'justfile'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   claude-review:
     uses: laurigates/.github/.github/workflows/reusable-claude-review.yml@main

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   conventional-commits:
     uses: laurigates/.github/.github/workflows/reusable-enforce-conventional-commits.yml@main

--- a/.github/workflows/notebook-doc-reminder.yml
+++ b/.github/workflows/notebook-doc-reminder.yml
@@ -19,6 +19,10 @@ on:
       - 'CLAUDE.md'
       - '.claude/rules/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/schematics-check.yml
+++ b/.github/workflows/schematics-check.yml
@@ -13,6 +13,13 @@ on:
       - '.github/workflows/schematics-check.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   svgs-up-to-date:
     name: Verify rendered SVGs match circuit source

--- a/.github/workflows/test-melody-train.yml
+++ b/.github/workflows/test-melody-train.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: packages/audio/melody-detector/training/uv.lock

--- a/.github/workflows/test-melody-train.yml
+++ b/.github/workflows/test-melody-train.yml
@@ -13,6 +13,13 @@ on:
       - '.github/workflows/test-melody-train.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test melody-train
@@ -25,7 +32,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           cache-dependency-glob: packages/audio/melody-detector/training/uv.lock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,13 @@ on:
       - 'Dockerfile'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     name: Detect Changes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Production-ready embedded systems monorepo for ESP32, STM32, and Arduino platforms with AI-powered robotics projects
 
-[![ESP32 Build](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/esp32-build.yml/badge.svg)](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/esp32-build.yml)
+[![Build Python Simulation](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/build-python-simulation.yml/badge.svg)](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/build-python-simulation.yml)
 [![Tests](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/test.yml/badge.svg)](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/test.yml)
 
 ## 🚀 Quick Start
@@ -266,7 +266,7 @@ pre-commit run --all-files
 
 Automated checks on every push and pull request:
 
-**Build Pipeline** (`.github/workflows/esp32-build.yml`):
+**Build Pipeline** (`.github/workflows/build-python-simulation.yml` + per-project `build-*.yml`):
 - ✅ Build all ESP32 projects in parallel
 - ✅ Generate size analysis reports
 - ✅ Archive firmware binaries (30-day retention)

--- a/packages/camera-vision/cam-webserver/README.md
+++ b/packages/camera-vision/cam-webserver/README.md
@@ -4,7 +4,7 @@ Live MJPEG video streaming web server for the ESP32-CAM (AI-Thinker) module.
 
 [![ESP-IDF](https://img.shields.io/badge/ESP--IDF-v5.4-blue)](https://docs.espressif.com/projects/esp-idf/en/v5.4/)
 [![Target](https://img.shields.io/badge/target-ESP32-green)](https://www.espressif.com/en/products/socs/esp32)
-[![CI](https://img.shields.io/github/actions/workflow/status/laurigates/mcu-tinkering-lab/esp32-build.yml?label=build)](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/esp32-build.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/laurigates/mcu-tinkering-lab/build-esp32-cam-webserver.yml?label=build)](https://github.com/laurigates/mcu-tinkering-lab/actions/workflows/build-esp32-cam-webserver.yml)
 
 ## Features
 


### PR DESCRIPTION
## Summary

Combined hygiene pass touching `.github/workflows/*.yml` to land four related cleanup tasks in one PR (grouped to avoid merge-conflict choreography).

### Closes #320 — concurrency blocks
Adds the standard concurrency block to every `pull_request`-triggered workflow so force-pushes cancel superseded runs:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Applied to: `test.yml`, `build-python-simulation.yml`, `test-melody-train.yml`, `schematics-check.yml`, `claude-code-review.yml`, `notebook-doc-reminder.yml`, `enforce-conventional-commits.yml`, and the 18 `build-*.yml` callers (24 files).

### Closes #321 — stale action version bumps
- `astral-sh/setup-uv@v7` → `@v8` in `test-melody-train.yml`
- `actions/checkout` in `notebook-refresh-reminder.yml` was already at `@v6` — no change needed (someone had already bumped past the `@v4` mentioned in the issue).

### Closes #322 — explicit least-privilege permissions
Adds `permissions: { contents: read }` to local non-delegating workflows so they don't inherit the broad default `GITHUB_TOKEN` scope:

- `test.yml`, `build-python-simulation.yml`, `test-melody-train.yml`, `schematics-check.yml`
- `enforce-conventional-commits.yml` (per issue list, even though it delegates)
- `_ci-build-esp32.yml`, `_ci-build-esphome.yml`
- All 18 `build-*.yml` callers

`build-firmware.yml` already declares the correct `contents: write` (plus `pages: write`, `id-token: write`) and is left untouched. Pure-delegation workflows (`claude-*.yml`, `release-please.yml`, etc.) were not in the issue scope.

### Closes #324 — rename + dead trigger fix
- `git mv .github/workflows/esp32-build.yml .github/workflows/build-python-simulation.yml` (the workflow only builds the Python sim — old name was misleading).
- Self-references inside the renamed file updated.
- `auto-fix.yml:5` — `"ESP32 Build Pipeline"` (which didn't match any workflow name) replaced with `"Build Python Simulation"`. `"Test Suite"` retained.
- `README.md` badge URL and CI/CD section updated.
- `packages/camera-vision/cam-webserver/README.md` badge corrected to point at its actual workflow (`build-esp32-cam-webserver.yml`).

## Validation

- Every modified `.github/workflows/*.yml` parses cleanly under `python3 -c "import yaml; yaml.safe_load(...)"` (38 files).
- No duplicate `permissions:` keys — verified `build-firmware.yml`, `notebook-doc-reminder.yml`, `notebook-refresh-reminder.yml` (the three that already had `permissions:`) were not modified for the permissions concern.
- No concurrency added to release-triggered or schedule-only workflows.

## Caveats

- The build-*.yml callers also trigger on `release: published`. Their new concurrency block scopes `cancel-in-progress` to `pull_request` only, so release builds still run to completion.
- `CLAUDE.md`, `CONTRIBUTING.md`, `tools/scaffold/new-esp32-project.sh`, `docs/prompts/*.md`, and `.claude/skills/register-project/SKILL.md` still mention `esp32-build.yml` in descriptive/grep contexts but those are out of CI hygiene scope — they'd be a doc-touch follow-up if desired.


## Follow-up fix

- `astral-sh/setup-uv@v8` reverted to `@v7` — Astral does not publish a moving `v8` major-version tag yet (only `v8.0.0` / `v8.1.0` specific tags). `@v7` matches `test.yml`.
- Dangling doc references to `esp32-build.yml` tracked in #332.
