### PR TITLE
fix(simulation): declare trail_line attribute to satisfy ty

### DIFF
--- a/packages/robocar/simulation/src/genesis_visualizer.py
+++ b/packages/robocar/simulation/src/genesis_visualizer.py
@@ -71,6 +71,7 @@ class MatplotlibVisualizer:
                 self.robot_patch = patches.Circle((0, 0), 0.2, color="blue", alpha=0.7)
                 self.direction_line = None
                 self.trail_points: list[tuple[float, float]] = []
+                self.trail_line = None
 
                 self.ax.add_patch(self.robot_patch)
                 print("✓ Matplotlib visualizer initialized on main thread")
@@ -120,8 +121,8 @@ class MatplotlibVisualizer:
                 # Draw trail
                 if len(self.trail_points) > 1:
                     trail_x, trail_y = zip(*self.trail_points, strict=False)
-                    if hasattr(self, "trail_line"):
-                        self.trail_line.remove()  # ty: ignore[unresolved-attribute]
+                    if self.trail_line is not None:
+                        self.trail_line.remove()
                     (self.trail_line,) = self.ax.plot(
                         trail_x, trail_y, "g-", alpha=0.5, linewidth=2
                     )


### PR DESCRIPTION
## Problem

The **Code Quality Checks** job (pre-commit `ty` hook) fails on every PR with:

```
error[unresolved-attribute]: Unresolved attribute `trail_line` on type `Self@start_update_loop`
   --> src/genesis_visualizer.py:125:22
```

The pre-commit hook auto-installs the latest `ty`, and a newer version now flags the tuple-unpack assignment `(self.trail_line,) = self.ax.plot(...)` — `ty` doesn't treat tuple unpacking as an attribute declaration. The existing `# ty: ignore` on the preceding `.remove()` line didn't cover the assignment. This is pre-existing on `main` and blocks all open PRs.

## Fix

- Declare `self.trail_line = None` in `MatplotlibVisualizer.__init__` so the attribute is known to `ty`.
- Replace the `hasattr(self, "trail_line")` guard with `self.trail_line is not None` and drop the now-unnecessary `# ty: ignore`.

Behavior is unchanged: the trail line is still lazily created and removed each frame. Verified locally — `pre-commit run ty` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEjC8YWk1KM41qSTorjr7M)_