### PR TITLE
ci(scan-secrets): skip AI secret scan for release-please actor

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -8,10 +8,12 @@ on:
 
 jobs:
   scan-secrets:
-    # Skip the AI secret scan for dependabot: the reusable workflow rejects
-    # non-human actors ("Workflow initiated by non-human actor"). gitleaks
-    # still covers pattern-based secret scanning on the same diff. See #259.
-    if: github.actor != 'dependabot[bot]'
+    # Skip the AI secret scan for bot actors: the reusable workflow rejects
+    # them ("Workflow initiated by non-human actor"). gitleaks still covers
+    # pattern-based secret scanning on the same diff. See #259; the
+    # release-please exclusion keeps release PRs (bot-authored changelog and
+    # manifest edits only) from failing the check.
+    if: github.actor != 'dependabot[bot]' && github.actor != 'laurigates-release-please[bot]'
     uses: laurigates/.github/.github/workflows/reusable-security-secrets.yml@main
     with:
       file-patterns: '**/*.c **/*.h **/*.cpp **/*.hpp **/*.py **/*.yml **/*.yaml **/*.json **/*.toml'


### PR DESCRIPTION
## Summary

Release PR #400's `scan-secrets / scan` check failed with `Workflow initiated by non-human actor: laurigates-release-please (type: Bot)` — the reusable secret-scan workflow rejects bot actors. Same failure class as dependabot (#259, fixed in a0bfcf6); this extends the existing skip condition to the release-please App actor (login verified via the failed run's payload: `laurigates-release-please[bot]`).

Release PRs only carry bot-authored changelog/manifest edits, and gitleaks still covers pattern-based secret scanning on the same diff, so skipping the AI scan loses nothing.

## Test plan

- [x] `actionlint` passes
- [x] Actor login confirmed from the failing run (`gh api .../runs/29559356565`)
- [ ] Next release-please PR shows scan-secrets skipped instead of failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JAEoiKqdRi8VtCHATQAqoN