### PR TITLE
fix(robocar-unified): unbrick the boot — flash offset + I2C driver conflict + graceful degradation

### DIFF
--- a/packages/robocar/unified/justfile
+++ b/packages/robocar/unified/justfile
@@ -46,7 +46,7 @@ flash: require-port
         write-flash --flash-mode dio --flash-size detect \
         0x0 build/bootloader/bootloader.bin \
         0x8000 build/partition_table/partition-table.bin \
-        0x12000 build/robocar-unified.bin
+        0x10000 build/robocar-unified.bin
     echo "Flashed OK"
 
 # Monitor serial output (Ctrl-C to stop)

--- a/packages/robocar/unified/main/main.c
+++ b/packages/robocar/unified/main/main.c
@@ -378,7 +378,22 @@ static esp_err_t init_hardware(void)
 {
     ESP_LOGI(TAG, "Phase 1: I2C bus + peripherals");
 
-    ESP_RETURN_ON_ERROR(i2c_bus_init(), TAG, "I2C bus init failed");
+    // The I2C bus (TCA9548A + PCA9685 + optional MCP23017) is non-fatal: a bare
+    // board with no I2C hardware fitted should still boot so the console,
+    // camera, WiFi and AI planner remain reachable. The bus accessors return
+    // ESP_ERR_INVALID_STATE while uninitialised, so the PCA9685-backed
+    // peripherals (motors, servos, LEDs) and the expander fail safely at
+    // runtime rather than crashing.
+    esp_err_t i2c_ret = i2c_bus_init();
+    if (i2c_ret != ESP_OK) {
+        ESP_LOGW(TAG, "I2C bus init failed (%s) — motors/servos/LEDs/expander disabled",
+                 esp_err_to_name(i2c_ret));
+        // Buzzer is on a dedicated GPIO (not I2C) — keep the startup beep.
+        ESP_RETURN_ON_ERROR(buzzer_init(), TAG, "Buzzer init failed");
+        buzzer_beep();
+        return ESP_OK;
+    }
+
     // Optional hardware: returns ESP_OK even when no expander is fitted
     ESP_RETURN_ON_ERROR(gpio_expander_init(), TAG, "GPIO expander init failed");
     ESP_RETURN_ON_ERROR(motor_controller_init(), TAG, "Motor init failed");

--- a/packages/robocar/unified/sdkconfig.defaults
+++ b/packages/robocar/unified/sdkconfig.defaults
@@ -31,6 +31,12 @@ CONFIG_ESP_HTTP_CLIENT_ENABLE_BASIC_AUTH=y
 # Camera (DMA on Core 1 to isolate from motor control on Core 0)
 CONFIG_CAMERA_CORE1=y
 CONFIG_CAMERA_DMA_BUFFER_SIZE_MAX=32768
+# Camera SCCB must use the LEGACY I2C driver. esp32-camera Kconfig defaults to
+# the new "driver_ng" (CONFIG_SCCB_HARDWARE_I2C_DRIVER_NEW), but the project bus
+# (i2c_bus.c → i2cdev: TCA9548A + PCA9685 + MCP23017) is legacy. ESP-IDF 5.4
+# aborts at boot if both driver types coexist ("CONFLICT! driver_ng is not
+# allowed to be used with this old driver"). Force legacy for consistency.
+CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY=y
 
 # Flash (XIAO ESP32-S3 Sense has 8MB flash)
 CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y


### PR DESCRIPTION
## Summary

The robocar-unified board was stuck in a boot loop. Investigation uncovered **three layered causes, each masking the next** — fixed together here.

| # | Cause | File | Fix |
|---|---|---|---|
| 1 | Flash-recipe offset drift | `justfile` | app offset `0x12000` → `0x10000` (matches `partitions.csv`) |
| 2 | I2C `driver_ng` conflict | `sdkconfig.defaults` | `CONFIG_SCCB_HARDWARE_I2C_DRIVER_LEGACY=y` |
| 3 | Fatal I2C init on a bare board | `main/main.c` | non-fatal `i2c_bus_init` (log + continue) |

### 1. Flash-offset drift (boot loop: "No bootable app partitions")
The flash recipe wrote the app to `0x12000`, but `partitions.csv` places `ota_0` at `0x10000` (64 KB-aligned, as ESP-IDF 5.4 requires — `0x12000` isn't even aligned). The bootloader read the app where the table said (`0x10000`), found stale data, and looped. The hand-rolled `esptool` recipe hard-codes offsets instead of deriving them from the partition table, so the drift (introduced in #399 when `ota_0` moved to `0x10000`) went uncaught.

### 2. I2C `driver_ng` conflict (`abort()` at boot)
With the app loading, it aborted: `CONFLICT! driver_ng is not allowed to be used with this old driver`. `esp32-camera`'s Kconfig defaults its SCCB backend to the **new** `i2c_master` driver (`sccb-ng.c`), but the project bus (`i2c_bus.c` → `i2cdev`: TCA9548A + PCA9685 + MCP23017) is **legacy**. ESP-IDF 5.4 aborts when both driver types coexist. Forcing the camera SCCB to legacy makes the whole firmware consistent (now compiles `sccb.c`, not `sccb-ng.c`). Migrating the entire mux/PCA9685/MCP23017 stack to the new driver would be a large, risky rewrite — out of scope.

### 3. Fatal I2C init on a bare board
With both driver bugs fixed, a board with **no TCA9548A fitted** still aborted: `init_hardware` fail-fast'd on the mux's `ESP_ERR_TIMEOUT`. Now `i2c_bus_init` is non-fatal (log + continue, following the existing speech-path idiom), so the console, camera, WiFi and AI planner remain reachable without the I2C peripherals. The bus accessors already return `ESP_ERR_INVALID_STATE` while uninitialised, so the PCA9685-backed peripherals fail safely at runtime rather than crashing.

## Verification (on hardware, XIAO ESP32-S3)

- App loads at `0x10000` (`Loaded app from partition at offset 0x10000`).
- No `driver_ng` abort — only a benign `W ... old driver` warning.
- Bare board boots through with `I2C bus init failed (ESP_ERR_TIMEOUT) — motors/servos/LEDs/expander disabled` logged as a **warning**, no loop.
- Before the fixes: aborting/looping every ~1 s. After: zero boot banners, zero aborts across flash + reset + monitor.

## Follow-up (not in this PR)
The flash recipe hard-coding offsets that duplicate `partitions.csv` is the root reason #1 could drift silently. A future improvement could derive the offset from the partition table (or flash via `idf.py flash`) so the two can't diverge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)