### PR TITLE
feat(robocar-unified): MCP23017 GPIO expander + latent IDF 5.4 build repairs

### DIFF
--- a/packages/robocar/unified/CLAUDE.md
+++ b/packages/robocar/unified/CLAUDE.md
@@ -35,7 +35,10 @@ All I2C devices hang off a **TCA9548A multiplexer** on GPIO5/6. Don't talk to de
 
 - ch0: PCA9685 (motors, servos, LEDs)
 - ch1: SSD1306 OLED
-- ch2-7: reserved
+- ch2: MCP23017 GPIO expander (optional — 16 generic GPIOs via `gpio_expander.c`, no roles assigned yet; firmware boots fine without the board fitted)
+- ch3-7: reserved
+
+The MCP23017 (1953W breakout, address 0x20) is exercised from the serial console with `gpio`, `gpio mode <pin> in|up|out`, `gpio set <pin> 0|1`, `gpio get <pin>`.
 
 ## PCA9685 channel layout
 

--- a/packages/robocar/unified/CMakeLists.txt
+++ b/packages/robocar/unified/CMakeLists.txt
@@ -23,9 +23,9 @@ set(EXTRA_COMPONENT_DIRS "components/esp-idf-lib/components")
 list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../components")
 list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../components")
 
-# Set partition table for OTA support
-set(CONFIG_PARTITION_TABLE_CUSTOM ON)
-set(CONFIG_PARTITION_TABLE_CUSTOM_FILENAME "partitions.csv")
+# Partition table + flash size are configured in sdkconfig.defaults
+# (CONFIG_PARTITION_TABLE_CUSTOM / CONFIG_ESPTOOLPY_FLASHSIZE_8MB). ESP-IDF
+# ignores set(CONFIG_* ...) here, so it is not repeated in this file.
 
 # Read version from release-please managed manifest for OTA version tracking
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/version.txt")

--- a/packages/robocar/unified/main/CMakeLists.txt
+++ b/packages/robocar/unified/main/CMakeLists.txt
@@ -2,6 +2,7 @@ idf_component_register(
     SRCS
         "main.c"
         "i2c_bus.c"
+        "gpio_expander.c"
         "motor_controller.c"
         "led_controller.c"
         "servo_controller.c"
@@ -23,6 +24,7 @@ idf_component_register(
     REQUIRES
         "pca9685"
         "tca9548"
+        "mcp23x17"
         "i2cdev"
         "esp32-camera"
         "esp_wifi"

--- a/packages/robocar/unified/main/Kconfig.projbuild
+++ b/packages/robocar/unified/main/Kconfig.projbuild
@@ -1,0 +1,15 @@
+menu "OTA Update Configuration"
+
+    config OTA_GITHUB_ORG
+        string "GitHub organization or username"
+        default "laurigates"
+        help
+            The GitHub organization or username that owns the repository.
+
+    config OTA_GITHUB_REPO
+        string "GitHub repository name"
+        default "mcu-tinkering-lab"
+        help
+            The GitHub repository name where firmware releases are published.
+
+endmenu

--- a/packages/robocar/unified/main/goal_state.c
+++ b/packages/robocar/unified/main/goal_state.c
@@ -171,7 +171,7 @@ esp_err_t goal_state_init(void)
     g_gs.has_been_written = false;
     g_gs.initialised = true;
 
-    ESP_LOGI(TAG, "Initialised (default TTL %u ms)", GOAL_STATE_DEFAULT_TTL_MS);
+    ESP_LOGI(TAG, "Initialised (default TTL %u ms)", (unsigned)GOAL_STATE_DEFAULT_TTL_MS);
     return ESP_OK;
 }
 
@@ -203,7 +203,7 @@ esp_err_t goal_state_write(const goal_t *goal, uint32_t ttl_ms)
     /* Log only when the goal kind changes to keep the serial log readable. */
     if (goal->kind != old_kind) {
         ESP_LOGI(TAG, "Goal kind: %d -> %d (ttl %u ms)", (int)old_kind, (int)goal->kind,
-                 effective_ttl);
+                 (unsigned)effective_ttl);
     }
 
     return ESP_OK;

