### PR TITLE
fix(llm-telegram): resolve ESP-IDF v5.4 build errors

### DIFF
--- a/packages/camera-vision/llm-telegram/main/camera_handler.c
+++ b/packages/camera-vision/llm-telegram/main/camera_handler.c
@@ -1,4 +1,5 @@
 #include "camera_handler.h"
+#include <inttypes.h>
 #include <string.h>
 #include "config.h"
 #include "esp_log.h"
@@ -28,7 +29,7 @@ static const char *TAG = "CAMERA_HANDLER";
 #define PCLK_GPIO_NUM 22
 
 // Camera state
-static camera_status_t camera_status = {0};
+static camera_handler_status_t camera_status = {0};
 static SemaphoreHandle_t camera_mutex = NULL;
 static TaskHandle_t capture_task_handle = NULL;
 static camera_capture_cb capture_callback = NULL;
@@ -234,7 +235,7 @@ esp_err_t camera_start_capture(uint32_t interval_ms, camera_capture_cb callback,
     xTaskCreate(camera_capture_task, "camera_capture", 4096, NULL, CAMERA_TASK_PRIORITY,
                 &capture_task_handle);
 
-    ESP_LOGI(TAG, "Started continuous capture with interval %d ms", interval_ms);
+    ESP_LOGI(TAG, "Started continuous capture with interval %" PRIu32 " ms", interval_ms);
     return ESP_OK;
 }
 
@@ -259,7 +260,7 @@ esp_err_t camera_stop_capture(void)
 }
 
 // Get camera status
-camera_status_t camera_get_status(void)
+camera_handler_status_t camera_get_status(void)
 {
     return camera_status;
 }

--- a/packages/camera-vision/llm-telegram/main/camera_handler.h
+++ b/packages/camera-vision/llm-telegram/main/camera_handler.h
@@ -13,7 +13,7 @@ typedef struct {
     uint32_t capture_count;
     uint32_t error_count;
     size_t last_frame_size;
-} camera_status_t;
+} camera_handler_status_t;
 
 // Camera capture callback
 typedef void (*camera_capture_cb)(const uint8_t *data, size_t size, void *user_data);
@@ -37,7 +37,7 @@ esp_err_t camera_start_capture(uint32_t interval_ms, camera_capture_cb callback,
 esp_err_t camera_stop_capture(void);
 
 // Get camera status
-camera_status_t camera_get_status(void);
+camera_handler_status_t camera_get_status(void);
 
 // Adjust camera settings
 esp_err_t camera_set_quality(int quality);

--- a/packages/camera-vision/llm-telegram/main/config_manager.c
+++ b/packages/camera-vision/llm-telegram/main/config_manager.c
@@ -9,7 +9,7 @@
 static const char *TAG = "CONFIG_MANAGER";
 static const char *NVS_NAMESPACE = "esp32cam_llm";
 
-static nvs_handle_t nvs_handle = 0;
+static nvs_handle_t s_nvs_handle = 0;
 static bool is_initialized = false;
 
 // Initialize configuration manager
@@ -28,7 +28,7 @@ esp_err_t config_manager_init(void)
     ESP_ERROR_CHECK(err);
 
     // Open NVS handle
-    err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &s_nvs_handle);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Error opening NVS handle: %s", esp_err_to_name(err));
         return err;
@@ -53,74 +53,74 @@ esp_err_t config_load(app_config_t *config)
 
     // Load WiFi settings
     length = sizeof(config->wifi_ssid);
-    err = nvs_get_str(nvs_handle, "wifi_ssid", config->wifi_ssid, &length);
+    err = nvs_get_str(s_nvs_handle, "wifi_ssid", config->wifi_ssid, &length);
     if (err != ESP_OK) {
         strcpy(config->wifi_ssid, WIFI_SSID_DEFAULT);
     }
 
     length = sizeof(config->wifi_password);
