### PR TITLE
chore(blueprint): reconcile melody-detector docs with sibling conventions

### DIFF
--- a/docs/blueprint/feature-tracker.json
+++ b/docs/blueprint/feature-tracker.json
@@ -1,7 +1,13 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "source_document": "docs/requirements/PRD-001-ai-robot-car-system.md",
-  "last_synced_at": "2026-04-05T00:00:00Z",
+  "source_documents": [
+    "docs/requirements/PRD-001-ai-robot-car-system.md",
+    "docs/requirements/PRD-002-esp32cam-vision-ai-backend.md",
+    "docs/requirements/PRD-003-robot-physics-simulation.md",
+    "docs/requirements/PRD-011-melody-detector.md"
+  ],
+  "last_synced_at": "2026-07-12T00:00:00Z",
   "features": [
     {
       "id": "FR-001",
@@ -158,7 +164,7 @@
   ],
   "summary": {
     "total": 19,
-    "active": 12,
+    "active": 13,
     "planned": 6,
     "in_progress": 0,
     "blocked": 0

--- a/docs/blueprint/feature-tracker.md
+++ b/docs/blueprint/feature-tracker.md
@@ -1,30 +1,30 @@
 # Feature Tracker
 
-| Feature | PRD | Status | Priority | Notes |
-|---------|-----|--------|----------|-------|
-| Main controller firmware (motor, LED, servo, OLED) | PRD-001 | active | P0 | Heltec WiFi LoRa 32 V1; ESP-IDF v5.4 |
-| ESP32-CAM firmware with AI vision | PRD-002 | active | P0 | OV2640; Claude API + Ollama backends |
-| MQTT telemetry and logging | PRD-002 | active | P1 | JSON messages, mDNS service discovery |
-| Pluggable AI backend (Claude / Ollama) | PRD-002 | active | P1 | Compile-time selection via config.h |
-| Pymunk 2D physics simulation | PRD-003 | active | P1 | Python 3.11; 18/24 tests passing |
-| WebSocket communication bridge | PRD-003 | active | P2 | Port 8765; bi-directional motor/sensor |
-| Hardware-in-the-loop (HIL) testing | PRD-003 | planned | P2 | Real ESP32 + virtual environment |
-| OTA firmware updates | PRD-001 | active | P1 | Dual-partition; size limits enforced in CI |
-| ESP32 build CI pipeline | PRD-001 | active | P0 | Parallel matrix; 4 projects; artifact archive |
-| Python simulation CI pipeline | PRD-003 | active | P1 | uv + pytest with coverage |
-| Pre-commit code quality hooks | — | active | P1 | clang-format, ruff, mypy, gitleaks |
-| Docker development environment | — | active | P2 | ESP-IDF containerized; reproducible builds |
-| ESP32-CAM LLM Telegram bot | — | active | P2 | Separate project; Claude/Ollama vision |
-| ESP32-CAM web video streaming | — | active | P3 | Live MJPEG server |
-| Arduino platform support | — | planned | P3 | No projects yet |
-| STM32 platform support | — | planned | P3 | No projects yet |
-| Automated project scaffolding tool | — | planned | P3 | Mentioned in README as coming soon |
-| ESP32 host-based unit tests | — | planned | P2 | Blocked; no tests exist yet |
-| SLAM / autonomous navigation | — | planned | P3 | Listed as future enhancement |
-| Multi-robot swarm coordination | — | planned | P3 | Listed as future enhancement |
-| Melody detector firmware (CV + ESP-DL + I2S) | PRD-011 | planned | P2 | XIAO ESP32-S3 Sense + MAX98357A; ROI classifier with INT8 CNN |
-| Melody detector training pipeline | PRD-011 | planned | P2 | PyTorch + ESP-PPQ; programmatic + diffusion synthetic data |
-| Melody detector validation harness | PRD-011 | planned | P3 | Gemini Robotics-ER 1.6 oracle benchmark |
+| ID | Feature | PRD | Status | Priority | Notes |
+|----|---------|-----|--------|----------|-------|
+| FR-001 | Main controller firmware (motor, LED, servo, OLED) | PRD-001 | active | P0 | Heltec WiFi LoRa 32 V1; ESP-IDF v5.4 |
+| FR-002 | ESP32-CAM firmware with AI vision | PRD-002 | active | P0 | OV2640; Claude API + Ollama backends |
+| FR-003 | MQTT telemetry and logging | PRD-002 | active | P1 | JSON messages, mDNS service discovery |
+| FR-004 | Pluggable AI backend (Claude / Ollama) | PRD-002 | active | P1 | Compile-time selection via config.h |
+| FR-005 | Pymunk 2D physics simulation | PRD-003 | active | P1 | Python 3.11; 18/24 tests passing |
+| FR-006 | WebSocket communication bridge | PRD-003 | active | P2 | Port 8765; bi-directional motor/sensor |
+| FR-007 | Hardware-in-the-loop (HIL) testing | PRD-003 | planned | P2 | Real ESP32 + virtual environment |
+| FR-008 | OTA firmware updates | PRD-001 | active | P1 | Dual-partition; size limits enforced in CI |
+| FR-009 | ESP32 build CI pipeline | PRD-001 | active | P0 | Parallel matrix; 4 projects; artifact archive |
+| FR-010 | Python simulation CI pipeline | PRD-003 | active | P1 | uv + pytest with coverage |
+| FR-011 | Pre-commit code quality hooks | — | active | P1 | clang-format, ruff, mypy, gitleaks |
+| FR-012 | Docker development environment | — | active | P2 | ESP-IDF containerized; reproducible builds |
+| FR-013 | ESP32-CAM LLM Telegram bot | — | active | P2 | Separate project; Claude/Ollama vision |
+| FR-014 | ESP32-CAM web video streaming | — | active | P3 | Live MJPEG server |
+| — | Arduino platform support | — | planned | P3 | No projects yet; no FR-ID in feature-tracker.json (drift) |
+| — | STM32 platform support | — | planned | P3 | No projects yet; no FR-ID in feature-tracker.json (drift) |
+| — | Automated project scaffolding tool | — | planned | P3 | Mentioned in README as coming soon; no FR-ID in feature-tracker.json (drift) |
+| FR-015 | ESP32 host-based unit tests | — | planned | P2 | Blocked; no tests exist yet |
+| FR-016 | SLAM / autonomous navigation | — | planned | P3 | Listed as future enhancement |
+| — | Multi-robot swarm coordination | — | planned | P3 | Listed as future enhancement; no FR-ID in feature-tracker.json (drift) |
+| FR-017 | Melody detector firmware (CV + ESP-DL + I2S) | PRD-011 | planned | P2 | XIAO ESP32-S3 Sense + MAX98357A; ROI classifier with INT8 CNN |
+| FR-018 | Melody detector training pipeline | PRD-011 | planned | P2 | PyTorch + ESP-PPQ; programmatic + diffusion synthetic data |
+| FR-019 | Melody detector validation harness | PRD-011 | planned | P3 | Gemini Robotics-ER 1.6 oracle benchmark |
 
 ## Status Key
 

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -30,8 +30,14 @@
   "feature_tracker": {
     "file": "feature-tracker.json",
     "source_document": "docs/requirements/PRD-001-ai-robot-car-system.md",
+    "source_documents": [
+      "docs/requirements/PRD-001-ai-robot-car-system.md",
+      "docs/requirements/PRD-002-esp32cam-vision-ai-backend.md",
+      "docs/requirements/PRD-003-robot-physics-simulation.md",
+      "docs/requirements/PRD-011-melody-detector.md"
+    ],
     "sync_targets": [
-      "docs/feature-tracker.md"
+      "docs/blueprint/feature-tracker.md"
     ]
   },
   "generated": {

--- a/docs/decisions/ADR-017-melody-detector-esp-dl.md
+++ b/docs/decisions/ADR-017-melody-detector-esp-dl.md
@@ -1,10 +1,13 @@
+---
+id: ADR-017
+title: ESP-DL for On-Device Vision in Melody Detector
+status: proposed
+created: 2026-04-26
+---
+
 # ADR-017: ESP-DL for On-Device Vision in Melody Detector
 
-**Status**: proposed
-**Date**: 2026-04-26
 **Confidence**: 8/10
-
----
 
 ## Context
 

--- a/docs/requirements/PRD-011-melody-detector.md
+++ b/docs/requirements/PRD-011-melody-detector.md
@@ -1,10 +1,13 @@
+---
+id: PRD-011
+title: Melody Detector
+status: draft
+created: 2026-04-26
+---
+
 # PRD-011: Melody Detector
 
-**Status**: draft
-**Created**: 2026-04-26
 **Confidence**: 7/10
-
----
 
 ## Overview
 


### PR DESCRIPTION
## Summary

PR #276 manually authored the melody-detector blueprint docs (ADR-017, PRD-011, feature-tracker entries) without the blueprint-plugin skills, introducing structural drift from sibling docs. An audit surfaced the inconsistencies. This PR applies **only the low-risk mechanical reconciliations**. Every lifecycle-status decision is deliberately deferred to the maintainer (see below).

Refs #289 — mechanical reconciliation only; the status-advancement items in the issue's acceptance are intentionally left for a human.

## Reconciled (this PR)

- **ADR-017** — added YAML frontmatter (`id`/`title`/`status`/`created`) matching sibling ADRs (e.g. ADR-013, ADR-001). Removed the redundant loose `**Status**`/`**Date**` bold lines that duplicated — and could contradict — the frontmatter. Status kept `proposed`; `**Date**` folded into `created`. `**Confidence**` line retained.
- **PRD-011** — added YAML frontmatter (`id`/`title`/`status`/`created`) matching sibling PRDs (e.g. PRD-001). Removed the duplicate `**Status**`/`**Created**` bold lines. Status kept `draft`. `**Confidence**` line retained.
- **feature-tracker.json** — fixed `summary.active` **12 → 13** (13 active + 6 planned = 19 total; the count was stale). Refreshed `last_synced_at` → `2026-07-12`, bumped `version` **1.0.0 → 1.0.1**.
- **source_documents** — the tracker aggregates FRs from PRD-001, PRD-002, PRD-003, PRD-011, but only PRD-001 was declared. Added a `source_documents` list `[PRD-001, PRD-002, PRD-003, PRD-011]` to **both** `feature-tracker.json` and `manifest.json`. Kept the original `source_document` key alongside it — least-disruptive choice so no blueprint-plugin consumer reading the singular key breaks.
- **manifest.json sync_targets** — fixed the stale path `docs/feature-tracker.md` → `docs/blueprint/feature-tracker.md` (file relocated under `docs/blueprint/` in the v3.3 upgrade; new path verified present).
- **feature-tracker.md** — added an `ID` column so `.md` rows carry the same FR IDs as `feature-tracker.json`; melody rows now labelled **FR-017/FR-018/FR-019**. The four `.md`-only rows without a JSON counterpart are marked `—` and flagged inline as drift. No rows deleted, no JSON entries invented.

JSON validated with `python3 -c "import json; json.load(...)"` after editing; status counts cross-checked against the features array.

## Deferred — needs maintainer decision

- **ADR-017** status `proposed → accepted` — human decision; left `proposed`.
- **PRD-011** status `draft → active` — left `draft`.
- Any **PRP** `planned → in-progress` advancement — left untouched.
- **FR-018** (melody detector training pipeline): #278 is closed, which may warrant flipping FR-018 off `planned`, but the correct target status is a judgement call — left `planned`.
- **feature-tracker.md vs .json membership drift**: four `.md`-only features (Arduino platform support, STM32 platform support, Automated project scaffolding tool, Multi-robot swarm coordination) have no FR-ID in `feature-tracker.json`. Left as-is and flagged inline; whether to add JSON entries or drop the rows is a maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)