--- a/packages/robocar/unified/main/gpio_expander.c
+++ b/packages/robocar/unified/main/gpio_expander.c
@@ -1,0 +1,125 @@
+/**
+ * @file gpio_expander.c
+ * @brief MCP23017 16-bit GPIO expander via TCA9548A channel 2
+ */
+
+#include "gpio_expander.h"
+
+#include <esp_log.h>
+#include <mcp23x17.h>
+
+#include "i2c_bus.h"
+#include "pin_config.h"
+
+static const char *TAG = "gpio_expander";
+
+static mcp23x17_t s_mcp23017;
+static bool s_available = false;
+
+// Select the expander's TCA9548A channel and run one driver call while
+// holding the bus mutex. Returns ESP_ERR_INVALID_STATE when no device
+// was detected at init so callers can treat the expander as optional.
+#define EXPANDER_OP(call)                                                    \
+    do {                                                                     \
+        if (!s_available)                                                    \
+            return ESP_ERR_INVALID_STATE;                                    \
+        esp_err_t op_ret = i2c_bus_select_channel(I2C_BUS_CHANNEL_MCP23017); \
+        if (op_ret != ESP_OK)                                                \
+            return op_ret;                                                   \
+        op_ret = (call);                                                     \
+        i2c_bus_release();                                                   \
+        return op_ret;                                                       \
+    } while (0)
+
+esp_err_t gpio_expander_init(void)
+{
+    if (s_available) {
+        ESP_LOGW(TAG, "Already initialized");
+        return ESP_OK;
+    }
+
+    esp_err_t ret =
+        mcp23x17_init_desc(&s_mcp23017, MCP23017_ADDR, I2C_NUM_0, I2C_SDA_PIN, I2C_SCL_PIN);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "MCP23017 init_desc failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    // Probe: read the IODIR registers. A missing board is expected — the
+    // expander is optional hardware, so absence downgrades to a warning.
+    ret = i2c_bus_select_channel(I2C_BUS_CHANNEL_MCP23017);
+    if (ret != ESP_OK) {
+        mcp23x17_free_desc(&s_mcp23017);
+        return ret;
+    }
+
+    uint16_t mode = 0;
+    ret = mcp23x17_port_get_mode(&s_mcp23017, &mode);
+    i2c_bus_release();
+
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "No MCP23017 at 0x%02X on TCA9548A ch%d (%s) — expander unavailable",
+                 MCP23017_ADDR, I2C_BUS_CHANNEL_MCP23017, esp_err_to_name(ret));
+        mcp23x17_free_desc(&s_mcp23017);
+        return ESP_OK;
+    }
+
+    s_available = true;
+    ESP_LOGI(TAG, "MCP23017 initialized at 0x%02X on TCA9548A ch%d (IODIR=0x%04X)", MCP23017_ADDR,
+             I2C_BUS_CHANNEL_MCP23017, mode);
+    return ESP_OK;
+}
+
+bool gpio_expander_available(void)
+{
+    return s_available;
+}
+
+static esp_err_t set_mode_locked(uint8_t pin, gpio_expander_mode_t mode)
+{
+    esp_err_t ret = mcp23x17_set_mode(&s_mcp23017, pin,
+                                      mode == GPIO_EXPANDER_OUTPUT ? MCP23X17_GPIO_OUTPUT
+                                                                   : MCP23X17_GPIO_INPUT);
+    if (ret != ESP_OK)
+        return ret;
+    return mcp23x17_set_pullup(&s_mcp23017, pin, mode == GPIO_EXPANDER_INPUT_PULLUP);
+}
+
+esp_err_t gpio_expander_set_mode(uint8_t pin, gpio_expander_mode_t mode)
+{
+    if (pin > 15)
+        return ESP_ERR_INVALID_ARG;
+    EXPANDER_OP(set_mode_locked(pin, mode));
+}
+
+esp_err_t gpio_expander_write(uint8_t pin, bool level)
+{
+    if (pin > 15)
+        return ESP_ERR_INVALID_ARG;
+    EXPANDER_OP(mcp23x17_set_level(&s_mcp23017, pin, level ? 1 : 0));
+}
+
+static esp_err_t read_locked(uint8_t pin, bool *level)
+{
+    uint32_t val = 0;
+    esp_err_t ret = mcp23x17_get_level(&s_mcp23017, pin, &val);
+    if (ret == ESP_OK)
+        *level = (val != 0);
+    return ret;
+}
+
+esp_err_t gpio_expander_read(uint8_t pin, bool *level)
+{
+    if (pin > 15)
+        return ESP_ERR_INVALID_ARG;
+    if (!level)
+        return ESP_ERR_INVALID_ARG;
+    EXPANDER_OP(read_locked(pin, level));
+}
+
+esp_err_t gpio_expander_read_port(uint16_t *value)
+{
+    if (!value)
+        return ESP_ERR_INVALID_ARG;
+    EXPANDER_OP(mcp23x17_port_read(&s_mcp23017, value));
+}

