### PR TITLE
fix(robocar-sim): close ty local/CI parity gap and fix real type errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,15 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
+      # Install the simulation dev dependencies so the `ty check src/` pre-commit
+      # hook can resolve imports and perform deep attribute checks. Without this,
+      # ty only sees unresolved-import and silently skips the real type errors,
+      # making the gate a no-op in CI while it is RED for a developer with the
+      # sim deps installed (local<->CI parity gap, issue #369).
+      - name: Sync simulation dev dependencies (for ty pre-commit hook)
+        working-directory: packages/robocar/simulation
+        run: uv sync --extra dev
+
       - name: Run pre-commit hooks
         run: pre-commit run --all-files --show-diff-on-failure
 

--- a/packages/robocar/simulation/src/ai_command_processor.py
+++ b/packages/robocar/simulation/src/ai_command_processor.py
@@ -164,7 +164,7 @@ GUIDELINES:
         _, buffer = cv2.imencode(".jpg", image, [cv2.IMWRITE_JPEG_QUALITY, 85])
 
         # Convert to base64
-        image_base64 = base64.b64encode(buffer).decode("utf-8")
+        image_base64 = base64.b64encode(buffer.tobytes()).decode("utf-8")
         return image_base64
 
     async def process_command(self, user_input: str, robot_context: RobotContext) -> AICommand:

--- a/packages/robocar/simulation/src/communication_bridge.py
+++ b/packages/robocar/simulation/src/communication_bridge.py
@@ -141,8 +141,12 @@ class ESP32CommunicationBridge:
 
         print(f"Starting WebSocket server on {host}:{port}")
 
-        async def handle_client(websocket, path):
-            """Handle WebSocket client connections"""
+        async def handle_client(websocket):
+            """Handle WebSocket client connections.
+
+            websockets >=14 invokes the handler with a single connection
+            argument; the legacy ``path`` parameter was removed.
+            """
             self.clients.add(websocket)
             print(f"Client connected: {websocket.remote_address}")
 

--- a/packages/robocar/simulation/src/genesis_visualizer.py
+++ b/packages/robocar/simulation/src/genesis_visualizer.py
@@ -181,7 +181,7 @@ class MatplotlibVisualizer:
         self._running = False
         if self.enabled and hasattr(self, "fig"):
             try:
-                if hasattr(self, "anim"):
+                if hasattr(self, "anim") and self.anim.event_source is not None:
                     self.anim.event_source.stop()
                 plt.close(self.fig)
                 print("✓ Matplotlib visualization closed")

--- a/packages/robocar/simulation/src/robot_model.py
+++ b/packages/robocar/simulation/src/robot_model.py
@@ -290,7 +290,7 @@ class PhysicsEngine:
         # Perform segment query (raycast)
         query_info = self.space.segment_query_first(start_pos, end_pos, 0, pymunk.ShapeFilter())
 
