### PR TITLE
refactor(tooling): single-source C/C++ lint+format via tools/cquality.sh

### DIFF
--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -25,19 +25,13 @@ esac
 
 case "$file_path" in
     *.c|*.h|*.cpp|*.hpp)
-        if command -v clang-format >/dev/null 2>&1; then
-            clang-format -i --style=file "$file_path"
-        fi
-        if command -v cppcheck >/dev/null 2>&1; then
-            cppcheck \
-                --enable=warning,style,performance,portability \
-                --suppress=missingIncludeSystem \
-                --suppress=unmatchedSuppression \
-                --suppress=unusedStructMember \
-                --inline-suppr \
-                --quiet \
-                --template=gcc \
-                "$file_path" || true
+        # Single-source the clang-format + cppcheck invocation via tools/cquality.sh
+        # (same flags as the justfile lint-c / CI). Fully non-blocking.
+        repo_root="$(git -C "$(dirname "$file_path")" rev-parse --show-toplevel 2>/dev/null || true)"
+        cq="${repo_root:+$repo_root/}tools/cquality.sh"
+        if [[ -x "$cq" ]]; then
+            "$cq" format-file "$file_path" || true
+            "$cq" lint-file "$file_path" || true
         fi
         ;;
     *.py)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,8 @@ jobs:
               - 'packages/**/*.cpp'
               - 'packages/**/*.hpp'
               - '.clang-format'
+              - 'tools/cquality.sh'
+              - '.github/workflows/test.yml'
             any-code:
               - 'packages/**'
               - '.pre-commit-config.yaml'
@@ -214,31 +216,17 @@ jobs:
       - name: Install cppcheck
         run: sudo apt-get update && sudo apt-get install -y cppcheck
 
-      - name: Run cppcheck
-        run: |
-          find packages \
-            -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \
-            ! -path "*/managed_components/*" \
-            ! -path "*/components/esp-idf-lib/*" \
-            ! -path "*/external/*" \
-            ! -path "*/build/*" \
-            ! -path "*/.esphome/*" \
-            -print0 | \
-          xargs -0 cppcheck \
-            --enable=warning,style,performance,portability \
-            --suppress=missingIncludeSystem \
-            --suppress=unmatchedSuppression \
-            --suppress=unusedStructMember \
-            --inline-suppr \
-            --error-exitcode=0 \
-            --template=gcc \
-            2>&1 | tee cppcheck-report.txt
+      # Advisory: uploads a report but does not fail the job. The find/exclude
+      # list and cppcheck flags live once in tools/cquality.sh (shared with the
+      # justfile lint-c recipe and the post-edit hook).
+      - name: Run cppcheck (advisory)
+        run: tools/cquality.sh lint --advisory
 
       - name: Upload cppcheck report
         uses: actions/upload-artifact@v7
         with:
           name: cppcheck-report-${{ github.sha }}
-          path: cppcheck-report.txt
+          path: tmp/cppcheck-report.txt
           retention-days: 30
 
   format-check:
@@ -260,17 +248,10 @@ jobs:
         run: pipx install clang-format==18.1.8
 
       - name: Check C/C++ formatting
+        # Shared find/exclude list lives in tools/cquality.sh (same as justfile format-check-c).
         run: |