--- a/packages/robocar/unified/main/gpio_expander.h
+++ b/packages/robocar/unified/main/gpio_expander.h
@@ -1,0 +1,85 @@
+/**
+ * @file gpio_expander.h
+ * @brief MCP23017 16-bit GPIO expander via TCA9548A channel 2
+ *
+ * Generic GPIO expansion — no pins are pre-assigned to a role. Direction
+ * is configurable per pin at runtime. The device is optional: if no
+ * MCP23017 responds at init, the module marks itself unavailable and all
+ * pin operations return ESP_ERR_INVALID_STATE without touching the bus.
+ *
+ * Pin numbering follows the mcp23x17 driver: 0-7 = PORTA (A0-A7),
+ * 8-15 = PORTB (B0-B7).
+ */
+
+#ifndef GPIO_EXPANDER_H
+#define GPIO_EXPANDER_H
+
+#include <esp_err.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief Pin direction
+ */
+typedef enum {
+    GPIO_EXPANDER_OUTPUT = 0,
+    GPIO_EXPANDER_INPUT,         //!< High-impedance input
+    GPIO_EXPANDER_INPUT_PULLUP,  //!< Input with internal 100k pullup
+} gpio_expander_mode_t;
+
+/**
+ * @brief Initialize the MCP23017 GPIO expander
+ *
+ * Probes the device on its TCA9548A channel. All pins default to inputs
+ * (the chip's power-on state). A missing device is not an error — the
+ * module logs a warning and reports unavailable.
+ *
+ * Requires i2c_bus_init() to have run first.
+ *
+ * @return ESP_OK on success or graceful absence; error only on bus faults
+ */
+esp_err_t gpio_expander_init(void);
+
+/**
+ * @brief Whether an MCP23017 was detected at init
+ */
+bool gpio_expander_available(void);
+
+/**
+ * @brief Configure a pin's direction
+ *
+ * @param pin Pin number (0-15)
+ * @param mode Direction (output, input, input with pullup)
+ * @return ESP_OK on success
+ */
+esp_err_t gpio_expander_set_mode(uint8_t pin, gpio_expander_mode_t mode);
+
+/**
+ * @brief Set an output pin's level
+ *
+ * Pin must be configured as output first.
+ *
+ * @param pin Pin number (0-15)
+ * @param level true = high, false = low
+ * @return ESP_OK on success
+ */
+esp_err_t gpio_expander_write(uint8_t pin, bool level);
+
+/**
+ * @brief Read a pin's current level
+ *
+ * @param pin Pin number (0-15)
+ * @param[out] level true = high, false = low
+ * @return ESP_OK on success
+ */
+esp_err_t gpio_expander_read(uint8_t pin, bool *level);
+
+/**
+ * @brief Read all 16 pins in one transaction
+ *
+ * @param[out] value Bit 0 = PORTA pin 0 ... bit 15 = PORTB pin 7
+ * @return ESP_OK on success
+ */
+esp_err_t gpio_expander_read_port(uint16_t *value);
+
+#endif  // GPIO_EXPANDER_H

--- a/packages/robocar/unified/main/idf_component.yml
+++ b/packages/robocar/unified/main/idf_component.yml
@@ -7,6 +7,10 @@ dependencies:
   espressif/esp32-camera: '^2.0.0'
   # mDNS component
   espressif/mdns: '^1.8.0'
-  # GitHub OTA component for automated firmware updates from GitHub Releases
-  fishwaldo/esp_ghota: '>=0.0.3'
+  # GitHub OTA component for automated firmware updates from GitHub Releases.
+  # Registry only has 0.0.1 — pin the git tag instead (same fix as the shared
+  # ota-github component, see commit ac3cd9b).
+  fishwaldo/esp_ghota:
+    git: https://github.com/FishWaldo/esp_ghota.git
+    version: 'v1.0.0'
   # Note: MQTT is built-in to ESP-IDF 6.0, no external dependency needed

--- a/packages/robocar/unified/main/main.c
+++ b/packages/robocar/unified/main/main.c
@@ -13,6 +13,8 @@
  */
 
 #include <string.h>
+#include "esp_app_desc.h"
+#include "esp_check.h"
 #include "esp_log.h"
 #include "esp_system.h"
 #include "esp_timer.h"