-        if query_info.shape:
+        if query_info is not None and query_info.shape:
             # Calculate distance to hit point
             hit_point = query_info.point
             distance = np.sqrt(

--- a/packages/robocar/simulation/src/swift_subprocess.py
+++ b/packages/robocar/simulation/src/swift_subprocess.py
@@ -33,12 +33,18 @@ async def run_swift():
 
     # Add simple test objects
     test_box = trimesh.primitives.Box(extents=[0.15, 0.10, 0.05])
-    test_box.visual.face_colors = [100, 150, 200, 255]
+    box_color = [100, 150, 200, 255]
+    # ty: trimesh stubs type .visual as ColorVisuals|TextureVisuals|None;
+    # primitives return ColorVisuals, whose face_colors is settable.
+    test_box.visual.face_colors = box_color  # ty: ignore[invalid-assignment]
     env.add(test_box)
 
     # Add direction indicator
     arrow = trimesh.primitives.Cylinder(radius=0.01, height=0.08, transform=SE3(0.06, 0, 0.03).A)
-    arrow.visual.face_colors = [255, 0, 0, 255]
+    arrow_color = [255, 0, 0, 255]
+    # ty: trimesh stubs type .visual as ColorVisuals|TextureVisuals|None;
+    # primitives return ColorVisuals, whose face_colors is settable.
+    arrow.visual.face_colors = arrow_color  # ty: ignore[invalid-assignment]
     env.add(arrow)
 
     print("✓ Robot visualization created")

--- a/packages/robocar/simulation/src/test_swift.py
+++ b/packages/robocar/simulation/src/test_swift.py
@@ -42,7 +42,10 @@ def test_browser_mode():
 
             # Add a simple test object
             test_box = trimesh.primitives.Box(extents=[0.1, 0.1, 0.1])
-            test_box.visual.face_colors = [255, 0, 0, 255]  # Red
+            box_color = [255, 0, 0, 255]  # Red
+            # ty: trimesh stubs type .visual as ColorVisuals|TextureVisuals|None;
+            # primitives return ColorVisuals, whose face_colors is settable.
+            test_box.visual.face_colors = box_color  # ty: ignore[invalid-assignment]
             env.add(test_box)
             print("✓ Test object added")
 
@@ -98,7 +101,10 @@ def test_visual_mode():
 
             # Add a simple test object
             test_cylinder = trimesh.primitives.Cylinder(radius=0.05, height=0.2)
-            test_cylinder.visual.face_colors = [0, 255, 0, 255]  # Green
+            cylinder_color = [0, 255, 0, 255]  # Green
+            # ty: trimesh stubs type .visual as ColorVisuals|TextureVisuals|None;
+            # primitives return ColorVisuals, whose face_colors is settable.
+            test_cylinder.visual.face_colors = cylinder_color  # ty: ignore[invalid-assignment]
             env.add(test_cylinder)
             print("✓ Test object added")
 
@@ -149,7 +155,10 @@ def test_headless_mode():
 
             # Add a simple test object
             test_sphere = trimesh.primitives.Sphere(radius=0.05)
-            test_sphere.visual.face_colors = [0, 0, 255, 255]  # Blue
+            sphere_color = [0, 0, 255, 255]  # Blue
+            # ty: trimesh stubs type .visual as ColorVisuals|TextureVisuals|None;
+            # primitives return ColorVisuals, whose face_colors is settable.
+            test_sphere.visual.face_colors = sphere_color  # ty: ignore[invalid-assignment]
             env.add(test_sphere)
             print("✓ Test object added")
 


### PR DESCRIPTION
Closes #369

## Problem

The pre-commit `ty check src/` hook (`.pre-commit-config.yaml`) runs
`cd packages/robocar/simulation && uvx ty check src/`. `ty` only performs
deep attribute checks when the sim's dependencies are importable. In CI the
`code-quality` job ran `pre-commit run --all-files` **without** syncing the
sim deps, so `ty` saw only unresolved-import and silently skipped the real
errors — a **no-op gate in CI** that was **RED for any developer** with the
sim deps installed. Classic local↔CI parity gap.

## Fix

**(a) Close the parity gap.** Added a `uv sync --extra dev` step (working
directory `packages/robocar/simulation`) **before** the "Run pre-commit hooks"
step in the `code-quality` job so `ty` resolves imports and deep-checks,
matching local behavior. `uv` is already available via `astral-sh/setup-uv`.

**(b) Fix the ~10 real errors** surfaced by `ty` (guards/asserts preferred,
targeted ignores only for genuine third-party stub mismatch):

| File | Error | Fix |
|---|---|---|
| `ai_command_processor.py` | `invalid-argument-type` on `b64encode` | pass `buffer.tobytes()` (bytes) instead of the numpy ndarray from `cv2.imencode` |
| `communication_bridge.py` | `invalid-argument-type` on `serve.__init__` | drop the removed `path` param — websockets ≥14 invokes handlers with a single connection arg |
| `robot_model.py` | `unresolved-attribute` `.shape`/`.point` on `SegmentQueryInfo \| None` | `if query_info is not None and query_info.shape:` — also a real runtime None guard |
| `genesis_visualizer.py` | `unresolved-attribute` `.stop` on `EventSourceProtocol \| None` | guard `anim.event_source is not None` — also a real runtime None guard |
| `swift_subprocess.py` ×2, `test_swift.py` ×3 | `invalid-assignment` on trimesh `.face_colors` | targeted `# ty: ignore[invalid-assignment]` — trimesh stubs type `.visual` as `ColorVisuals \| TextureVisuals \| None`, but primitives return `ColorVisuals` whose `face_colors` is settable |

The trimesh color is extracted to a local variable so the suppressed
assignment line cannot be reflowed by `ruff format` (which would otherwise
move the `# ty: ignore` comment off the diagnostic line and un-suppress it).

## Verification

- `uvx ty check src/` (with `uv sync --extra dev` including `genesis-world`): **All checks passed** (was 10 diagnostics)
- `uv run pytest tests/ -q`: **68 passed, 4 pre-existing xfail** (physics calibration, unrelated)
- `pre-commit` ran on commit (incl. the `ty` hook) and passed
- Workflow YAML parses (`yaml.safe_load`)
- All changes behavior-preserving; the two None-guards are also genuine runtime safety improvements
