### PR TITLE
docs(rules): capture shared flash-recipe + CI-discovery conventions

### DIFF
--- a/.claude/rules/containerized-builds.md
+++ b/.claude/rules/containerized-builds.md
@@ -34,6 +34,10 @@ Standard ESP-IDF projects import `tools/esp32-idf.just` to get shared containeri
 | `_idf-build` | Private recipe — containerized `idf.py set-target + build` |
 | `_idf-clean` | Private recipe — containerized `idf.py fullclean` |
 | `_idf *args` | Private recipe — run any `idf.py` command in the container |
+| `_idf-build-checked bin` | Private — validated build: filters output to warnings/errors/size and fails fast if `build/{{bin}}.bin` is missing. Pass the app basename. |
+| `_esp32-flash bin` | Private — native ESP32 flash (bootloader @0x1000, flash-size detect). Pass the app basename. |
+| `_s3-flash bin` | Private — native ESP32-S3 flash (bootloader @0x0, 4MB @80MHz). Pass the app basename. |
+| `_s3-reset` / `_s3-monitor` | Private — ESP32-S3 USB-Serial-JTAG reset / CDC-reset monitor (wrap the `tools/esp32s3-*.sh` scripts). |
 | `build` | Public — delegates to `_idf-build` (override to add pre-build steps) |
 | `clean` | Public — delegates to `_idf-clean` |
 | `menuconfig` | Public — containerized `idf.py menuconfig` |
@@ -65,6 +69,14 @@ build: credentials _idf-build
 [group: "build"]
 size: (_idf "size")
 
+# Shared flash/build/monitor recipes — pass bin_name (the compiled app basename)
+# as a recipe ARGUMENT, not a shared variable (see note below):
+bin_name := "robocar-main"            # = the CMake project() name, no .bin
+build: (_idf-build-checked bin_name)  # validated build
+flash: (_esp32-flash bin_name)        # or (_s3-flash bin_name) for esp32s3
+reset: _s3-reset                      # esp32s3 only
+monitor: _s3-monitor                  # esp32s3 (esp32 uses _serial-monitor)
+
 # Non-building projects (orchestration, port detection only):
 import '../../../tools/esp32.just'
 
