### PR TITLE
feat(notebooks): notebooks-refresh recipe + PR-reminder routing for ADR-017/018

### DIFF
--- a/.github/workflows/notebook-doc-reminder.yml
+++ b/.github/workflows/notebook-doc-reminder.yml
@@ -16,6 +16,7 @@ on:
       - 'packages/robocar/main/**'
       - 'packages/robocar/simulation/**'
       - 'packages/robocar/unified/main/motor_controller.*'
+      - 'packages/robotics/**'
       - 'CLAUDE.md'
       - '.claude/rules/**'
 
@@ -65,6 +66,11 @@ jobs:
                 HITS["2cb7153a — ESPHome platform & components"]=1 ;;
               docs/decisions/ADR-011-*|packages/audio/*)
                 HITS["8cbdd8bb — I2S audio & synthesis on ESP32"]=1 ;;
+              docs/decisions/ADR-017-*|docs/requirements/PRD-011-*)
+                HITS["8cbdd8bb — I2S audio & synthesis on ESP32"]=1
+                HITS["3bb67ba2 — ESP32-S3 hardware families"]=1 ;;
+              docs/decisions/ADR-018-*|docs/requirements/PRD-012-*|packages/robotics/balancebot/*)
+                HITS["c8675955 — RP2350 / XIAO RP2350 boards"]=1 ;;
               docs/decisions/ADR-007-*|packages/components/i2c-protocol/*)
                 HITS["5601a768 — ESP32 peripherals (I2C, UART, I2S, GPIO)"]=1 ;;
               docs/requirements/PRD-006-*|packages/games/nfc-scavenger-hunt/*)

--- a/.github/workflows/notebook-refresh-reminder.yml
+++ b/.github/workflows/notebook-refresh-reminder.yml
@@ -72,10 +72,10 @@ jobs:
           Scheduled monthly refresh of the curated NotebookLM knowledge base.
           See `docs/reference/notebook-mapping.md` for the full mapping.
 
-          **How to run:** `notebooklm login` (once) then `just notebooks-status`
-          to audit, and drive the refresh with the `notebooklm` CLI per the
-          mapping doc. The CLI is not available in CI because auth lives on
-          your machine.
+          **How to run:** `notebooklm login` (once), `just notebooks-status`
+          to audit, then `just notebooks-refresh` to regenerate + download
+          the briefing docs. The CLI is not available in CI because auth
+          lives on your machine.
 
           ## Active notebooks — monthly checklist
 

--- a/.github/workflows/notebook-refresh-reminder.yml
+++ b/.github/workflows/notebook-refresh-reminder.yml
@@ -72,9 +72,10 @@ jobs:
           Scheduled monthly refresh of the curated NotebookLM knowledge base.
           See `docs/reference/notebook-mapping.md` for the full mapping.
 
-          **How to run:** `notebooklm login` (once) then `just notebooks-refresh`
-          from your local machine. The CLI is not available in CI because auth
-          lives on your machine.
+          **How to run:** `notebooklm login` (once) then `just notebooks-status`
+          to audit, and drive the refresh with the `notebooklm` CLI per the
+          mapping doc. The CLI is not available in CI because auth lives on
+          your machine.
 
           ## Active notebooks — monthly checklist
 

--- a/docs/reference/notebook-mapping.md
+++ b/docs/reference/notebook-mapping.md
@@ -27,7 +27,7 @@ purpose below.
 | XIAO ESP32-C5 (RISC-V, dual-band WiFi) | `878b1f67-d2ac-4e77-a009-ee6f96d1bce5` | XIAO C5 board projects |
 | XIAO ESP32-C6 (RISC-V, WiFi 6 / Thread / Zigbee) | `4165a6db-5021-44c0-b1f5-42ceb2b2bab7` | XIAO C6 board projects; ESP32-S3 families cross-ref |
 | ESP32-P4 (RISC-V, high-performance, no radio) | `25de0275-7d54-44a2-a574-5d4efb8ef62d` | ESP32-P4 board projects |
-| RP2350 (Raspberry Pi, dual-core ARM/RISC-V) | `c8675955-0cd1-4ab0-a641-58f1ad139bb9` | RP2350 board projects |
+| RP2350 (Raspberry Pi, dual-core ARM/RISC-V) | `c8675955-0cd1-4ab0-a641-58f1ad139bb9` | ADR-018; PRD-012; `packages/robotics/balancebot/`; RP2350 board projects |
 
 ### Peripheral IC classes
 
@@ -81,6 +81,7 @@ purpose below.
 | `docs/decisions/ADR-011-*`, `docs/decisions/ADR-017-*`, `docs/requirements/PRD-011-*`, `packages/audio/**` (non-gamepad) | I2S audio + ESP32-S3 boards |
 | `docs/decisions/ADR-007-*`, `packages/components/i2c-protocol/**` | ESP32 peripherals |
 | `docs/requirements/PRD-006-*`, `packages/games/nfc-scavenger-hunt/**` | ChameleonUltra RFID/NFC |
+| `docs/decisions/ADR-018-*`, `docs/requirements/PRD-012-*`, `packages/robotics/balancebot/**` | RP2350 boards |
 | `packages/robocar/camera/**`, `packages/robocar/main/**`, `docs/reference/boards/ttgo-lora32-v2.md` | ESP32 classic boards |
 | `packages/robocar/*/main/motor_controller.*` | Motor drivers & power electronics |
 | `docs/requirements/PRD-007-*`, `packages/audio/audiobook-player/**`, `packages/networking/wireguard-ha/**` | ESPHome platform & components |

--- a/docs/reference/notebook-mapping.md
+++ b/docs/reference/notebook-mapping.md
@@ -5,7 +5,7 @@ file is the source of truth for:
 
 - The scheduled monthly refresh reminder (`.github/workflows/notebook-refresh-reminder.yml`)
 - The PR-triggered ADR/PRD reminder (`.github/workflows/notebook-doc-reminder.yml`)
-- The `just notebooks-status` audit recipe (`tools/notebooks-status.sh`)
+- The `just notebooks-status` (audit) and `just notebooks-refresh` (report regen) recipes
 
 When you add a new ADR or PRD, update the matching notebook's sources in
 the same PR (or within the next monthly refresh cycle).

--- a/docs/reference/notebook-mapping.md
+++ b/docs/reference/notebook-mapping.md
@@ -5,7 +5,7 @@ file is the source of truth for:
 
 - The scheduled monthly refresh reminder (`.github/workflows/notebook-refresh-reminder.yml`)
 - The PR-triggered ADR/PRD reminder (`.github/workflows/notebook-doc-reminder.yml`)
-- The `just notebooks-refresh` recipe
+- The `just notebooks-status` audit recipe (`tools/notebooks-status.sh`)
 
 When you add a new ADR or PRD, update the matching notebook's sources in
 the same PR (or within the next monthly refresh cycle).

--- a/justfile
+++ b/justfile
@@ -372,6 +372,11 @@ docker-logs:
 notebooks-status:
     tools/notebooks-status.sh
 
+# Regenerate + download reports for all active notebooks (FORMAT=briefing-doc|study-guide|...)
+[group: "notebooks"]
+notebooks-refresh:
+    tools/notebooks-refresh.sh
+
 ##########
 # Git
 ##########

--- a/tools/notebooks-refresh.sh
+++ b/tools/notebooks-refresh.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Batch-regenerate NotebookLM reports for every active notebook in the
+# mapping doc: submit all generations up front (they run server-side in
+# parallel), then wait for each artifact and download it.
+#
+# Usage:
+#   tools/notebooks-refresh.sh                 # briefing-doc for all active notebooks
+#   FORMAT=study-guide tools/notebooks-refresh.sh
+#   MAPPING=docs/reference/notebook-mapping.md OUTDIR=tmp/notebooklm tools/notebooks-refresh.sh
+#
+# Prereq: notebooklm login (one-time, OAuth stored at ~/.notebooklm).
+# Cannot run in CI — auth lives on the local machine.
+
+set -euo pipefail
+
+MAPPING="${MAPPING:-docs/reference/notebook-mapping.md}"
+FORMAT="${FORMAT:-briefing-doc}"
+OUTDIR="${OUTDIR:-tmp/notebooklm}/${FORMAT}s"
+
+if ! command -v notebooklm >/dev/null 2>&1; then
+  echo "notebooklm CLI not found. Install with: pip install notebooklm-py" >&2
+  exit 1
+fi
+
+if ! notebooklm auth check >/dev/null 2>&1; then
+  echo "notebooklm is not authenticated. Run: notebooklm login" >&2
+  exit 1
+fi
+
+mkdir -p "$OUTDIR"
+TASKS_TSV="$OUTDIR/tasks.tsv"
+: > "$TASKS_TSV"
+
+# Extract backtick-wrapped UUIDs from the mapping doc's tables
+# shellcheck disable=SC2016  # backticks are literal markdown, not expansion
+ids=$(grep -oE '`[0-9a-f]{8}-[0-9a-f-]+`' "$MAPPING" | tr -d '`' | sort -u)
+
+echo "== Submitting $FORMAT generation for $(wc -w <<<"$ids" | tr -d ' ') notebooks =="
+for nid in $ids; do
+  out=$(notebooklm generate report --format "$FORMAT" --notebook "$nid" --retry 3 --json 2>>"$OUTDIR/errors.log") || {
+    echo "  SUBMIT-FAILED ${nid:0:8} (see $OUTDIR/errors.log)"; continue; }
+  tid=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('task_id',''))" <<<"$out")
+  if [ -n "$tid" ]; then
+    printf '%s\t%s\n' "$nid" "$tid" >> "$TASKS_TSV"
+    echo "  submitted ${nid:0:8} -> $tid"
+  else
+    echo "  SUBMIT-FAILED ${nid:0:8}: $out"
+  fi
+  sleep 5
+done
+
+echo "== Waiting for artifacts and downloading to $OUTDIR =="
+fail=0
+while IFS=$'\t' read -r nid tid; do
+  if notebooklm artifact wait "$tid" -n "$nid" --timeout 1800 >/dev/null; then
+    if notebooklm download report "$OUTDIR/${nid:0:8}-$FORMAT.md" -a "$tid" -n "$nid" >/dev/null; then
+      echo "  downloaded ${nid:0:8}-$FORMAT.md"
+    else
+      echo "  DOWNLOAD-FAILED ${nid:0:8} $tid"; fail=$((fail+1))
+    fi
+  else
+    echo "  WAIT-FAILED ${nid:0:8} $tid"; fail=$((fail+1))
+  fi
+done < "$TASKS_TSV"
+
+echo "== Done ($fail failure(s)). Skim the reports, then update sources per $MAPPING =="
+exit $((fail > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary

Follow-ups from executing the July NotebookLM refresh (#354), three commits:

1. **Routing**: the PR-triggered notebook reminder (`notebook-doc-reminder.yml`) had no routing for the doc sets that landed since the taxonomy was last extended — ADR-017/PRD-011 (melody detector, ESP-DL) → I2S audio + ESP32-S3 families, ADR-018/PRD-012 (balancebot, Pico SDK) → RP2350 — and `packages/robotics/**` was missing from the `paths:` filter. Adds the case arms and mapping-table rows.
2. **Docs**: the monthly reminder template and mapping doc referenced a `just notebooks-refresh` recipe that never existed.
3. **Recipe**: …so this PR adds it. `tools/notebooks-refresh.sh` batch-regenerates reports for every active notebook (IDs read from the mapping doc): submit all generations up front (server-side parallel), then wait + download each artifact. `FORMAT=study-guide just notebooks-refresh` covers the quarterly artifacts. This is the exact pattern used to execute #354, promoted from a session script. Docs updated to point at the now-real recipe.

The four new ADR/PRD docs themselves have been seeded into the three notebooks as part of #354.

## Test plan

- [x] `actionlint` passes on both workflows
- [x] `shellcheck` clean on `tools/notebooks-refresh.sh`
- [x] `just --list` shows the recipe; ID-extraction smoke-tested against the mapping doc (22 notebooks)
- [x] The submit→wait→download flow is exactly what ran the July refresh (16 briefing docs + 5 study guides, zero failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAEoiKqdRi8VtCHATQAqoN