-          find packages \
-            -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \
-            ! -path "*/managed_components/*" \
-            ! -path "*/components/esp-idf-lib/*" \
-            ! -path "*/external/*" \
-            ! -path "*/build/*" \
-            ! -path "*/.esphome/*" \
-            -print0 | \
-          xargs -0 clang-format --dry-run --Werror --style=file || {
-            echo "::error::Code formatting issues found. Run 'make format-c' to fix."
+          tools/cquality.sh format-check || {
+            echo "::error::Code formatting issues found. Run 'just format-c' to fix."
             exit 1
           }
 

--- a/justfile
+++ b/justfile
@@ -162,31 +162,10 @@ log-listen udp_port="4444":
 lint: lint-c lint-python
     @echo "All lint checks passed"
 
-# Lint C/C++ code with cppcheck
+# Lint C/C++ code with cppcheck (blocking). See tools/cquality.sh for the shared config.
 [group: "quality"]
 lint-c:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    command -v cppcheck >/dev/null 2>&1 || { echo "Error: cppcheck not found — brew install cppcheck"; exit 1; }
-    mkdir -p tmp
-    find packages -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \
-        ! -path "*/managed_components/*" \
-        ! -path "*/components/esp-idf-lib/*" \
-        ! -path "*/external/*" \
-        ! -path "*/build/*" \
-        ! -path "*/.esphome/*" \
-        ! -path "*/.venv/*" \
-        -print0 | \
-        xargs -0 cppcheck \
-            --enable=warning,style,performance,portability \
-            --suppress=missingIncludeSystem \
-            --suppress=unmatchedSuppression \
-            --suppress=unusedStructMember \
-            --inline-suppr \
-            --error-exitcode=1 \
-            --template=gcc \
-            2>&1 | tee tmp/cppcheck-report.txt
-    echo "C/C++ lint checks passed"
+    tools/cquality.sh lint
 
 # Lint Python code with ruff
 [group: "quality"]
@@ -202,22 +181,10 @@ lint-python:
 format: format-c format-python
     @echo "All code formatting complete"
 
-# Format C/C++ code with clang-format
+# Format C/C++ code with clang-format. See tools/cquality.sh for the shared config.
 [group: "quality"]
 format-c:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    command -v clang-format >/dev/null 2>&1 || { echo "Warning: clang-format not found — brew install clang-format"; exit 0; }
-    find packages -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \
-        ! -path "*/managed_components/*" \
-        ! -path "*/components/esp-idf-lib/*" \
-        ! -path "*/external/*" \
-        ! -path "*/build/*" \
-        ! -path "*/.esphome/*" \
-        ! -path "*/.venv/*" \
-        -print0 | \
-        xargs -0 clang-format -i --style=file
-    echo "C/C++ code formatted"
+    tools/cquality.sh format
 
 # Format Python code with ruff
 [group: "quality"]
@@ -233,22 +200,10 @@ format-python:
 format-check: format-check-c format-check-python
     @echo "All format checks passed"
 
-# Check C/C++ formatting without modifying
+# Check C/C++ formatting without modifying. See tools/cquality.sh for the shared config.
 [group: "quality"]
 format-check-c:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    command -v clang-format >/dev/null 2>&1 || { echo "Error: clang-format not found"; exit 1; }
-    find packages -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" \) \
-        ! -path "*/managed_components/*" \
-        ! -path "*/components/esp-idf-lib/*" \
-        ! -path "*/external/*" \
-        ! -path "*/build/*" \
-        ! -path "*/.esphome/*" \
-        ! -path "*/.venv/*" \
-        -print0 | \
-        xargs -0 clang-format --dry-run --Werror --style=file
-    echo "C/C++ formatting check passed"
+    tools/cquality.sh format-check
 
 # Check Python formatting without modifying
 [group: "quality"]

--- a/tools/cquality.sh
+++ b/tools/cquality.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Single source of truth for C/C++ lint (cppcheck) and format (clang-format).
+#
+# Consumed by:
+#   - justfile        : lint-c / format-c / format-check-c recipes
+#   - CI test.yml     : C/C++ Linting + Format Check jobs
+#   - post-edit hook  : .claude/hooks/post-edit-lint.sh (single-file)
+#
+# Before this script, the find-expression, the exclude list, and the cppcheck
+# flag set were copy-pasted across all three call sites (5-7 copies) and had
+# already drifted (CI omitted the `.venv` exclude). Owning them here once is the
+# offload-to-deterministic-substrate + local-ci-parity fix: change the exclude
+# list in ONE place and every consumer picks it up.
+#
+# Usage:
+#   tools/cquality.sh lint [--advisory]   # cppcheck the tree (blocking; --advisory never fails)
+#   tools/cquality.sh format              # clang-format -i the tree
+#   tools/cquality.sh format-check        # clang-format --dry-run --Werror (blocking)
+#   tools/cquality.sh lint-file   FILE    # cppcheck a single file (advisory)
+#   tools/cquality.sh format-file FILE    # clang-format -i a single file
+set -euo pipefail
+
+# --- Canonical, single-definition config -------------------------------------
+
+# Directories excluded from all C/C++ checks: vendored/generated/build trees.
+EXCLUDES=(
+    '*/managed_components/*'
+    '*/components/esp-idf-lib/*'
+    '*/external/*'
+    '*/build/*'
+    '*/.esphome/*'
+    '*/.venv/*'
+)
+
+# cppcheck flags shared by the whole-tree lint and the single-file hook.
+# shellcheck disable=SC2054  # --enable=... commas are cppcheck flag syntax, not element separators
+CPPCHECK_FLAGS=(
+    --enable=warning,style,performance,portability
+    --suppress=missingIncludeSystem
+    --suppress=unmatchedSuppression
+    --suppress=unusedStructMember
+    --inline-suppr
+    --template=gcc
+)
+
+# Print NUL-delimited list of in-scope C/C++ files under packages/.
+_c_files() {
+    local find_args=(packages -type f
+        '(' -name '*.c' -o -name '*.h' -o -name '*.cpp' -o -name '*.hpp' ')')
+    local ex
+    for ex in "${EXCLUDES[@]}"; do
+        find_args+=(! -path "$ex")
+    done
+    find "${find_args[@]}" -print0
+}
+
+_require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "Error: $1 not found — $2" >&2
+        exit 1
+    }
+}
+
+# --- Subcommands -------------------------------------------------------------
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    lint)
+        # Default blocks (exit 1 on findings); --advisory reports without failing
+        # (CI uploads tmp/cppcheck-report.txt as an artifact instead of failing).
+        exitcode=1
+        [[ "${1:-}" == "--advisory" ]] && exitcode=0
+        _require cppcheck "brew install cppcheck (or apt-get install cppcheck)"
+        mkdir -p tmp
+        _c_files | xargs -0 cppcheck "${CPPCHECK_FLAGS[@]}" \
+            --error-exitcode="$exitcode" 2>&1 | tee tmp/cppcheck-report.txt
+        echo "C/C++ lint complete"
+        ;;
+    format)
+        _require clang-format "brew install clang-format"
+        _c_files | xargs -0 clang-format -i --style=file
+        echo "C/C++ code formatted"
+        ;;
+    format-check)
+        _require clang-format "brew install clang-format"
+        _c_files | xargs -0 clang-format --dry-run --Werror --style=file
+        echo "C/C++ formatting check passed"
+        ;;
+    lint-file)
+        f="${1:?usage: cquality.sh lint-file FILE}"
+        command -v cppcheck >/dev/null 2>&1 &&
+            cppcheck "${CPPCHECK_FLAGS[@]}" --quiet "$f" || true
+        ;;
+    format-file)
+        f="${1:?usage: cquality.sh format-file FILE}"
+        command -v clang-format >/dev/null 2>&1 &&
+            clang-format -i --style=file "$f"
+        ;;
+    *)
+        echo "usage: cquality.sh {lint [--advisory]|format|format-check|lint-file FILE|format-file FILE}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Wave 1 of 4 — tooling simplification

Single-sources the C/C++ lint+format pipeline. Part of a consensus-backed 4-wave tooling simplification (directions from a **glm-5.2 + gpt-5.2** consensus, each adjudicated against the repo).

### Problem
The cppcheck/clang-format find-expression, exclude list, and flag sets were copy-pasted across **5–7 call sites** — justfile `lint-c`/`format-c`/`format-check-c`, CI `test.yml` (2 jobs), and `.claude/hooks/post-edit-lint.sh` — and had already **drifted**: CI omitted the `.venv` exclude the justfile carried.

### Change
- New **`tools/cquality.sh`** owns the exclude list + cppcheck flags **once**, with subcommands: `lint [--advisory]`, `format`, `format-check`, `lint-file`, `format-file`.
- justfile recipes, both CI jobs, and the post-edit hook now delegate to it.
- Added `tools/cquality.sh` + `test.yml` to the `c-code` paths-filter so lint-tooling changes re-run the C checks (this PR exercises them).

### Behavior preserved
- Advisory-in-CI (`--error-exitcode=0` + uploaded report) vs blocking-locally (`=1`) split kept via the `--advisory` flag.
- The `.venv` drift only affected **local** runs (CI checkouts have no `.venv`), so this is a maintainability/DX fix, not a CI-correctness bug — stated honestly.

### Verification
- `just --list` parses; `lint-c`/`format-c`/`format-check-c` still present and delegate.
- `actionlint test.yml`: the edited jobs are clean; the 2 remaining `SC2086`/`SC2129` infos are **pre-existing** in `test-esp32-host`/`test-summary` (untouched here; `test-esp32-host` is removed in Wave 0).
- `bash -n` + `shellcheck` clean; smoke-tested `cquality.sh lint-file`.
- CI **Format Check** (pinned clang-format 18.1.8) + advisory cppcheck run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8QTWXn3To4JtR7rcSfpdK
