### PR TITLE
ci: drop unparseable release-please title patterns

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -169,7 +169,6 @@
   "release-type": "simple",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "pull-request-title-pattern": "chore: release ${version}",
   "changelog-sections": [
     {
       "type": "feat",
@@ -193,6 +192,5 @@
       "hidden": false
     }
   ],
-  "group-pull-request-title-pattern": "chore: release ${version}",
   "separate-pull-requests": false
 }


### PR DESCRIPTION
## Summary

Release PR #359 merged but was never tagged — the run aborts with `There are untagged, merged release PRs outstanding`.

**Root cause:** with `separate-pull-requests: false`, the grouped 18-component release PR has no single `${version}`, so the custom `"pull-request-title-pattern": "chore: release ${version}"` rendered as the bare title `chore: release`. On the tagging pass release-please cannot parse that title back against the pattern (the run logs `pullRequestTitlePattern miss the part of '${component}'`), so the merged PR stays untagged and blocks all future runs.

**Fix:** remove both custom title patterns; the defaults render and round-trip correctly for grouped manifest releases.

**Unsticking plan (after merge):** relabel #359 `autorelease: pending` → `autorelease: tagged` so it stops blocking, then dispatch release-please to regenerate a fresh release PR with a parseable title (no tags exist yet, so it recomputes the same 18 first releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7uP2K1fN6n3DZf5A52cp7