### PR TITLE
ci(scan-secrets): skip AI secret scan for dependabot actor

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   scan-secrets:
+    # Skip the AI secret scan for dependabot: the reusable workflow rejects
+    # non-human actors ("Workflow initiated by non-human actor"). gitleaks
+    # still covers pattern-based secret scanning on the same diff. See #259.
+    if: github.actor != 'dependabot[bot]'
     uses: laurigates/.github/.github/workflows/reusable-security-secrets.yml@main
     with:
       file-patterns: '**/*.c **/*.h **/*.cpp **/*.hpp **/*.py **/*.yml **/*.yaml **/*.json **/*.toml'


### PR DESCRIPTION
Closes #259

Dependabot-opened PRs always fail the `scan-secrets` check with "Workflow initiated by non-human actor: dependabot". The caller `.github/workflows/security-secrets.yml` invokes `laurigates/.github` `reusable-security-secrets.yml`, which does not plumb through `allowed_bots`, so there is no way to allow the bot actor from the reusable side without upstream changes.

## Fix

A one-line job-level guard on the `scan-secrets` job:

```yaml
if: github.actor != 'dependabot[bot]'
```

A reusable-workflow job (`uses:`) supports a job-level `if:`, so the whole AI scan is skipped for the dependabot actor while running normally for every human PR and push.

## Coverage is not lost

`gitleaks` still runs pattern-based secret scanning on the same diff (pre-commit + CI), so dependabot PRs remain covered for actual secret leaks — only the AI-powered scan (which cannot run for non-human actors) is skipped.