@@ -72,6 +84,29 @@ import '../../../tools/esp32.just'
 import '../../../tools/esphome.just'
 device_name := "my-device"
 ```
+
+**Why `bin_name` is a recipe parameter, not a shared variable.** `just` treats an
+import that *defaults* a variable a module also assigns as a conflict (`variable
+`bin_name` has multiple definitions`), and an imported recipe that references
+`{{bin_name}}` forces *every* importing module to define it at load time (or it
+errors `variable not defined`). Passing it as a recipe argument
+(`flash: (_s3-flash bin_name)`) sidesteps both and keeps the `.bin` name explicit
+at the call site. Flash baud reads `${BAUD:-460800}` at the bash level, so no baud
+variable is needed.
+
+**Verify flash/build recipe changes with `just --dry-run` — CI does not exercise
+them.** CI builds firmware via `esp-idf-ci-action` (not the justfile) and flash
+runs host-native, so no automated gate covers these recipes; a wrong flash offset
+bricks or fails-to-boot the device. Before changing a shared flash/build recipe,
+confirm each consumer still expands to its original command:
+`PORT=/dev/ttyDUMMY just <module>::flash --dry-run` (the `--dry-run` flag must
+precede the recipe).
+
+**Exotic flash layouts stay inline.** `_esp32-flash`/`_s3-flash` cover the two
+standard single-app layouts only. Projects with a non-standard memory map (app
+@0x12000, an extra `ota_data` segment, an esptool `@flash_args` argfile) or an
+ESP32-CAM GPIO0 programming reminder keep their flash recipe inline so the offsets
+stay explicit and auditable.
 
 ### Monitor Recipe
 
@@ -82,12 +117,17 @@ ESP32-S3 projects with native USB-Serial-JTAG override `monitor` with their own 
 ## Adding New ESP-IDF Projects
 
 1. Create justfile with `import '../../../tools/esp32-idf.just'`
-2. Set `project_dir`, `port`, and `target`
-3. Define `flash` recipe (project-specific: binary name, chip, offsets)
+2. Set `project_dir`, `bin_name` (the compiled app basename), `port`, and `target`
+3. Compose the shared flash/build recipes: `build: (_idf-build-checked bin_name)` and
+   `flash: (_esp32-flash bin_name)` (or `(_s3-flash bin_name)`). Standard layouts only —
+   keep an exotic flash recipe inline (see the flash-layout note above)
 4. Define `info` recipe (project-specific)
-5. Override `build` if pre-build steps are needed (e.g., `build: credentials _idf-build`)
-6. Use `require-port` as dependency for flash recipes
+5. Override `build` for pre-build steps if needed (e.g., `build: credentials (_idf-build-checked bin_name)`)
+6. Use `require-port` as dependency for flash recipes (the shared `_*-flash` recipes already do)
 7. Register as a module in the root justfile: `mod name 'packages/<domain>/name'`
+8. Add a CI entry to `.github/project-matrix.json` (`system`, `project`, `path`, `target`,
+   plus `fetch_bluepad32: true` if it vendors bluepad32) — the single `build.yml` matrix
+   discovers it; no per-project `build-<project>.yml` is needed
 
 ## Do Not
 
@@ -96,4 +136,9 @@ ESP32-S3 projects with native USB-Serial-JTAG override `monitor` with their own 
 - Define `container_cmd`, `require-port`, `_monitor_baud`, or `_serial-monitor` locally — they come from the import
 - Define `build`, `clean`, `menuconfig`, or `shell` with inline container commands — use `esp32-idf.just` shared recipes
 - Copy the pyserial monitor block inline — use `_serial-monitor` instead
+- Inline the native `esptool` flash block or the S3 reset/monitor scripts for a
+  standard-layout project — compose the shared `_esp32-flash` / `_s3-flash` /
+  `_s3-reset` / `_s3-monitor` recipes instead (exotic layouts excepted)
+- Create a per-project `build-<project>.yml` CI workflow — add a
+  `.github/project-matrix.json` entry instead; the single `build.yml` matrix builds it
 - Use absolute symlinks for vendored dependencies (`external/<name>`) — absolute targets like `/Users/...` don't resolve inside the container's `/workspace` bind mount. Use relative symlinks that stay under the repo root, e.g. `ln -sfn ../../../input-gaming/xbox-switch-bridge/external/bluepad32 external/bluepad32`.

--- a/.claude/rules/web-flasher.md
+++ b/.claude/rules/web-flasher.md
@@ -4,6 +4,14 @@
 
 The web flasher (`docs/flasher/index.html`) enables browser-based firmware flashing via ESP Web Tools. It is deployed to GitHub Pages on every firmware release.
 
+**`flasher.json` scopes the RELEASE / web-flasher set, not CI.** Only
+flasher-enabled projects carry a `flasher.json`, and `build-firmware.yml`
+discovers them from it on release. CI builds a **superset** — every buildable
+project across ESP-IDF, ESPHome, and Pico — discovered from
+`.github/project-matrix.json` by `build.yml`. Do **not** drive CI discovery from
+`flasher.json`: several CI projects (non-flasher ESP-IDF, ESPHome, Pico) have none
+and would be silently dropped.
+
 ## Flash Offset Reference
 
 Both robocar targets use identical partition layouts on standard ESP32 (4MB flash):


### PR DESCRIPTION
Session-distill of the tooling-simplification session (#403/#404/#406/#407).

Captures three durable, project-specific conventions into `.claude/rules/`:

- **`containerized-builds.md`** — the new shared `esp32-idf.just` recipes (`_idf-build-checked`, `_esp32-flash`, `_s3-flash`, `_s3-reset`, `_s3-monitor`); the `bin_name`-as-recipe-argument convention **and why** (just's import-default vs module-override conflict + load-time variable resolution); a **`just --dry-run` verification note** (CI builds via `esp-idf-ci-action`, not the justfile — flash offsets brick hardware with no automated gate); the exotic-layout-stays-inline rule; and the new `project-matrix.json` CI step.
- **`web-flasher.md`** — `flasher.json` scopes the **release/web-flasher** set; CI builds a **superset** from `.github/project-matrix.json`. Driving CI discovery off `flasher.json` silently drops non-flasher/ESPHome/Pico projects.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8QTWXn3To4JtR7rcSfpdK