### PR TITLE
fix(gamepad-synth): correct fetch-deps xbox-switch-bridge path and use relative symlink

### DIFF
--- a/packages/audio/gamepad-synth/justfile
+++ b/packages/audio/gamepad-synth/justfile
@@ -28,17 +28,21 @@ fetch-deps:
         echo "Bluepad32 deps already present"
         exit 0
     fi
-    # Try symlinking from xbox-switch-bridge (avoids duplicate clones)
-    XBOX_BP32="$(dirname "{{bp32_ext}}")/../xbox-switch-bridge/external/bluepad32"
-    if [ -d "$XBOX_BP32/src" ]; then
+    # Try symlinking from xbox-switch-bridge (avoids duplicate clones).
+    # Keep the symlink RELATIVE so it resolves inside the container's
+    # /workspace bind mount (see .claude/rules/containerized-builds.md).
+    # xbox-switch-bridge lives under packages/input-gaming/ since the re-org.
+    XBOX_SRC="$(dirname "{{bp32_ext}}")/../../../input-gaming/xbox-switch-bridge/external/bluepad32"
+    XBOX_REL="../../../input-gaming/xbox-switch-bridge/external/bluepad32"
+    if [ -d "$XBOX_SRC/src" ]; then
         mkdir -p "$(dirname "{{bp32_ext}}")"
-        ln -sfn "$(cd "$XBOX_BP32" && pwd)" "{{bp32_ext}}"
+        ln -sfn "$XBOX_REL" "{{bp32_ext}}"
         echo "Symlinked bluepad32 from xbox-switch-bridge"
     else
         echo "xbox-switch-bridge deps not found — fetching for xbox-switch-bridge first..."
         just xbox::fetch-deps
         mkdir -p "$(dirname "{{bp32_ext}}")"
-        ln -sfn "$(cd "$XBOX_BP32" && pwd)" "{{bp32_ext}}"
+        ln -sfn "$XBOX_REL" "{{bp32_ext}}"
         echo "Symlinked bluepad32 from xbox-switch-bridge"
     fi
 


### PR DESCRIPTION
## Problem

`packages/audio/gamepad-synth/justfile`'s `fetch-deps` recipe:

1. Resolved the shared Bluepad32 source at `packages/audio/xbox-switch-bridge/external/bluepad32`, which does **not** exist — the bridge lives at `packages/input-gaming/xbox-switch-bridge/` since the monorepo re-org (`mod xbox 'packages/input-gaming/xbox-switch-bridge'` in the root justfile).
2. Wrote the symlink with `ln -sfn "$(cd "$XBOX_BP32" && pwd)" ...`, producing an **absolute** target — violating the relative-symlink rule in `.claude/rules/containerized-builds.md` (absolute `/Users/...` targets don't resolve inside the container's `/workspace` bind mount).

## Fix

- Existence check now targets `packages/input-gaming/xbox-switch-bridge/external/bluepad32`.
- The symlink is written as the literal **relative** target `../../../input-gaming/xbox-switch-bridge/external/bluepad32` (matching the already-committed live symlink) via `ln -sfn "$XBOX_REL" ...`.
- The `just xbox::fetch-deps` fallback branch is preserved.

## Verification

With the xbox source staged, from `packages/audio/gamepad-synth`:

```
rm -rf external/bluepad32 && just fetch-deps && readlink external/bluepad32
# → ../../../input-gaming/xbox-switch-bridge/external/bluepad32   (relative, not absolute)
# [ -d external/bluepad32/src ] → true
```

`external/` is gitignored, so the working tree stays clean except for the justfile edit.

Closes #269