### PR TITLE
docs(rules): capture the ESP_LOG string-literal format-arg gotcha

### DIFF
--- a/.claude/rules/esp-log-format-literal.md
+++ b/.claude/rules/esp-log-format-literal.md
@@ -1,0 +1,50 @@
+# ESP_LOG Format Argument Must Be a String Literal
+
+## The Rule
+
+The `ESP_LOGx` macros (`ESP_LOGE/W/I/D/V`) require their **format argument to
+be a compile-time string literal**. The logging macros string-concatenate the
+format with color/prefix literals at expansion time (`LOG_FORMAT(letter,
+format)` token-pastes `"\033[…m" format "\033[0m"`). C only concatenates
+adjacent *string literals*, so anything that is not a literal — a ternary, a
+variable, a function call — breaks the expansion.
+
+## The Failure
+
+```c
+// WRONG — ternary is not a string literal
+ESP_LOGI(TAG, connected ? "Host connected" : "Host disconnected");
+```
+
+Compiles to a syntax error far from the obvious cause:
+
+```
+error: expected ')' before 'connected'
+```
+
+The error points at the log macro's internals (`esp_log_color.h`), not at an
+obviously malformed call, so it reads as a toolchain problem rather than a
+misused macro.
+
+## The Fix
+
+Keep the format a literal; pass the dynamic part as a `%s` (or other) argument:
+
+```c
+// RIGHT — literal format, ternary passed as an argument
+ESP_LOGI(TAG, "Host %s", connected ? "connected" : "disconnected");
+```
+
+Same rule for any non-literal: build the message with format specifiers and
+pass the values as arguments — never `ESP_LOGI(TAG, some_char_ptr)` or
+`ESP_LOGI(TAG, cond ? a : b)`.
+
+## When It Bites
+
+- Logging a state change with a ternary describing the new state.
+- Passing a `const char *` variable directly as the format (also a
+  format-string-injection risk if the string is attacker-influenced).
+- Any project under `packages/` — this is an ESP-IDF-wide gotcha, not specific
+  to one firmware.
+
+First hit 2026-07 in `facedancer-espdancer-fw/main/main.c` (PR #415).


### PR DESCRIPTION
## What

Adds `.claude/rules/esp-log-format-literal.md` — a project rule documenting that `ESP_LOGx` macros require a **string-literal** format argument.

## Why

Surfaced while unblocking the `facedancer-espdancer-fw` build (#415): `ESP_LOGI(TAG, cond ? "a" : "b")` failed with a misleading `error: expected ')' before 'connected'` pointing at `esp_log_color.h`, because the log macros string-concatenate the format literal and C only concatenates adjacent *literals*. It's an ESP-IDF-wide footgun that applies to every firmware project in the monorepo, so it's worth codifying once.

## Content

- The mechanism (why the literal is required).
- The failure signature (the misleading error).
- The fix (`ESP_LOGI(TAG, "Host %s", cond ? "a" : "b")`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)