@@ -28,6 +30,7 @@
 #include "config.h"
 #include "credentials_loader.h"
 #include "goal_state.h"
+#include "gpio_expander.h"
 #include "i2c_bus.h"
 #include "led_controller.h"
 #include "mdns.h"
@@ -230,6 +233,65 @@ static void dispatch_sound(const char *sound)
 }
 
 // ========================================
+// GPIO expander console commands (bench testing)
+//   gpio                     - 16-pin port dump
+//   gpio mode <pin> in|up|out - set direction (up = input with pullup)
+//   gpio set <pin> 0|1       - drive an output pin
+//   gpio get <pin>           - read one pin
+// ========================================
+static void handle_gpio_cmd(const char *buf)
+{
+    if (!gpio_expander_available()) {
+        printf("gpio: no MCP23017 detected\n");
+        return;
+    }
+
+    char op[8] = {0};
+    unsigned pin = 0;
+    char arg[8] = {0};
+    int n = sscanf(buf, "gpio %7s %u %7s", op, &pin, arg);
+
+    esp_err_t ret = ESP_ERR_INVALID_ARG;
+    if (n <= 0) {
+        uint16_t port = 0;
+        ret = gpio_expander_read_port(&port);
+        if (ret == ESP_OK)
+            printf("gpio: port=0x%04X\n", port);
+    } else if (n == 3 && strcmp(op, "mode") == 0) {
+        gpio_expander_mode_t mode;
+        if (strcmp(arg, "in") == 0)
+            mode = GPIO_EXPANDER_INPUT;
+        else if (strcmp(arg, "up") == 0)
+            mode = GPIO_EXPANDER_INPUT_PULLUP;
+        else if (strcmp(arg, "out") == 0)
+            mode = GPIO_EXPANDER_OUTPUT;
+        else {
+            printf("gpio: mode must be in|up|out\n");
+            return;
+        }
+        ret = gpio_expander_set_mode((uint8_t)pin, mode);
+        if (ret == ESP_OK)
+            printf("gpio: pin %u mode=%s\n", pin, arg);
+    } else if (n == 3 && strcmp(op, "set") == 0) {
+        ret = gpio_expander_write((uint8_t)pin, arg[0] != '0');
+        if (ret == ESP_OK)
+            printf("gpio: pin %u = %c\n", pin, arg[0] != '0' ? '1' : '0');
+    } else if (n == 2 && strcmp(op, "get") == 0) {
+        bool level = false;
+        ret = gpio_expander_read((uint8_t)pin, &level);
+        if (ret == ESP_OK)
+            printf("gpio: pin %u = %d\n", pin, level);
+    } else {
+        printf("gpio: usage: gpio | gpio mode <pin> in|up|out | gpio set <pin> 0|1 | gpio get "
+               "<pin>\n");
+        return;
+    }
+
+    if (ret != ESP_OK)
+        printf("gpio: error: %s\n", esp_err_to_name(ret));
+}
+
+// ========================================
 // Serial command task (Core 0, priority 5)
 // ========================================
 static void command_task(void *pvParameters)
@@ -284,6 +346,8 @@ static void command_task(void *pvParameters)
                             dispatch_movement("stop");
                             break;
                     }
+                } else if (strncmp(buf, "gpio", 4) == 0) {
+                    handle_gpio_cmd(buf);
                 }
 
                 buf_pos = 0;
@@ -312,6 +376,8 @@ static esp_err_t init_hardware(void)
     ESP_LOGI(TAG, "Phase 1: I2C bus + peripherals");
 
     ESP_RETURN_ON_ERROR(i2c_bus_init(), TAG, "I2C bus init failed");
+    // Optional hardware: returns ESP_OK even when no expander is fitted
+    ESP_RETURN_ON_ERROR(gpio_expander_init(), TAG, "GPIO expander init failed");
     ESP_RETURN_ON_ERROR(motor_controller_init(), TAG, "Motor init failed");
     ESP_RETURN_ON_ERROR(led_controller_init(), TAG, "LED init failed");
     ESP_RETURN_ON_ERROR(servo_controller_init(), TAG, "Servo init failed");