-    err = nvs_get_str(nvs_handle, "wifi_pass", config->wifi_password, &length);
+    err = nvs_get_str(s_nvs_handle, "wifi_pass", config->wifi_password, &length);
     if (err != ESP_OK) {
         strcpy(config->wifi_password, WIFI_PASSWORD_DEFAULT);
     }
 
     // Load Telegram settings
     length = sizeof(config->telegram_bot_token);
-    err = nvs_get_str(nvs_handle, "tg_token", config->telegram_bot_token, &length);
+    err = nvs_get_str(s_nvs_handle, "tg_token", config->telegram_bot_token, &length);
     if (err != ESP_OK) {
         strcpy(config->telegram_bot_token, TELEGRAM_BOT_TOKEN);
     }
 
-    err = nvs_get_i64(nvs_handle, "tg_chat_id", &config->telegram_chat_id);
+    err = nvs_get_i64(s_nvs_handle, "tg_chat_id", &config->telegram_chat_id);
     if (err != ESP_OK) {
         config->telegram_chat_id = 0;  // Will need to be set
     }
 
     // Load LLM settings
-    err = nvs_get_i32(nvs_handle, "llm_backend", &config->llm_backend_type);
+    err = nvs_get_i32(s_nvs_handle, "llm_backend", (int32_t *)&config->llm_backend_type);
     if (err != ESP_OK) {
         config->llm_backend_type = LLM_BACKEND_TYPE;
     }
 
     length = sizeof(config->claude_api_key);
-    err = nvs_get_str(nvs_handle, "claude_key", config->claude_api_key, &length);
+    err = nvs_get_str(s_nvs_handle, "claude_key", config->claude_api_key, &length);
     if (err != ESP_OK) {
         strcpy(config->claude_api_key, CLAUDE_API_KEY);
     }
 
     length = sizeof(config->ollama_server_url);
-    err = nvs_get_str(nvs_handle, "ollama_url", config->ollama_server_url, &length);
+    err = nvs_get_str(s_nvs_handle, "ollama_url", config->ollama_server_url, &length);
     if (err != ESP_OK) {
         strcpy(config->ollama_server_url, OLLAMA_SERVER_URL);
     }
 
     length = sizeof(config->llm_model);
-    err = nvs_get_str(nvs_handle, "llm_model", config->llm_model, &length);
+    err = nvs_get_str(s_nvs_handle, "llm_model", config->llm_model, &length);
     if (err != ESP_OK) {
         strcpy(config->llm_model, config->llm_backend_type ? CLAUDE_MODEL : OLLAMA_MODEL);
     }
 
     // Load camera settings
-    err = nvs_get_i32(nvs_handle, "cam_quality", &config->camera_quality);
+    err = nvs_get_i32(s_nvs_handle, "cam_quality", (int32_t *)&config->camera_quality);
     if (err != ESP_OK) {
         config->camera_quality = CAMERA_JPEG_QUALITY;
     }
 
-    err = nvs_get_i32(nvs_handle, "cam_interval", &config->capture_interval_ms);
+    err = nvs_get_i32(s_nvs_handle, "cam_interval", (int32_t *)&config->capture_interval_ms);
     if (err != ESP_OK) {
         config->capture_interval_ms = CAMERA_CAPTURE_INTERVAL_MS;
     }
 
     // Load system settings
     uint8_t auto_capture;
-    err = nvs_get_u8(nvs_handle, "auto_capture", &auto_capture);
+    err = nvs_get_u8(s_nvs_handle, "auto_capture", &auto_capture);
     config->auto_capture_enabled = (err == ESP_OK) ? auto_capture : true;
 
     uint8_t tg_commands;
-    err = nvs_get_u8(nvs_handle, "tg_commands", &tg_commands);
+    err = nvs_get_u8(s_nvs_handle, "tg_commands", &tg_commands);
     config->telegram_commands_enabled = (err == ESP_OK) ? tg_commands : true;
 
-    err = nvs_get_i32(nvs_handle, "log_level", &config->log_level);
+    err = nvs_get_i32(s_nvs_handle, "log_level", (int32_t *)&config->log_level);
     if (err != ESP_OK) {
         config->log_level = LOG_LEVEL_DEBUG;
     }
