### PR TITLE
ci: fix three chronically failing workflows

### DIFF
--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -8,8 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# The reusable workflow needs pull-requests: write to rewrite PR titles;
+# a called workflow cannot exceed the caller's grant, so it must be here.
 permissions:
-  contents: read
+  pull-requests: write
 
 jobs:
   conventional-commits:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,9 +4,38 @@ on:
   push:
     branches:
       - main
+  # Allow manual triggering, e.g. after a stale release PR is closed.
+  workflow_dispatch: {}
+
+# Prevent concurrent runs from racing on the release-please branch.
+# cancel-in-progress: false ensures queued runs wait rather than being
+# cancelled — avoids a race where two runs both try to update CHANGELOG.md.
+concurrency:
+  group: release-please-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   release-please:
-    uses: laurigates/.github/.github/workflows/reusable-release-please.yml@main
-    secrets:
-      MY_RELEASE_PLEASE_TOKEN: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+    steps:
+      # Credentials are pushed by gitops for repos with release_please = true.
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.github/workflows/sync-ai-rules.yml
+++ b/.github/workflows/sync-ai-rules.yml
@@ -1,8 +1,9 @@
 name: Sync AI Rules
 
+# Schedule disabled: the reusable workflow is broken upstream (no rules/
+# directory in laurigates/.github), so every weekly run fails. Re-enable
+# once laurigates/.github#10 is resolved.
 on:
-  schedule:
-    - cron: '0 7 * * 1'  # Mondays at 07:00 UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Fixes the three workflows that have been failing on every run (see run history below).

### release-please — failing since April (46 consecutive failures)
Migrates from the legacy PAT-based `reusable-release-please.yml` (secret `MY_RELEASE_PLEASE_TOKEN` was never provisioned → `Input required and not supplied: token`) to the canonical inlined GitHub App token pattern (reference: `pal-mcp-server`). Credentials are pushed by gitops once laurigates/gitops#182 lands — **merge that first**, then this workflow goes green on the next push to main.

### enforce-conventional-commits — startup_failure on all 20 runs since May 24
The workflow hygiene pass (#331) added `permissions: contents: read` to the caller. The reusable workflow requires `pull-requests: write`, and a called workflow cannot exceed the caller's grant, so GitHub rejected every run at dispatch. Last success was May 23. This grants `pull-requests: write`.

### sync-ai-rules — failing weekly for 5+ weeks
The upstream reusable workflow is broken (`rulesync fetch` 404s on the nonexistent `rules/` directory in `laurigates/.github`). Schedule disabled to stop the weekly failure noise; manual dispatch kept. Re-enable once laurigates/.github#10 is resolved.

## Verification
- `actionlint` clean on all three files.
- release-please success depends on gitops#182 (App credentials); the other two are self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7uP2K1fN6n3DZf5A52cp7