### PR TITLE
fix(robocar-main): correct uint32_t/int32_t log format specifiers

### DIFF
--- a/packages/robocar/main/main/wifi_manager.c
+++ b/packages/robocar/main/main/wifi_manager.c
@@ -7,6 +7,7 @@
  */
 
 #include "wifi_manager.h"
+#include <inttypes.h>
 #include <math.h>
 #include <string.h>
 #include "esp_event.h"
@@ -714,8 +715,8 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base, int32_t e
                 notify_state_change(WIFI_STATE_RECONNECTING);
 
                 uint32_t delay = calculate_backoff_delay(g_wifi_context.retry_count);
-                ESP_LOGI(TAG, "Reconnection attempt %d/%d in %d ms", g_wifi_context.retry_count,
-                         WIFI_MAXIMUM_RETRY, delay);
+                ESP_LOGI(TAG, "Reconnection attempt %" PRIu32 "/%d in %" PRIu32 " ms",
+                         g_wifi_context.retry_count, WIFI_MAXIMUM_RETRY, delay);
 
                 esp_timer_stop(g_wifi_context.reconnect_timer);
                 esp_timer_start_once(g_wifi_context.reconnect_timer, delay * 1000);
@@ -736,7 +737,7 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base, int32_t e
             break;
 
         default:
-            ESP_LOGD(TAG, "Unhandled WiFi event: %d", event_id);
+            ESP_LOGD(TAG, "Unhandled WiFi event: %" PRId32, event_id);
             break;
     }
 }


### PR DESCRIPTION
Fixes the `-Werror=format` defect in `packages/robocar/main/main/wifi_manager.c` (issue #378). With this change the project **compiles and links cleanly** in the `espressif/idf:v5.4` container.

## Change
- Added `<inttypes.h>`; corrected two `ESP_LOGx` sites where `uint32_t`/`int32_t` were logged with `%d` (`int32_t` is `long int` on xtensa-esp-elf, so `%d` fails `-Werror=format`) → `%"PRIu32"` / `%"PRId32"`.

## Verification
Compiles + links clean (verified with the shared `thinkpack-mesh` `esp_mac.h` fix from #382/PR for `fix/thinkpack-mesh-consumers` applied).

## ⚠️ Separate blocker (not this PR's scope)
A full `just robocar-main::build` still fails at the final `app_check_size` step: the ~1.09 MB binary overflows the **1 MB `SINGLE_APP` default** because the custom OTA `partitions.csv` is wired via an inert CMake `set(CONFIG_PARTITION_TABLE_CUSTOM ON)` that never reaches Kconfig. This is a **pre-existing partition/flash-size infra bug** (also affects robocar-camera) tracked separately — it touches the `0x12000` app offset that `.claude/rules/web-flasher.md` and `build-firmware.yml` manifest generation depend on. The `-Werror=format` defect that #378 is about is fully resolved here.

Fixes #378
Refs #375