@@ -141,64 +141,64 @@ esp_err_t config_save(const app_config_t *config)
     esp_err_t err;
 
     // Save WiFi settings
-    err = nvs_set_str(nvs_handle, "wifi_ssid", config->wifi_ssid);
+    err = nvs_set_str(s_nvs_handle, "wifi_ssid", config->wifi_ssid);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_str(nvs_handle, "wifi_pass", config->wifi_password);
+    err = nvs_set_str(s_nvs_handle, "wifi_pass", config->wifi_password);
     if (err != ESP_OK)
         goto save_error;
 
     // Save Telegram settings
-    err = nvs_set_str(nvs_handle, "tg_token", config->telegram_bot_token);
+    err = nvs_set_str(s_nvs_handle, "tg_token", config->telegram_bot_token);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_i64(nvs_handle, "tg_chat_id", config->telegram_chat_id);
+    err = nvs_set_i64(s_nvs_handle, "tg_chat_id", config->telegram_chat_id);
     if (err != ESP_OK)
         goto save_error;
 
     // Save LLM settings
-    err = nvs_set_i32(nvs_handle, "llm_backend", config->llm_backend_type);
+    err = nvs_set_i32(s_nvs_handle, "llm_backend", config->llm_backend_type);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_str(nvs_handle, "claude_key", config->claude_api_key);
+    err = nvs_set_str(s_nvs_handle, "claude_key", config->claude_api_key);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_str(nvs_handle, "ollama_url", config->ollama_server_url);
+    err = nvs_set_str(s_nvs_handle, "ollama_url", config->ollama_server_url);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_str(nvs_handle, "llm_model", config->llm_model);
+    err = nvs_set_str(s_nvs_handle, "llm_model", config->llm_model);
     if (err != ESP_OK)
         goto save_error;
 
     // Save camera settings
-    err = nvs_set_i32(nvs_handle, "cam_quality", config->camera_quality);
+    err = nvs_set_i32(s_nvs_handle, "cam_quality", config->camera_quality);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_i32(nvs_handle, "cam_interval", config->capture_interval_ms);
+    err = nvs_set_i32(s_nvs_handle, "cam_interval", config->capture_interval_ms);
     if (err != ESP_OK)
         goto save_error;
 
     // Save system settings
-    err = nvs_set_u8(nvs_handle, "auto_capture", config->auto_capture_enabled ? 1 : 0);
+    err = nvs_set_u8(s_nvs_handle, "auto_capture", config->auto_capture_enabled ? 1 : 0);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_u8(nvs_handle, "tg_commands", config->telegram_commands_enabled ? 1 : 0);
+    err = nvs_set_u8(s_nvs_handle, "tg_commands", config->telegram_commands_enabled ? 1 : 0);
     if (err != ESP_OK)
         goto save_error;
 
-    err = nvs_set_i32(nvs_handle, "log_level", config->log_level);
+    err = nvs_set_i32(s_nvs_handle, "log_level", config->log_level);
     if (err != ESP_OK)
         goto save_error;
 
     // Commit changes
-    err = nvs_commit(nvs_handle);
+    err = nvs_commit(s_nvs_handle);
     if (err != ESP_OK)
         goto save_error;
 
@@ -243,9 +243,9 @@ esp_err_t config_set_string(const char *key, const char *value)
         return ESP_ERR_INVALID_ARG;
     }
 
-    esp_err_t err = nvs_set_str(nvs_handle, key, value);
+    esp_err_t err = nvs_set_str(s_nvs_handle, key, value);
     if (err == ESP_OK) {
-        err = nvs_commit(nvs_handle);
+        err = nvs_commit(s_nvs_handle);
     }
     return err;
 }
@@ -257,9 +257,9 @@ esp_err_t config_set_int(const char *key, int value)
         return ESP_ERR_INVALID_ARG;
     }
 