--- a/packages/robocar/unified/main/ota_manager.c
+++ b/packages/robocar/unified/main/ota_manager.c
@@ -1,10 +1,9 @@
 /**
  * @file ota_manager.c
- * @brief OTA update manager implementation for ESP32-CAM robocar
+ * @brief OTA update manager for the single-board unified robocar
  *
  * Uses esp_ghota for GitHub release checking and firmware download,
- * with MQTT notifications for immediate update triggers. After
- * self-updating, orchestrates main controller update via I2C OTA commands.
+ * with MQTT notifications for immediate update triggers.
  */
 
 #include "ota_manager.h"
@@ -19,9 +18,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/timers.h"
-#include "i2c_master.h"
-#include "i2c_protocol.h"
-#include "semver.h"
 #if MQTT_LOGGING_ENABLED
 #include "mqtt_logger.h"
 #endif
@@ -38,7 +34,6 @@ static TimerHandle_t s_stability_timer = NULL;
 static void ghota_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id,
                                 void *event_data);
 static void ota_stability_timer_callback(TimerHandle_t xTimer);
-static void orchestrate_main_controller_update(void *pvParameters);
 
 #if MQTT_LOGGING_ENABLED
 static void mqtt_ota_notify_handler(const char *topic, const char *data, int data_len);
@@ -49,14 +44,15 @@ esp_err_t ota_manager_init(void)
     ESP_LOGI(TAG, "Initializing OTA manager");
     ESP_LOGI(TAG, "Current firmware version: %s", ota_manager_get_version());
 
-    // Configure esp_ghota
+    // Configure esp_ghota (filenamematch is a char array — copy, don't assign)
     ghota_config_t ghota_config = {
-        .filenamematch = OTA_FIRMWARE_FILENAME_MATCH,
         .hostname = OTA_GITHUB_HOST,
         .orgname = OTA_GITHUB_ORG,
         .reponame = OTA_GITHUB_REPO,
         .updateInterval = OTA_CHECK_INTERVAL_MIN,
     };
