### PR TITLE
feat(gamepad-synth): encode lfo_rate as value-scaled blip ladder

### DIFF
--- a/packages/audio/gamepad-synth/main/main.c
+++ b/packages/audio/gamepad-synth/main/main.c
@@ -1746,9 +1746,14 @@ static void settings_play_value_ladder(int cursor)
             settings_play_ladder(n, BLIP_FREQ_NEUTRAL);
             break;
         }
-        case SETTING_LFO_RATE:
-            settings_play_ladder(3, BLIP_FREQ_NEUTRAL);
+        case SETTING_LFO_RATE: {
+            /* Map 0.1..20 Hz onto a 1..11 blip ladder — higher rate = more
+             * blips, mirroring the drum_volume / lfo_depth encoding. */
+            float norm = (s_settings.lfo_rate_hz - LFO_RATE_MIN) / (LFO_RATE_MAX - LFO_RATE_MIN);
+            int n = (int)(norm * 10.0f + 0.5f) + 1;
+            settings_play_ladder(n, BLIP_FREQ_NEUTRAL);
             break;
+        }
         case SETTING_LFO_DEPTH: {
             int n = (int)(s_settings.lfo_depth * 10.0f + 0.5f) + 1;
             settings_play_ladder(n, BLIP_FREQ_NEUTRAL);


### PR DESCRIPTION
## What changed

`settings_play_value_ladder()` in `packages/audio/gamepad-synth/main/main.c` played a fixed **3-neutral-blip placeholder** for the `SETTING_LFO_RATE` field that ignored the actual value. On the screenless settings-edit overlay this meant the user could not audit the LFO rate by ear.

This replaces the placeholder with a **value-encoding blip ladder** that mirrors the proven sibling encodings in the same file (`drum_volume`, `lfo_depth`, `lfo_target`):

```c
case SETTING_LFO_RATE: {
    float norm = (s_settings.lfo_rate_hz - LFO_RATE_MIN) / (LFO_RATE_MAX - LFO_RATE_MIN);
    int n = (int)(norm * 10.0f + 0.5f) + 1;
    settings_play_ladder(n, BLIP_FREQ_NEUTRAL);
    break;
}
```

- Normalizes `lfo_rate_hz` over its documented `0.1..20 Hz` range (`LFO_RATE_MIN`..`LFO_RATE_MAX`) onto a **1..11 blip count** — the same scale the `drum_volume`/`lfo_depth` siblings use — so **higher rate = more blips**.
- Uses the identical helper signature (`settings_play_ladder(count, freq)`) and `BLIP_FREQ_NEUTRAL` constant as the siblings. `settings_play_ladder` already clamps the count to `[1, 12]`.
- Minimal diff: no changes to the settings system, the blip engine, or pitch-bend.

Mapping (verified by isolated host compile of the exact arithmetic):

| `lfo_rate_hz` | blips |
|---|---|
| 0.1 Hz (min) | 1 |
| 5 Hz (default) | 3 |
| 10 Hz | 6 |
| 20 Hz (max) | 11 |

## drum_tempo half of #267 is obsolete — nothing added for it

The other half of #267 asked for a `drum_tempo` ladder. That is **obsolete**: the unified-controls refactor (#272) moved tempo to the **global d-pad**, and `drum_tempo` is no longer a member of the settings enum. There is no cursor case to encode, so nothing is added for it. This PR therefore fully addresses #267's remaining scope.

## Verification — read carefully

- **Isolated host compile of the ladder arithmetic**: extracted the exact expression into a standalone C file, compiled with `cc -Wall -Wextra` (clean, no warnings), and confirmed the monotonic mapping in the table above. This proves the arithmetic and syntax are correct.
- **Full ESP-IDF container build (`idf.py build`) was NOT run** in this environment. The `just synth::build` recipe requires the Bluepad32 dependency (`external/bluepad32`), and fetching it (a clone of the third-party `ricardoquesada/bluepad32` repo) was blocked by the sandbox's untrusted-external-code policy. I did not run the containerized firmware build, so I am **not** claiming a firmware build passed. The change touches a single self-contained `switch` case that references only already-defined, verified symbols (`s_settings.lfo_rate_hz`, `LFO_RATE_MIN`, `LFO_RATE_MAX`, `BLIP_FREQ_NEUTRAL`, `settings_play_ladder`) and adds no new includes or symbols, so a compile break is unlikely — but CI's build job is the authoritative check here.
- **Audio *feel* cannot be verified without hardware.** Whether the 1..11 blip ladder reads intuitively by ear (spacing, count legibility at the high end) can only be judged on the physical device with an I2S DAC. Not verified.

Closes #267