-    esp_err_t err = nvs_set_i32(nvs_handle, key, value);
+    esp_err_t err = nvs_set_i32(s_nvs_handle, key, value);
     if (err == ESP_OK) {
-        err = nvs_commit(nvs_handle);
+        err = nvs_commit(s_nvs_handle);
     }
     return err;
 }
@@ -271,7 +271,7 @@ esp_err_t config_get_string(const char *key, char *value, size_t max_len)
         return ESP_ERR_INVALID_ARG;
     }
 
-    return nvs_get_str(nvs_handle, key, value, &max_len);
+    return nvs_get_str(s_nvs_handle, key, value, &max_len);
 }
 
 // Get single int configuration value
@@ -281,7 +281,7 @@ esp_err_t config_get_int(const char *key, int *value)
         return ESP_ERR_INVALID_ARG;
     }
 
-    return nvs_get_i32(nvs_handle, key, value);
+    return nvs_get_i32(s_nvs_handle, key, (int32_t *)value);
 }
 
 // Validate configuration

--- a/packages/camera-vision/llm-telegram/main/main.c
+++ b/packages/camera-vision/llm-telegram/main/main.c
@@ -219,7 +219,7 @@ static void process_telegram_command(const char *command, const char *args)
         motor_stop();
         telegram_send_text(&telegram_bot, "✅ Stopped");
     } else if (strcmp(command, "status") == 0) {
-        camera_status_t cam_status = camera_get_status();
+        camera_handler_status_t cam_status = camera_get_status();
         motor_status_t motor_status = motor_get_status();
         vision_interpreter_t vision_status = vision_get_status();
 
@@ -244,7 +244,7 @@ static void process_telegram_command(const char *command, const char *args)
     } else if (strcmp(command, "auto") == 0) {
         if (strcmp(args, "on") == 0) {
             app_config.auto_capture_enabled = true;
-            camera_status_t auto_cam_status = camera_get_status();
+            camera_handler_status_t auto_cam_status = camera_get_status();
             if (!auto_cam_status.is_capturing) {
                 camera_start_capture(app_config.capture_interval_ms, camera_capture_callback, NULL);
             }

--- a/packages/camera-vision/llm-telegram/main/motor_controller.c
+++ b/packages/camera-vision/llm-telegram/main/motor_controller.c
@@ -107,7 +107,7 @@ esp_err_t motor_execute_command(motor_command_t command, int speed, uint32_t dur
         return ESP_ERR_INVALID_STATE;
     }
 
-    ESP_LOGI(TAG, "Executing command: %s, speed: %d, duration: %d ms",
+    ESP_LOGI(TAG, "Executing command: %s, speed: %d, duration: %" PRIu32 " ms",
              motor_get_command_name(command), speed, duration_ms);
 
     motor_status.current_command = command;


### PR DESCRIPTION
Resolves the ESP-IDF v5.4 build for `packages/camera-vision/llm-telegram`. Builds **fully green** in the `espressif/idf:v5.4` container (`esp32cam-llm-telegram.bin` generated, exit 0).

## Root causes fixed
- **`camera_status_t` name collision** — the esp32-camera driver defines its own `camera_status_t` in `sensor.h` (pulled in transitively via `esp_camera.h`). Renamed the project's local struct to `camera_handler_status_t` (`camera_handler.h`/`.c`, plus two locals in `main.c`).
- **`nvs_handle` shadowing** — the `static nvs_handle` variable in `config_manager.c` collided with the deprecated `nvs_handle` typedef in `nvs.h`; renamed to `s_nvs_handle`.
- **`nvs_get_i32` pointer type** — `int*` != `int32_t*` on xtensa-esp-elf (`int32_t` is `long int`); cast the 5 call sites to `(int32_t *)` (identical representation, no struct/API churn).
- **`-Werror=format`** — `uint32_t` logged with `%d` → `%"PRIu32"` in `camera_handler.c` and `motor_controller.c`; added `<inttypes.h>` where missing.

## Verification
`just telegram::build` → clean, exit 0, `.bin` generated (40% partition free).

Fixes #380
Refs #375