+    strncpy(ghota_config.filenamematch, OTA_FIRMWARE_FILENAME_MATCH,
+            sizeof(ghota_config.filenamematch) - 1);
 
     s_ghota_client = ghota_init(&ghota_config);
     if (!s_ghota_client) {
@@ -157,9 +153,9 @@ static void ghota_event_handler(void *arg, esp_event_base_t event_base, int32_t 
             mqtt_logger_publish(OTA_MQTT_STATUS_TOPIC, "{\"status\":\"downloading\"}", 1, false);
 #endif
             // esp_ghota handles the download and flash automatically
-            esp_err_t update_ret = ghota_start_update(s_ghota_client);
+            esp_err_t update_ret = ghota_start_update_task(s_ghota_client);
             if (update_ret != ESP_OK) {
-                ESP_LOGE(TAG, "ghota_start_update failed: %s", esp_err_to_name(update_ret));
+                ESP_LOGE(TAG, "ghota_start_update_task failed: %s", esp_err_to_name(update_ret));
                 s_ota_in_progress = false;
             }
             break;
@@ -177,7 +173,7 @@ static void ghota_event_handler(void *arg, esp_event_base_t event_base, int32_t 
             ESP_LOGI(TAG, "Storage partition update complete");
             break;
 
-        case GHOTA_EVENT_START_FIRMWARE_UPDATE:
+        case GHOTA_EVENT_START_UPDATE:
             ESP_LOGI(TAG, "Firmware update starting...");
             break;
 
@@ -189,7 +185,7 @@ static void ghota_event_handler(void *arg, esp_event_base_t event_base, int32_t 
             break;
         }
 
-        case GHOTA_EVENT_FINISH_FIRMWARE_UPDATE:
+        case GHOTA_EVENT_FINISH_UPDATE:
             ESP_LOGI(TAG, "Firmware update complete — rebooting...");
             s_ota_in_progress = false;
 
@@ -223,138 +219,9 @@ static void ghota_event_handler(void *arg, esp_event_base_t event_base, int32_t 
 
 static void ota_stability_timer_callback(TimerHandle_t xTimer)
 {
+    (void)xTimer;
     ESP_LOGI(TAG, "Stability timeout reached — confirming firmware validity");
     ota_manager_confirm_valid();
-
-    // After confirming self-update, check if main controller needs updating
-    // This runs as a separate task to avoid blocking the timer callback
-    xTaskCreate(orchestrate_main_controller_update, "ota_main_ctrl", OTA_TASK_STACK_SIZE, NULL,
-                OTA_TASK_PRIORITY, NULL);
-}
-
-// Polling constants for main controller OTA orchestration
-#define OTA_VERSION_POLL_INTERVAL_MS 1000
-#define OTA_VERSION_POLL_MAX_ATTEMPTS 30
-#define OTA_MAINTENANCE_SETTLE_MS 2000
-#define OTA_STATUS_POLL_INTERVAL_MS 5000
-#define OTA_STATUS_TIMEOUT_MS (5 * 60 * 1000)
-
-static void orchestrate_main_controller_update(void *pvParameters)
-{
-    ESP_LOGI(TAG, "Checking if main controller needs OTA update...");
-
-    // Step 1: Get main controller version via I2C helper
-    char mc_version_str[VERSION_STRING_LEN];
-    esp_err_t ret = i2c_get_version(mc_version_str, sizeof(mc_version_str));
-    if (ret != ESP_OK) {
-        ESP_LOGW(TAG, "Failed to query main controller version: %s", esp_err_to_name(ret));
-        goto done;
-    }
-    ESP_LOGI(TAG, "Main controller firmware version: %s", mc_version_str);
-
-    // Step 2: Parse main controller version as semver
-    semver_t mc_version = {};
-    if (semver_parse(mc_version_str, &mc_version) != 0) {
-        ESP_LOGW(TAG, "Failed to parse main controller version: %s", mc_version_str);
-        goto done;
-    }
-
-    // Step 3: Get latest release version from esp_ghota
-    semver_t *latest = ghota_get_latest_version(s_ghota_client);
-    if (!latest || (!latest->major && !latest->minor && !latest->patch)) {
-        ESP_LOGI(TAG, "No cached release info — triggering GitHub check...");
-        ghota_check(s_ghota_client);
-
-        for (int i = 0; i < OTA_VERSION_POLL_MAX_ATTEMPTS; i++) {
-            vTaskDelay(pdMS_TO_TICKS(OTA_VERSION_POLL_INTERVAL_MS));
-            latest = ghota_get_latest_version(s_ghota_client);
-            if (latest && (latest->major || latest->minor || latest->patch)) {
-                break;
-            }
-        }
-    }
-
-    if (!latest || (!latest->major && !latest->minor && !latest->patch)) {
-        ESP_LOGW(TAG, "Could not determine latest release version");
-        semver_free(&mc_version);
-        goto done;
-    }
-
-    char latest_str[32];
-    semver_render(latest, latest_str);
-    ESP_LOGI(TAG, "Latest release version: %s", latest_str);
-
-    // Step 4: Compare — skip if main controller is already up to date
-    if (!semver_gt(*latest, mc_version)) {
-        ESP_LOGI(TAG, "Main controller is up to date (v%s)", mc_version_str);
-        semver_free(&mc_version);
-        goto done;
-    }
-
-    ESP_LOGI(TAG, "Main controller needs update: v%s -> v%s", mc_version_str, latest_str);
-
-    // Step 5: Enter maintenance mode (stops motors on main controller)
-    ret = i2c_send_enter_maintenance_mode();
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to enter maintenance mode: %s", esp_err_to_name(ret));
-        semver_free(&mc_version);
-        goto done;
-    }
-    vTaskDelay(pdMS_TO_TICKS(OTA_MAINTENANCE_SETTLE_MS));
-
-    // Step 6: Send OTA begin with release tag (e.g., "v0.2.0").
-    // OTA_TAG_MAX_LEN = 20; the receiver looks the tag up against the GitHub
-    // release name, so silent truncation here would point the main controller
-    // at the wrong (or no) release. Abort instead of sending a partial tag.
-    char release_tag[OTA_TAG_MAX_LEN];
-    int written = snprintf(release_tag, sizeof(release_tag), "v%s", latest_str);
-    if (written < 0 || (size_t)written >= sizeof(release_tag)) {
-        ESP_LOGE(TAG, "Release tag '%s' would exceed %u-byte limit — aborting main OTA", latest_str,
-                 (unsigned)sizeof(release_tag));
-        semver_free(&mc_version);
-        goto done;
-    }
-
-    ret = i2c_send_begin_ota(release_tag, NULL);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to start main controller OTA: %s", esp_err_to_name(ret));
-        semver_free(&mc_version);
-        goto done;
-    }
-
-    // Step 7: Poll OTA status until success, failure, or timeout
-    const int max_polls = OTA_STATUS_TIMEOUT_MS / OTA_STATUS_POLL_INTERVAL_MS;
-    for (int i = 0; i < max_polls; i++) {
-        vTaskDelay(pdMS_TO_TICKS(OTA_STATUS_POLL_INTERVAL_MS));
-
-        ota_status_response_t ota_status;
-        ret = i2c_get_ota_status(&ota_status);
-        if (ret != ESP_OK) {
-            ESP_LOGW(TAG, "Failed to poll OTA status (%d/%d)", i + 1, max_polls);
-            continue;
-        }
-
-        ESP_LOGI(TAG, "OTA progress: %d%% (status: %d)", ota_status.progress, ota_status.status);
-
-        if (ota_status.status == OTA_STATUS_SUCCESS) {
-            ESP_LOGI(TAG, "Main controller OTA successful — sending reboot");
-            i2c_send_reboot();
-            semver_free(&mc_version);
-            goto done;
-        }
-
-        if (ota_status.status == OTA_STATUS_FAILED) {
-            ESP_LOGE(TAG, "Main controller OTA failed (error: %d)", ota_status.error_code);
-            semver_free(&mc_version);
-            goto done;
-        }
-    }
-
-    ESP_LOGE(TAG, "Main controller OTA timed out after %d seconds", OTA_STATUS_TIMEOUT_MS / 1000);
-    semver_free(&mc_version);
-
-done:
-    vTaskDelete(NULL);
 }
 
 #if MQTT_LOGGING_ENABLED

--- a/packages/robocar/unified/main/pin_config.h
+++ b/packages/robocar/unified/main/pin_config.h
@@ -31,9 +31,10 @@
 #define TCA9548A_ADDR 0x70  // Default address (A0=A1=A2=GND)
 
 // TCA9548A channel assignments
-#define I2C_BUS_CHANNEL_PCA9685 0  // Channel 0: PCA9685 PWM driver
-#define I2C_BUS_CHANNEL_OLED 1     // Channel 1: SSD1306 OLED display
-// Channels 2-7: reserved for future sensors (IMU, ToF, etc.)
+#define I2C_BUS_CHANNEL_PCA9685 0   // Channel 0: PCA9685 PWM driver
+#define I2C_BUS_CHANNEL_OLED 1      // Channel 1: SSD1306 OLED display
+#define I2C_BUS_CHANNEL_MCP23017 2  // Channel 2: MCP23017 GPIO expander
+// Channels 3-7: reserved for future sensors (IMU, ToF, etc.)
 
 // ========================================
 // PCA9685 PWM Driver (via TCA9548A ch0)
@@ -74,6 +75,13 @@
 // ========================================
 #define MOTOR_STBY_PIN GPIO_NUM_1  // XIAO D0: HIGH = motors enabled
 #define DEFAULT_SPEED 3200         // Default motor speed (~78% of 4095)
+
+// ========================================
+// MCP23017 GPIO Expander (via TCA9548A ch2)
+// 16 extra GPIOs (pins 0-7 = PORTA, 8-15 = PORTB). No role assigned yet —
+// generic expansion, direction configurable per pin at runtime.
+// ========================================
+#define MCP23017_ADDR 0x20  // Default address (A0=A1=A2=GND)
 
 // ========================================
 // SSD1306 OLED Display (via TCA9548A ch1)

--- a/packages/robocar/unified/partitions.csv
+++ b/packages/robocar/unified/partitions.csv
@@ -1,16 +1,18 @@
 # XIAO ESP32-S3 Sense Partition Table for OTA (8MB Flash)
 # Name,   Type, SubType, Offset,  Size,     Flags
+# App partitions (ota_0/ota_1) MUST start on a 0x10000 (64KB) boundary —
+# ESP-IDF rejects unaligned app offsets ("Offset ... is not aligned to 0x10000").
 # Flash Layout:
-#   nvs:      24KB  (Non-Volatile Storage)
+#   nvs:      16KB  (Non-Volatile Storage)
 #   otadata:  8KB   (OTA selection data)
 #   phy_init: 4KB   (PHY init data)
-#   ota_0:    3.5MB (OTA app partition 0)
-#   ota_1:    3.5MB (OTA app partition 1)
-#   spiffs:   448KB (File storage)
+#   ota_0:    3.5MB (OTA app partition 0, @0x10000 — 64KB aligned)
+#   ota_1:    3.5MB (OTA app partition 1, @0x390000 — 64KB aligned)
+#   spiffs:   960KB (File storage)
 # Total: 8MB (0x800000 bytes)
-nvs,      data, nvs,     0x9000,  0x6000,
-otadata,  data, ota,     0xF000,  0x2000,
-phy_init, data, phy,     0x11000, 0x1000,
-ota_0,    app,  ota_0,   0x12000, 0x380000,
-ota_1,    app,  ota_1,   0x392000,0x380000,
-spiffs,   data, spiffs,  0x712000,0xEE000,
+nvs,      data, nvs,     0x9000,  0x4000,
+otadata,  data, ota,     0xD000,  0x2000,
+phy_init, data, phy,     0xF000,  0x1000,
+ota_0,    app,  ota_0,   0x10000, 0x380000,
+ota_1,    app,  ota_1,   0x390000,0x380000,
+spiffs,   data, spiffs,  0x710000,0xF0000,

--- a/packages/robocar/unified/sdkconfig.defaults
+++ b/packages/robocar/unified/sdkconfig.defaults
@@ -34,6 +34,15 @@ CONFIG_CAMERA_DMA_BUFFER_SIZE_MAX=32768
 
 # Flash (XIAO ESP32-S3 Sense has 8MB flash)
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="8MB"
+
+# Custom OTA partition table (partitions.csv).
+# ESP-IDF ignores set(CONFIG_PARTITION_TABLE_* ...) in CMakeLists — sdkconfig
+# is authoritative — so these MUST live here or the build falls back to the
+# default single-app 1M factory table and the binary overflows it.
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
 
 # Logging
 CONFIG_LOG_DEFAULT_LEVEL_INFO=y

--- a/packages/robocar/unified/sdkconfig.defaults
+++ b/packages/robocar/unified/sdkconfig.defaults
@@ -72,6 +72,9 @@ CONFIG_OTA_GITHUB_REPO="mcu-tinkering-lab"
 # mDNS hostname discovery (robocar.local)
 CONFIG_MDNS_ENABLED=y
 
+# MCP23017 GPIO expander (I2C variant of the mcp23x17 driver)
+CONFIG_MCP23X17_IFACE_I2C=y
+
 # Heap configuration (disable advanced features)
 CONFIG_HEAP_TRACING=n
 CONFIG_HEAP_CORRUPTION_DETECTION=n


### PR DESCRIPTION
## What

Integrates the **1953W-MCP23017 GPIO expander** boards into robocar-unified, and repairs the latent defects that were blocking any containerized IDF 5.4 build of this project.

### MCP23017 integration (feat commit)
- New `gpio_expander.c/h`: generic 16-pin GPIO API (read/write/direction, optional pullup) on **TCA9548A channel 2**, address 0x20, via the vendored esp-idf-lib `mcp23x17` driver
- Every operation holds the shared i2c_bus mutex with the mux channel selected — consistent with the PCA9685/OLED pattern
- **Optional hardware**: init probes the chip; a missing board degrades to a warning and `gpio_expander_available() == false`, so the same firmware runs with or without the board fitted
- Bench-test console commands: `gpio`, `gpio mode <pin> in|up|out`, `gpio set <pin> 0|1`, `gpio get <pin>`
- No pins are role-assigned yet — this makes the hardware usable; consumers come later

### Build repairs (fix commit)
robocar-unified had never fully built in the v5.4 container. Fixed:
1. `fishwaldo/esp_ghota '>=0.0.3'` matches nothing on the registry (only 0.0.1 exists) → git-pinned at tag v1.0.0, mirroring ac3cd9b's fix for the shared ota-github component
2. `ota_manager.c` used pre-release esp_ghota API names → corrected to the real v1.0.0 API; also **removed the dual-board "orchestrate main controller via I2C" flow** copied from robocar-camera — there is no second controller on this board
3. `CONFIG_OTA_GITHUB_ORG/REPO` set in sdkconfig.defaults but declared by no Kconfig → added `main/Kconfig.projbuild`
4. Custom OTA partition table applied via **inert** `set(CONFIG_* ...)` in CMakeLists → moved to sdkconfig.defaults; realigned `ota_0/ota_1` to 64KB boundaries (0x12000 → 0x10000, required by ESP-IDF). Same defect class as #389. Web-flasher manifests parse partitions.csv, so offsets propagate automatically
5. `goal_state.c` `%u` vs `uint32_t` under `-Werror=format`

## Verification

Full build **GREEN** in the `espressif/idf:v5.4` container (`just robocar-unified::build`): binary 0x11c7b0 bytes, 68% free in the 3.5MB OTA slot. clang-format clean.

Hardware smoke test (board on mux ch2, `gpio` console commands) pending — boards are on hand but not yet wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8oeZrWbsADrzftpmgrWWk