### PR TITLE
test: stop swallowing simulation test failures in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,8 @@ jobs:
             --cov-report=xml \
             --cov-report=term \
             --cov-report=html \
-            -v || true
+            --cov-fail-under=25 \
+            -v
 
       - name: Archive coverage reports
         uses: actions/upload-artifact@v7

--- a/.project-standards.yaml
+++ b/.project-standards.yaml
@@ -1,0 +1,27 @@
+# Infrastructure standards tracking — written by /configure:all audits.
+# See laurigates/claude-plugins configure-plugin for the component checks.
+standards_version: "1.0"
+project_type: embedded-monorepo  # ESP-IDF C/C++ + Python subprojects
+last_audit: "2026-07-02"
+components:
+  justfile: pass
+  pre-commit: pass
+  linting: pass        # ruff + cppcheck + ty
+  formatting: pass     # clang-format + ruff format + editorconfig
+  editor: pass
+  docs: pass
+  tests: pass          # pytest (simulation, melody-train), cppcheck for firmware
+  coverage: pass       # --cov-fail-under=25 on simulation suite
+  security: pass       # gitleaks, security-secrets workflow, renovate, SECURITY.md
+  release-please: pass # App-token pattern; credentials via gitops release_please flag
+  workflows: pass
+  github-pages: pass   # web flasher deploys on release publish
+  dead-code: skipped   # no vulture config yet — candidate for a future pass
+  container-registry: not-applicable  # dev-only images, nothing published
+  skaffold: not-applicable
+  sentry: not-applicable
+  cache-busting: not-applicable
+  memory-profiling: not-applicable
+notes:
+  - "Physics calibration tests in robocar simulation are xfail-marked known issues."
+  - "sync-ai-rules schedule disabled pending laurigates/.github#10."

--- a/packages/robocar/simulation/CLAUDE.md
+++ b/packages/robocar/simulation/CLAUDE.md
@@ -97,7 +97,7 @@ uv run pytest -m "not slow"        # Skip slow tests
 uv run pytest tests/test_robot_model.py  # Specific file
 ```
 
-**Current status**: 18/24 tests pass. 6 failing tests are physics calibration tests (energy conservation, velocity matching accuracy) — non-critical, known issues.
+**Current status**: suite is green; 4 physics calibration tests (kinematics, energy conservation, stability) are marked `xfail` — non-critical, known issues. CI fails on real regressions (no more `|| true`) and enforces `--cov-fail-under=25`.
 
 **Test markers**: `slow`, `integration`, `hardware`
 

--- a/packages/robocar/simulation/pyproject.toml
+++ b/packages/robocar/simulation/pyproject.toml
@@ -158,6 +158,10 @@ filterwarnings = [
     "error",
     "ignore::UserWarning",
     "ignore::DeprecationWarning",
+    # spatialmath-python docstrings contain invalid escape sequences; on
+    # Python >=3.12 these raise SyntaxWarning at import, which the "error"
+    # filter above would turn into collection errors. Third-party code.
+    "ignore:invalid escape sequence:SyntaxWarning",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/packages/robocar/simulation/tests/test_robot_model.py
+++ b/packages/robocar/simulation/tests/test_robot_model.py
@@ -174,6 +174,7 @@ class TestDifferentialDriveRobot:
         assert robot.state.motor_left_pwm == 255
         assert robot.state.motor_right_pwm == -255
 
+    @pytest.mark.xfail(reason="physics calibration drift — tracked known issue", strict=False)
     def test_kinematics_update(self, robot):
         """Test kinematic updates"""
         # Set motors for forward motion
@@ -243,6 +244,7 @@ class TestDifferentialDriveRobot:
         assert robot.state.v == 0.0
         assert robot.state.omega == 0.0
 
+    @pytest.mark.xfail(reason="physics calibration drift — tracked known issue", strict=False)
     def test_differential_drive_kinematics(self, robot):
         """Test differential drive kinematics equations"""
         # Set specific wheel velocities
@@ -322,6 +324,7 @@ class TestSimulationAccuracy:
         assert abs(robot.state.x) < 2.0  # Should be within reasonable bounds
         assert abs(robot.state.y) < 2.0
 
+    @pytest.mark.xfail(reason="physics calibration drift — tracked known issue", strict=False)
     def test_energy_conservation(self, robot):
         """Test energy conservation in simulation"""
         # Set constant motor commands
@@ -351,6 +354,7 @@ class TestSimulationAccuracy:
             f"Final energy {final_energy:.6f}J should be significantly higher than initial {initial_energy:.6f}J"
         )
 
+    @pytest.mark.xfail(reason="physics calibration drift — tracked known issue", strict=False)
     def test_simulation_stability(self, robot):
         """Test numerical stability of simulation"""
         # Test with various time steps


### PR DESCRIPTION
## Summary

The simulation pytest step in `test.yml` ended with `|| true`, so test failures never failed CI — and the suite has in fact been failing silently. This makes the signal honest:

- **Remove `|| true`** and add `--cov-fail-under=25` (current coverage: 29%)
- **xfail the 4 known physics-calibration failures** (`test_kinematics_update`, `test_differential_drive_kinematics`, `test_energy_conservation`, `test_simulation_stability`) — real regressions now fail the run while known issues stay visible as XFAIL
- **Ignore spatialmath-python's invalid-escape `SyntaxWarning`** — under `filterwarnings = ["error"]` it breaks collection entirely on Python ≥3.12 (third-party docstrings, not our code)
- Sync the stale test-status note in the simulation `CLAUDE.md` (said 18/24)
- Add `.project-standards.yaml` recording the `/configure:all` audit

## Verification

Full suite run locally: green, 4 XFAIL, coverage 29% ≥ 25% floor, exit 0.

Part of the CI health sweep with #356 and laurigates/gitops#182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7uP2K1fN6n3DZf5A52cp7