### PR TITLE
chore: ignore per-machine Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 build/
 # But don't ignore Claude Code skill directories
 !.claude/skills/build/
+# Per-machine Claude Code agent worktrees (created by /worktree-* skills)
+.claude/worktrees/
 # Host test binaries (produced by make test in test/ directories)
 test_runner
 *_test_runner


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore`. The `/worktree-*` skills create isolated git worktrees under `.claude/worktrees/agent-<id>/`, one per spawned agent. They're local machine state — checkouts of feature branches that live on real refs already — and the directory accumulates across sessions (20 entries here today).

## Test plan

- [ ] `git status` no longer surfaces `.claude/worktrees/` as untracked
- [ ] The existing `!.claude/skills/build/` negation continues to apply (skill build dirs remain trackable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)