### PR TITLE
perf(robocar-sim): make Genesis/torch import lazy in genesis_visualizer

### DIFF
--- a/packages/robocar/simulation/src/genesis_visualizer.py
+++ b/packages/robocar/simulation/src/genesis_visualizer.py
@@ -4,26 +4,16 @@ Genesis Visualizer for ESP32 Robot Car Simulation
 This module provides 3D visualization using the Genesis simulation framework.
 """
 
+import importlib.util
 import os
 import queue
 import threading
 import time
 
-import numpy as np
-import yaml
-
-try:
-    import genesis as gs
-    import trimesh
-    from spatialmath import SE3
-
-    HAS_GENESIS = True
-except ImportError:
-    HAS_GENESIS = False
-    print("Info: Genesis simulation framework not available - using matplotlib fallback")
-
 # Configure matplotlib for thread safety BEFORE importing pyplot
 import matplotlib
+import numpy as np
+import yaml
 
 # Use Agg backend for headless, TkAgg for GUI (with main thread requirement)
 if "DISPLAY" not in os.environ or os.environ.get("TERM_PROGRAM") == "vscode":
@@ -37,6 +27,26 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
 from robot_model import DifferentialDriveRobot, RobotState
+
+# Detect Genesis availability WITHOUT importing the heavy stack (genesis pulls
+# torch, adding ~2s to import time). The actual import is deferred to
+# _ensure_genesis(), called lazily by methods that dereference these globals.
+gs = None
+trimesh = None
+SE3 = None
+HAS_GENESIS = importlib.util.find_spec("genesis") is not None
+
+if not HAS_GENESIS:
+    print("Info: Genesis simulation framework not available - using matplotlib fallback")
+
+
+def _ensure_genesis():
+    """Import the heavy Genesis stack into module globals on first use."""
+    global gs, trimesh, SE3
+    if gs is None:
+        import genesis as gs
+        import trimesh
+        from spatialmath import SE3
 
 
 class MatplotlibVisualizer:
@@ -226,6 +236,7 @@ class RobotVisualizer:
 
     def _init_genesis_environment(self):
         """Initialize Genesis simulation environment"""
+        _ensure_genesis()
         try:
             print(f"Initializing Genesis in {self.viz_mode} mode...")
 
@@ -261,6 +272,7 @@ class RobotVisualizer:
 
     def _create_environment(self):
         """Create the simulation environment"""
+        _ensure_genesis()
         if not self.scene:
             return
 
@@ -281,6 +293,7 @@ class RobotVisualizer:
 
     def _create_obstacle(self, obstacle: dict, index: int):
         """Create obstacle in the environment"""
+        _ensure_genesis()
         if not self.scene:
             return
         pos = obstacle["position"]
@@ -306,6 +319,7 @@ class RobotVisualizer:
 
     def _add_coordinate_axes(self):
         """Add coordinate axes to the environment"""
+        _ensure_genesis()
         if not self.scene:
             return
 
@@ -339,6 +353,7 @@ class RobotVisualizer:
 
     def _create_robot_model(self):
         """Create 3D model of the robot"""
+        _ensure_genesis()
         if not self.scene:
             return
 
@@ -411,6 +426,7 @@ class RobotVisualizer:
 
     def _update_robot_state(self, state: RobotState):
         """Update robot visualization with new state"""
+        _ensure_genesis()
         if not self.scene:
             return
 
@@ -493,6 +509,7 @@ class RobotVisualizer:
 
     def _update_sensor_visualization(self, state: RobotState):
         """Update sensor visualization"""
+        _ensure_genesis()
         if not self.scene:
             return
 
@@ -511,6 +528,7 @@ class RobotVisualizer:
 
     def add_trajectory_point(self, x: float, y: float, color: list[float] | None = None):
         """Add a trajectory point marker"""
+        _ensure_genesis()
         if color is None:
             color = [1.0, 1.0, 1.0]
         if not self.scene:
@@ -522,6 +540,7 @@ class RobotVisualizer:
 
     def add_waypoint(self, x: float, y: float, z: float = 0.1):
         """Add a waypoint marker"""
+        _ensure_genesis()
         if not self.scene:
             return
         self.scene.add_entity(
@@ -571,6 +590,7 @@ class RobotVisualizer:
 
     def _create_simple_robot_visualization(self):
         """Create a simple robot visualization for testing"""
+        _ensure_genesis()
         if not self.env:  # ty: ignore[unresolved-attribute]
             return
 

--- a/packages/robocar/simulation/src/genesis_visualizer.py
+++ b/packages/robocar/simulation/src/genesis_visualizer.py
@@ -9,6 +9,7 @@ import os
 import queue
 import threading
 import time
+from typing import Any
 
 # Configure matplotlib for thread safety BEFORE importing pyplot
 import matplotlib
@@ -31,9 +32,12 @@ from robot_model import DifferentialDriveRobot, RobotState
 # Detect Genesis availability WITHOUT importing the heavy stack (genesis pulls
 # torch, adding ~2s to import time). The actual import is deferred to
 # _ensure_genesis(), called lazily by methods that dereference these globals.
-gs = None
-trimesh = None
-SE3 = None
+# Typed Any so static type checkers (ty) accept attribute access after the
+# lazy import populates them; without this they infer `None` and flag every
+# gs.*/trimesh.*/SE3(...) dereference as unresolved-attribute.
+gs: Any = None
+trimesh: Any = None
+SE3: Any = None
 HAS_GENESIS = importlib.util.find_spec("genesis") is not None
 
 if not HAS_GENESIS:


### PR DESCRIPTION
Lazy-load the Genesis/torch stack in genesis_visualizer.py: detect availability with importlib.util.find_spec, defer the heavy import to a _ensure_genesis() loader called by methods that dereference gs/trimesh/SE3. Warm import drops from ~2.1s to ~0.2s; headless runs no longer pull torch. HAS_GENESIS stays a truthy bool so main.py checks are unchanged. Tests (pytest tests/ + test_simplified_visualizer.py) pass; ruff format/check clean; headless main reaches banner cleanly. Closes #55