### PR TITLE
fix(thinkpack-mesh): resolve build failures in shared mesh component and consumers

### DIFF
--- a/packages/components/thinkpack-mesh/CMakeLists.txt
+++ b/packages/components/thinkpack-mesh/CMakeLists.txt
@@ -3,5 +3,5 @@ idf_component_register(SRCS "espnow_mesh.c"
                             "group_manager.c"
                             "fragment_reassembler.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES esp_wifi esp_event esp_netif nvs_flash log thinkpack-protocol
+                    REQUIRES esp_wifi esp_event esp_netif nvs_flash log esp_timer thinkpack-protocol
                     PRIV_REQUIRES freertos)

--- a/packages/components/thinkpack-mesh/group_manager.c
+++ b/packages/components/thinkpack-mesh/group_manager.c
@@ -5,9 +5,11 @@
 
 #include "group_manager.h"
 
+#include <inttypes.h>
 #include <string.h>
 
 #include "esp_log.h"
+#include "esp_mac.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 

--- a/packages/components/thinkpack-mesh/leader_election.c
+++ b/packages/components/thinkpack-mesh/leader_election.c
@@ -19,9 +19,11 @@
 
 #include "leader_election.h"
 
+#include <inttypes.h>
 #include <string.h>
 
 #include "esp_log.h"
+#include "esp_mac.h"
 
 static const char *TAG = "election";
 

--- a/packages/robocar/camera/main/CMakeLists.txt
+++ b/packages/robocar/camera/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "main.c" "camera.c" "wifi_manager.c" "claude_api.c" "base64.c" "ai_response_parser.c" "i2c_master.c" "ai_backend.c" "ollama_backend.c" "ollama_discovery.c" "gemini_backend.c" "credentials_loader.c" "mqtt_logger.c" "system_state.c" "serial_comm.c" "ota_manager.c"
                     INCLUDE_DIRS "."
-                    REQUIRES "esp32-camera" "esp_wifi" "esp_http_client" "json" "nvs_flash" "driver" "espressif__mdns" "mqtt" "esp_https_ota" "app_update" "i2c-protocol" "improv-wifi" "ota-github")
+                    REQUIRES "esp32-camera" "esp_wifi" "esp_http_client" "json" "nvs_flash" "driver" "espressif__mdns" "mqtt" "esp_https_ota" "app_update" "i2c-protocol" "improv-wifi" "ota-github" "fishwaldo__esp_ghota")

--- a/packages/robocar/camera/main/mqtt_logger.c
+++ b/packages/robocar/camera/main/mqtt_logger.c
@@ -39,6 +39,8 @@ typedef struct {
     bool initialized;
     bool connected;
     TaskHandle_t log_task_handle;
+    char *sub_topic;                  ///< Extra subscribed topic (optional)
+    mqtt_logger_command_cb_t sub_cb;  ///< Callback for sub_topic messages
 } mqtt_logger_context_t;
 
 static mqtt_logger_context_t s_context = {0};
@@ -206,6 +208,7 @@ esp_err_t mqtt_logger_deinit(void)
         free((void *)s_context.config.username);
     if (s_context.config.password)
         free((void *)s_context.config.password);
+    free(s_context.sub_topic);
 
     memset(&s_context, 0, sizeof(s_context));
 
@@ -264,6 +267,56 @@ esp_err_t mqtt_logger_publish_status(const char *status_json)
         s_context.stats.messages_failed++;
         xSemaphoreGive(s_context.mutex);
         return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t mqtt_logger_publish(const char *topic, const char *payload, int qos, bool retain)
