### PR TITLE
fix(flasher): show per-project versions and add missing project cards

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -156,11 +156,14 @@ jobs:
           pattern: firmware-*
           path: artifacts
 
+      # Pass the tag verbatim — release-please monorepo tags look like
+      # "robocar-unified-v0.1.5" (no leading "v" to strip). Per-project card
+      # versions come from .release-please-manifest.json inside the generator.
       - name: Get version from tag
         id: version
         run: |
           TAG="${{ github.event.release.tag_name || inputs.release_tag }}"
-          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+          echo "version=$TAG" >> $GITHUB_OUTPUT
 
       - name: Assemble firmware directory
         run: |

--- a/docs/flasher/index.html
+++ b/docs/flasher/index.html
@@ -234,10 +234,11 @@
     }
 
     // ---- Category display configuration ----
-    const CATEGORY_ORDER  = ["thinkpack", "robocar", "tools", "games", "standalone"];
+    const CATEGORY_ORDER  = ["thinkpack", "robocar", "audio", "tools", "games", "standalone"];
     const CATEGORY_LABELS = {
       thinkpack:  "ThinkPack — Modular Toy Mesh",
       robocar:    "RoboCar Components",
+      audio:      "Audio & Synth",
       tools:      "Utility Tools",
       games:      "Games & Toys",
       standalone: "Standalone Projects",
@@ -268,7 +269,9 @@
       // Update footer with generation metadata
       if (data.version || data.generatedAt) {
         const parts = [];
-        if (data.version)      parts.push(`v${data.version}`);
+        // Site-level version is the release tag that triggered the build
+        // (e.g. "robocar-unified-v0.1.5") — already carries its own "v".
+        if (data.version)      parts.push(data.version);
         if (data.generatedAt)  parts.push(`built ${data.generatedAt.slice(0, 10)}`);
         document.getElementById("footer-meta").textContent = parts.join(" · ");
       }

--- a/packages/audio/gamepad-synth/flasher.json
+++ b/packages/audio/gamepad-synth/flasher.json
@@ -1,0 +1,9 @@
+{
+  "name": "Gamepad Synth",
+  "description": "Korg Monotron-inspired synthesizer driven by a BLE gamepad, with dual DDS oscillators and I2S audio out",
+  "chipFamily": "ESP32-S3",
+  "board": "ESP32-S3 DevKit (MAX98357A I2S DAC)",
+  "appBinaryName": "gamepad-synth.bin",
+  "category": "audio",
+  "flashMode": "usb"
+}

--- a/packages/camera-vision/cam-i2s-audio/flasher.json
+++ b/packages/camera-vision/cam-i2s-audio/flasher.json
@@ -1,0 +1,9 @@
+{
+  "name": "ESP32-CAM I2S Audio",
+  "description": "Camera and I2S audio experiments on the AI Thinker ESP32-CAM",
+  "chipFamily": "ESP32",
+  "board": "AI Thinker ESP32-CAM",
+  "appBinaryName": "esp32-cam-i2s-audio.bin",
+  "category": "standalone",
+  "flashMode": "gpio0"
+}

--- a/packages/networking/wifitest/flasher.json
+++ b/packages/networking/wifitest/flasher.json
@@ -1,0 +1,9 @@
+{
+  "name": "WiFi Test",
+  "description": "WiFi access-point test firmware for verifying connectivity and radio behaviour",
+  "chipFamily": "ESP32-S3",
+  "board": "ESP32-S3 DevKit",
+  "appBinaryName": "esp32-wifitest.bin",
+  "category": "tools",
+  "flashMode": "usb"
+}

--- a/packages/robocar/unified/flasher.json
+++ b/packages/robocar/unified/flasher.json
@@ -1,0 +1,10 @@
+{
+  "name": "RoboCar Unified",
+  "description": "Single-board robocar consolidation — camera, motor control, and AI vision on one board",
+  "chipFamily": "ESP32-S3",
+  "board": "Seeed XIAO ESP32-S3 Sense",
+  "appBinaryName": "robocar-unified.bin",
+  "category": "robocar",
+  "flashMode": "usb",
+  "improv": true
+}

--- a/tools/generate-flasher-manifests.sh
+++ b/tools/generate-flasher-manifests.sh
@@ -5,8 +5,14 @@
 #   ./tools/generate-flasher-manifests.sh <version> [firmware-dir]
 #
 # Arguments:
-#   version      Release version string, e.g. "0.3.1"
+#   version      Release tag that triggered the build, e.g. "robocar-unified-v0.1.5".
+#                Used as the site-level version and as a fallback for projects
+#                missing from .release-please-manifest.json.
 #   firmware-dir Output directory for manifests (default: "firmware")
+#
+# Per-project versions come from .release-please-manifest.json — this is a
+# release-please monorepo where every package carries its own version, so the
+# triggering release's tag would be wrong for every other project's card.
 #
 # For every packages/*/*/flasher.json found, this script:
 #   1. Reads chipFamily and appBinaryName from flasher.json
@@ -31,6 +37,17 @@ set -euo pipefail
 VERSION="${1:?Usage: $0 <version> [firmware-dir]}"
 FIRMWARE_DIR="${2:-firmware}"
 PROJECTS_GLOB="packages/*/*/flasher.json"
+RELEASE_MANIFEST=".release-please-manifest.json"
+
+# Look up a project's own version in the release-please manifest (keyed by the
+# package path, e.g. "packages/audio/kids-audio-toy"). Falls back to $VERSION.
+project_version() {
+    local dir="$1" v=""
+    if [[ -f "$RELEASE_MANIFEST" ]]; then
+        v=$(jq -r --arg p "$dir" '.[$p] // empty' "$RELEASE_MANIFEST")
+    fi
+    echo "${v:-$VERSION}"
+}
 
 # Associative array: chip family -> bootloader offset (decimal)
 bootloader_offset() {
@@ -101,6 +118,8 @@ for flasher_json in ${PROJECTS_GLOB}; do
     category=$(jq -r '.category // "standalone"' "$flasher_json")
     flash_mode=$(jq -r '.flashMode // "uart"'  "$flasher_json")
     improv=$(jq -r '.improv // false'          "$flasher_json")
+    version=$(project_version "$project_dir")
+    echo "    version=$version"
 
     # Determine offsets
     bl_offset=$(bootloader_offset "$chip_family")
@@ -130,7 +149,7 @@ for flasher_json in ${PROJECTS_GLOB}; do
 
     jq -n \
         --arg  name    "$name" \
-        --arg  version "$VERSION" \
+        --arg  version "$version" \
         --arg  chip    "$chip_family" \
         --argjson parts "$parts" \
         '{
@@ -148,7 +167,7 @@ for flasher_json in ${PROJECTS_GLOB}; do
         --arg  description  "$description" \
         --arg  chip         "$chip_family" \
         --arg  board        "$board" \
-        --arg  version      "$VERSION" \
+        --arg  version      "$version" \
         --arg  category     "$category" \
         --arg  flash_mode   "$flash_mode" \
         --argjson improv    "$improv" \


### PR DESCRIPTION
## Problem

Every card on the web flasher showed the version `vrobocar-unified-v0.1.5`:

1. `build-firmware.yml` computed `version=${TAG#v}`, which strips a leading `v` — but release-please monorepo tags are `<project>-vX.Y.Z`, so the full tag passed through and the page prepended another `v`.
2. Stamping the *triggering* release's tag on **all** cards is wrong in a monorepo anyway — each package has its own version.

Several flashable projects were also missing from the page entirely because they had no `flasher.json` (the discover step only picks up `packages/*/*/flasher.json`).

## Changes

- **Per-project versions**: `tools/generate-flasher-manifests.sh` now reads each project's version from `.release-please-manifest.json` (keyed by package path, e.g. `packages/audio/kids-audio-toy`), falling back to the release tag argument. Both `manifest.json` and `projects.json` entries use it.
- **Site-level version**: the workflow passes the tag verbatim; the page footer displays it as-is (it already carries its `vX.Y.Z` part) instead of prefixing `v`.
- **New cards**: added `flasher.json` for four release-tracked ESP-IDF projects that were missing:
  - `gamepad-synth` (ESP32-S3, audio) — the workflow already special-cased its bluepad32 dependency fetching, so it was clearly meant to be included
  - `robocar-unified` (XIAO ESP32-S3 Sense, Improv WiFi) — the project whose releases were triggering these builds without appearing on the page
  - `wifitest` (ESP32-S3)
  - `cam-i2s-audio` (AI Thinker ESP32-CAM)
- **New category**: `audio` added to the flasher page's category order/labels.

## Verification

Ran the generator locally against the repo (`bash tools/generate-flasher-manifests.sh robocar-unified-v0.1.5 <tmp>`): 15 projects generated, each with its own release-please version (e.g. `chatterbox 1.1.1`, `unified 0.1.5`, `xbox-switch-bridge 0.1.2`), and `robocar-unified`'s non-default partition offsets (app `0x12000`, otadata `0xf000`) were parsed correctly from its `partitions.csv`.

**Note for the first release after merge**: the four new projects join the release build matrix, and the deploy job requires all matrix builds to succeed. Their per-project CI workflows build them today, but this PR only touches `flasher.json`/tooling (path filters won't trigger those builds here). If in doubt, `workflow_dispatch` `build-firmware.yml` with any existing release tag after merging to validate the full matrix + deploy before the next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMZZCsncmugebsEvEdkE13

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMZZCsncmugebsEvEdkE13)_