### PR TITLE
docs: fix dangling esp32-build.yml references after workflow split

### DIFF
--- a/.claude/skills/register-project/SKILL.md
+++ b/.claude/skills/register-project/SKILL.md
@@ -29,11 +29,11 @@ mod project-name 'packages/<domain>/project-name'
 
 Place it alphabetically among the existing `mod` declarations. Use the justfile recipe naming convention (lowercase-kebab-case).
 
-### 3. Verify CI Matrix
+### 3. Verify CI Build Workflow
 
-Check `.github/workflows/esp32-build.yml` for the project matrix. If the project should be built in CI:
-- Verify it appears in the build matrix
-- Or note that it needs to be added manually (don't auto-edit workflow files without confirmation)
+Each ESP32 project has its own `.github/workflows/build-<project>.yml` (calling the reusable `_ci-build-esp32.yml`). If the project should be built in CI:
+- Verify `.github/workflows/build-<project>.yml` exists
+- Or note that it needs to be created (copy an existing one such as `build-melody-detector.yml`; don't auto-edit workflow files without confirmation)
 
 ### 4. Check Standard File Inventory
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,8 @@ Most workflows delegate to reusable workflows from [`laurigates/.github`](https:
 
 | Workflow | Trigger | Purpose | Reusable? |
 |----------|---------|---------|-----------|
-| `esp32-build.yml` | Push/PR to main/develop | Build all ESP32 firmware + simulation | No (local) |
+| `build-<project>.yml` | Push/PR (path-filtered) / release | Per-project ESP32 firmware build (CI via `_ci-build-esp32.yml`, release via `_build-esp32-firmware.yml`) | Local reusable `_*.yml` |
+| `build-python-simulation.yml` | Push/PR to main/develop | Build the Python simulation package (import check) | No (local) |
 | `test.yml` | Push/PR to main/develop | Pre-commit, pytest, cppcheck, format check | No (local) |
 | `build-firmware.yml` | Release published | Build + attach firmware binaries to release + deploy web flasher | No (local) |
 | `release-please.yml` | Push to main | Auto-generate release PRs from conventional commits | `reusable-release-please.yml` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -433,7 +433,7 @@ Brief description of changes
    ```
 
 4. **Add to CI pipeline:**
-   Edit `.github/workflows/esp32-build.yml` to include your project in the build matrix.
+   Create a per-project workflow `.github/workflows/build-<project>.yml` (copy an existing one such as `build-melody-detector.yml`) that calls the reusable `_ci-build-esp32.yml` workflow with your project's `project`, `project_path`, and `target`.
 
 5. **Update root justfile:**
    Add build/flash targets for your project.

--- a/docs/prompts/host-based-unit-tests.md
+++ b/docs/prompts/host-based-unit-tests.md
@@ -26,7 +26,7 @@ ESP-IDF supports building and running unit tests on the host machine via `CONFIG
 - `packages/robocar/camera/main/` — AI command parsing, UART message formatting
 
 ### Phase 3: CI integration
-- Add host-test job to `esp32-build.yml` GitHub Actions workflow
+- Add host-test job to the `test.yml` GitHub Actions workflow (the Test Suite that already runs pre-commit / pytest / cppcheck)
 - Run all host tests as part of PR checks
 
 ## Test Framework

--- a/docs/prompts/melody-detector.md
+++ b/docs/prompts/melody-detector.md
@@ -62,7 +62,7 @@ loop with on-hardware measurements.
   `info` recipes
 - Root `justfile` registers the module: `mod melody-detector
   'packages/audio/melody-detector'`
-- CI matrix entry in `.github/workflows/esp32-build.yml`
+- Per-project CI workflow `.github/workflows/build-melody-detector.yml` (calls the reusable `_ci-build-esp32.yml`)
 - Skeleton `README.md`, `WIRING.md`, `CLAUDE.md` (use the
   `project-readme`, `wiring-doc`, `project-claude-md` skills)
 - Status LED feedback patterns

--- a/tools/scaffold/new-esp32-project.sh
+++ b/tools/scaffold/new-esp32-project.sh
@@ -183,6 +183,6 @@ echo -e "  4. ${CYAN}idf.py build${NC} to build the project"
 echo
 echo "Optional:"
 echo -e "  - Add to root Makefile for easy building: ${CYAN}make $PROJECT_NAME-build${NC}"
-echo -e "  - Add to CI pipeline: ${CYAN}.github/workflows/esp32-build.yml${NC}"
+echo -e "  - Add to CI pipeline: ${CYAN}create .github/workflows/build-$PROJECT_NAME.yml (copy build-melody-detector.yml)${NC}"
 echo
 echo -e "${GREEN}Happy coding! 🚀${NC}"


### PR DESCRIPTION
Closes #332.

## What
Updates the six in-repo references to the removed `esp32-build.yml` workflow.

## Why the fix isn't a blind rename
#332 framed this as a rename (`esp32-build.yml` → `build-python-simulation.yml`). Investigating the actual history (PR #331), the "rename" was the tail end of a **split**:

- ESP32 firmware builds had already moved to **per-project** `build-<name>.yml` workflows (each calling the reusable `_ci-build-esp32.yml` / `_build-esp32-firmware.yml`).
- The leftover `esp32-build.yml` had been reduced to *just* the Python simulation build, and #331 renamed it to `build-python-simulation.yml`.

So the dangling refs were **doubly stale**: a dead filename *and* a build-matrix model that no longer exists. A blind `esp32-build.yml` → `build-python-simulation.yml` swap would have told contributors to add their **ESP32** project to the **Python-sim** workflow — wrong. Each reference is instead pointed at the real architecture.

## Changes
| File | Before | After |
|------|--------|-------|
| `CLAUDE.md` | single `esp32-build.yml` table row | per-project `build-<project>.yml` + `build-python-simulation.yml` rows |
| `CONTRIBUTING.md` | "add to the `esp32-build.yml` build matrix" | create a per-project `build-<project>.yml` (copy `build-melody-detector.yml`) calling `_ci-build-esp32.yml` |
| `tools/scaffold/new-esp32-project.sh` | scaffold hint → `esp32-build.yml` | hint → create `build-<name>.yml` |
| `.claude/skills/register-project/SKILL.md` | "Verify CI Matrix" | "Verify CI Build Workflow" (per-project) |
| `docs/prompts/host-based-unit-tests.md` | host-test job → `esp32-build.yml` | host-test job → `test.yml` (the Test Suite running pre-commit/pytest/cppcheck) |
| `docs/prompts/melody-detector.md` | "CI matrix entry in `esp32-build.yml`" | per-project `build-melody-detector.yml` |

## Verification
`rg 'esp32-build\.yml'` across the repo (excluding `.git`) returns no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)