+{
+    if (!s_context.initialized || !s_context.connected) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!topic || !payload) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    int msg_id =
+        esp_mqtt_client_publish(s_context.client, topic, payload, strlen(payload), qos, retain);
+
+    if (msg_id < 0) {
+        xSemaphoreTake(s_context.mutex, pdMS_TO_TICKS(SEMAPHORE_TIMEOUT_MS));
+        s_context.stats.messages_failed++;
+        xSemaphoreGive(s_context.mutex);
+        return ESP_FAIL;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t mqtt_logger_subscribe(const char *topic, mqtt_logger_command_cb_t callback)
+{
+    if (!s_context.initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!topic || !callback) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // Store the subscription so it can be (re-)applied on every connect.
+    free(s_context.sub_topic);
+    s_context.sub_topic = strdup(topic);
+    if (!s_context.sub_topic) {
+        return ESP_ERR_NO_MEM;
+    }
+    s_context.sub_cb = callback;
+
+    // Subscribe immediately if already connected; otherwise the connect
+    // handler will apply it once the session is established.
+    if (s_context.connected) {
+        esp_mqtt_client_subscribe(s_context.client, s_context.sub_topic, 1);
     }
 
     return ESP_OK;
@@ -347,6 +400,11 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
                 esp_mqtt_client_subscribe(s_context.client, s_context.config.command_topic, 1);
             }
 
+            // Re-apply any user subscription registered via mqtt_logger_subscribe
+            if (s_context.sub_topic) {
+                esp_mqtt_client_subscribe(s_context.client, s_context.sub_topic, 1);
+            }
+
             // Publish online status
             char status_msg[128];
             snprintf(status_msg, sizeof(status_msg),
@@ -380,9 +438,15 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
         case MQTT_EVENT_DATA:
             // Handle remote commands
-            if (strncmp(event->topic, s_context.config.command_topic, event->topic_len) == 0) {
+            if (s_context.config.command_topic &&
+                strncmp(event->topic, s_context.config.command_topic, event->topic_len) == 0) {
                 ESP_LOGI(TAG, "Received command: %.*s", event->data_len, event->data);
                 // TODO: Implement command processing
+            }
+            // Dispatch to a user subscription registered via mqtt_logger_subscribe
+            if (s_context.sub_topic && s_context.sub_cb &&
+                strncmp(event->topic, s_context.sub_topic, event->topic_len) == 0) {
+                s_context.sub_cb(s_context.sub_topic, event->data, event->data_len);
             }
             break;
 

--- a/packages/robocar/camera/main/mqtt_logger.h
+++ b/packages/robocar/camera/main/mqtt_logger.h
@@ -16,6 +16,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief Callback invoked when a message arrives on a subscribed topic
+ *
+ * @param topic Topic the message was received on
+ * @param data Message payload (not NUL-terminated; use data_len)
+ * @param data_len Length of the payload in bytes
+ */
+typedef void (*mqtt_logger_command_cb_t)(const char *topic, const char *data, int data_len);
+
+/**
  * @brief MQTT Logger configuration structure
  */
 typedef struct {
@@ -102,6 +111,26 @@ esp_err_t mqtt_logger_logf(esp_log_level_t level, const char *tag, const char *f
  * @return ESP_OK on success, error code otherwise
  */
 esp_err_t mqtt_logger_publish_status(const char *status_json);
+
+/**
+ * @brief Publish an arbitrary payload to an arbitrary topic
+ *
+ * @param topic Topic to publish to
+ * @param payload Message payload (NUL-terminated string)
+ * @param qos QoS level (0, 1, or 2)
+ * @param retain Whether the broker should retain the message
+ * @return ESP_OK on success, error code otherwise
+ */
+esp_err_t mqtt_logger_publish(const char *topic, const char *payload, int qos, bool retain);
+
+/**
+ * @brief Subscribe to a topic and register a callback for incoming messages
+ *
+ * @param topic Topic to subscribe to
+ * @param callback Callback invoked when a message arrives on the topic
+ * @return ESP_OK on success, error code otherwise
+ */
+esp_err_t mqtt_logger_subscribe(const char *topic, mqtt_logger_command_cb_t callback);
 
 /**
  * @brief Get MQTT logger statistics

--- a/packages/robocar/camera/main/ota_manager.c
+++ b/packages/robocar/camera/main/ota_manager.c
@@ -264,7 +264,7 @@ static void orchestrate_main_controller_update(void *pvParameters)
 
     /* Step 5: Send OTA begin with release tag. */
     char release_tag[OTA_TAG_MAX_LEN];
-    snprintf(release_tag, sizeof(release_tag), "v%s", latest_str);
+    snprintf(release_tag, sizeof(release_tag), "v%.*s", (int)(sizeof(release_tag) - 2), latest_str);
 
     ret = i2c_send_begin_ota(release_tag, NULL);
     if (ret != ESP_OK) {

--- a/packages/thinkpack/chatterbox/main/audio_engine.h
+++ b/packages/thinkpack/chatterbox/main/audio_engine.h
@@ -14,6 +14,7 @@
 #ifndef AUDIO_ENGINE_H
 #define AUDIO_ENGINE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 

--- a/packages/thinkpack/finderbox/main/idf_component.yml
+++ b/packages/thinkpack/finderbox/main/idf_component.yml
@@ -1,0 +1,5 @@
+dependencies:
+  idf:
+    version: ">=5.4"
+  espressif/led_strip:
+    version: "^3.0.0"


### PR DESCRIPTION
Fixes the app-code build defects in the shared `thinkpack-mesh` component and its consumers. **finderbox and chatterbox build fully green**; the mesh root fix also unblocks robocar-main and robocar-camera.

## Shared root fix (`thinkpack-mesh`)
- `leader_election.c` / `group_manager.c` used `MACSTR`/`MAC2STR` and `PRIu32` but only included `esp_log.h` → added `#include "esp_mac.h"` and `#include <inttypes.h>` (matching `espnow_mesh.c`). This resolves the `expected ')' before 'MACSTR'` cascades (#382) across every consumer.
- `CMakeLists.txt`: added `esp_timer` to `REQUIRES` (`espnow_mesh.c` calls `esp_timer_get_time`, #379).

## Consumers
- **finderbox** (#381): created missing `main/idf_component.yml` declaring `espressif/led_strip ^3.0.0` (`led_ring.c` uses the 3.x `color_component_format` API). **Green.**
- **chatterbox** (#382): added `<stdbool.h>` to `audio_engine.h`. **Green.**
- **robocar-camera** (#379): added `fishwaldo__esp_ghota` to `main/REQUIRES` (so `ota_manager.c` resolves `semver.h`/`esp_ghota.h`); implemented the declared-but-missing `mqtt_logger_publish`/`mqtt_logger_subscribe` (latent link error — `ota_manager.c` calls both); bounded a release-tag `snprintf` for `-Werror=format-truncation`. **Compiles + links clean.**

## ⚠️ Separate blocker for robocar-camera (not this PR's scope)
`just robocar-camera::build` compiles and links but fails the final `app_check_size` (~1.31 MB binary vs 1 MB `SINGLE_APP` default) — the same **pre-existing partition/flash-size infra bug** as robocar-main (custom `partitions.csv` not wired via Kconfig; `ota_0@0x12000` not 64 KB-aligned; 2 MB vs 4 MB flash). Tracked separately; app-code for #379 is resolved here.

Fixes #379
Fixes #381
Fixes #382
Refs #375
