### PR TITLE
feat(robocar-unified): speak a self-introduction + status self-diagnostic

### DIFF
--- a/packages/robocar/unified/main/CMakeLists.txt
+++ b/packages/robocar/unified/main/CMakeLists.txt
@@ -18,6 +18,7 @@ idf_component_register(
         "ultrasonic.c"
         "reactive_controller.c"
         "planner_task.c"
+        "self_report.c"
         "credentials_loader.c"
         "wifi_manager.c"
         "mqtt_logger.c"

--- a/packages/robocar/unified/main/audio_player.c
+++ b/packages/robocar/unified/main/audio_player.c
@@ -234,3 +234,8 @@ bool audio_player_is_busy(void)
     }
     return s_channel_active || xRingbufferGetCurFreeSize(s_ring) < AUDIO_RING_BYTES;
 }
+
+bool audio_player_is_ready(void)
+{
+    return s_task != NULL && s_ring != NULL;
+}

--- a/packages/robocar/unified/main/audio_player.h
+++ b/packages/robocar/unified/main/audio_player.h
@@ -69,6 +69,9 @@ void audio_player_abort(void);
 /** True while audio is buffered or actively playing. */
 bool audio_player_is_busy(void);
 
+/** True once the player task and PSRAM ring are up (i.e. init succeeded). */
+bool audio_player_is_ready(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/robocar/unified/main/gemini_backend.c
+++ b/packages/robocar/unified/main/gemini_backend.c
@@ -39,6 +39,21 @@ static const char *TAG = "gemini_backend";
 #define GEMINI_BASE_URL \
     "https://generativelanguage.googleapis.com/v1beta/models/" GEMINI_MODEL ":generateContent"
 
+/** Text model that phrases self-report facts into a spoken line. A cheap flash
+ *  text model — this is a short one-sentence completion, not vision. */
+#define NARRATE_MODEL "gemini-flash-latest"
+#define NARRATE_BASE_URL \
+    "https://generativelanguage.googleapis.com/v1beta/models/" NARRATE_MODEL ":generateContent"
+
+/** Narrate uses its own small buffer (not s_response_buf) so it can run
+ *  concurrently with the planner on another task without racing the shared
+ *  buffer. A one-sentence reply is tiny; 4 kB also absorbs an error body. */
+#define NARRATE_RESPONSE_BUF_SIZE (4 * 1024)
+#define NARRATE_TIMEOUT_MS 15000
+/** Ample for one ≤25-word sentence; keeps thinking-capable models from
+ *  spending the whole budget before emitting text. */
+#define NARRATE_MAX_OUTPUT_TOKENS 128
+
 /** HTTP response buffer.  16 kB matches the reference client; function-call
  *  responses are much smaller but the buffer is also used to absorb error
  *  bodies from the API. */
@@ -475,6 +490,181 @@ esp_err_t gemini_backend_plan(const uint8_t *jpeg, size_t jpeg_len, goal_t *out_
 cleanup:
     esp_http_client_cleanup(client);
     free(request_body);
+    return err;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Narration (text-only self-report phrasing)                                  */
+/* -------------------------------------------------------------------------- */
+
+/** Build the text-only generateContent body for a spoken status line. */
+static char *build_narrate_json(const char *facts, bool is_update)
+{
+    char prompt[1024];
+    snprintf(prompt, sizeof(prompt),
+             "You are a small wheeled robot named Robocar, speaking aloud. "
+             "Here are your live on-device subsystem facts:\n%s\n\n"
+             "%s"
+             "Write ONE short, friendly spoken sentence (at most 25 words, plain text only — "
+             "no markdown, no emoji, no quotes) %s and stating your status, naming anything that "
+             "is not responding. Report only the facts above; do not invent hardware.",
+             facts,
+             is_update ? "This is a status UPDATE: a subsystem's health just changed — keep to "
+                         "what changed. "
+                       : "",
+             is_update ? "noting the change" : "introducing yourself");
+
+    cJSON *root = cJSON_CreateObject();
+
+    cJSON *contents = cJSON_AddArrayToObject(root, "contents");
+    cJSON *content = cJSON_CreateObject();
+    cJSON_AddStringToObject(content, "role", "user");
+    cJSON *parts = cJSON_AddArrayToObject(content, "parts");
+    cJSON *text_part = cJSON_CreateObject();
+    cJSON_AddStringToObject(text_part, "text", prompt);
+    cJSON_AddItemToArray(parts, text_part);
+    cJSON_AddItemToArray(contents, content);
+
+    cJSON *gen_config = cJSON_AddObjectToObject(root, "generationConfig");
+    cJSON_AddNumberToObject(gen_config, "maxOutputTokens", NARRATE_MAX_OUTPUT_TOKENS);
+    cJSON_AddNumberToObject(gen_config, "temperature", 0.7);
+    /* Disable thinking so the token budget is spent on the reply, not silent
+     * reasoning (a flash text model would otherwise risk an empty completion). */
+    cJSON *thinking = cJSON_AddObjectToObject(gen_config, "thinkingConfig");
+    cJSON_AddNumberToObject(thinking, "thinkingBudget", 0);
+
+    char *body = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    return body; /* caller frees */
+}
+
+/** Collapse newlines to spaces and strip surrounding whitespace, in place. */
+static void sanitize_spoken_line(char *s)
+{
+    for (char *p = s; *p != '\0'; ++p) {
+        if (*p == '\n' || *p == '\r' || *p == '\t') {
+            *p = ' ';
+        }
+    }
+    /* trim leading */
+    char *start = s;
+    while (*start == ' ') {
+        ++start;
+    }
+    if (start != s) {
+        memmove(s, start, strlen(start) + 1);
+    }
+    /* trim trailing */
+    size_t len = strlen(s);
+    while (len > 0 && s[len - 1] == ' ') {
+        s[--len] = '\0';
+    }
+}
+
+/** Extract and concatenate candidates[0].content.parts[*].text into @p out. */
+static esp_err_t parse_narrate_response(const char *json, char *out, size_t out_len)
+{
+    cJSON *root = cJSON_Parse(json);
+    if (!root) {
+        return ESP_FAIL;
+    }
+
+    esp_err_t ret = ESP_FAIL;
+    cJSON *candidates = cJSON_GetObjectItem(root, "candidates");
+    cJSON *c0 = cJSON_IsArray(candidates) ? cJSON_GetArrayItem(candidates, 0) : NULL;
+    cJSON *content = c0 ? cJSON_GetObjectItem(c0, "content") : NULL;
+    cJSON *parts = content ? cJSON_GetObjectItem(content, "parts") : NULL;
+
+    if (cJSON_IsArray(parts)) {
+        out[0] = '\0';
+        const int n = cJSON_GetArraySize(parts);
+        for (int i = 0; i < n; ++i) {
+            cJSON *t = cJSON_GetObjectItem(cJSON_GetArrayItem(parts, i), "text");
+            if (cJSON_IsString(t) && t->valuestring) {
+                strlcat(out, t->valuestring, out_len);
+            }
+        }
+        if (out[0] != '\0') {
+            sanitize_spoken_line(out);
+            if (out[0] != '\0') {
+                ret = ESP_OK;
+            }
+        }
+    }
+
+    cJSON_Delete(root);
+    return ret;
+}
+
+esp_err_t gemini_backend_narrate(const char *facts, bool is_update, char *out, size_t out_len)
+{
+    if (!facts || !out || out_len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    out[0] = '\0';
+
+    const char *api_key = get_gemini_api_key();
+    if (!api_key || api_key[0] == '\0') {
+        ESP_LOGW(TAG, "narrate: API key unavailable");
+        return ESP_FAIL;
+    }
+
+    char *request_body = build_narrate_json(facts, is_update);
+    if (!request_body) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    /* Own buffer — do not touch s_response_buf, which the planner task uses. */
+    char *resp = malloc(NARRATE_RESPONSE_BUF_SIZE);
+    if (!resp) {
+        free(request_body);
+        return ESP_ERR_NO_MEM;
+    }
+    resp[0] = '\0';
+
+    response_acc_t acc = {.buf = resp, .len = 0, .cap = NARRATE_RESPONSE_BUF_SIZE};
+
+    esp_http_client_config_t cfg = {
+        .url = NARRATE_BASE_URL,
+        .method = HTTP_METHOD_POST,
+        .timeout_ms = NARRATE_TIMEOUT_MS,
+        .event_handler = http_event_handler,
+        .user_data = &acc,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&cfg);
+    if (!client) {
+        free(request_body);
+        free(resp);
+        return ESP_FAIL;
+    }
+
+    esp_http_client_set_header(client, "Content-Type", "application/json");
+    esp_http_client_set_header(client, "x-goog-api-key", api_key);
+    esp_http_client_set_post_field(client, request_body, strlen(request_body));
+
+    esp_err_t err = esp_http_client_perform(client);
+    const int status = esp_http_client_get_status_code(client);
+
+    if (err != ESP_OK || status != 200) {
+        ESP_LOGW(TAG, "narrate request failed: %s status=%d", esp_err_to_name(err), status);
+        if (acc.len > 0) {
+            ESP_LOGD(TAG, "narrate error body: %.*s", (int)acc.len, acc.buf);
+        }
+        err = ESP_FAIL;
+        goto cleanup;
+    }
+
+    err = parse_narrate_response(acc.buf, out, out_len);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "narrate: no usable text in response");
+    }
+
+cleanup:
+    esp_http_client_cleanup(client);
+    free(request_body);
+    free(resp);
     return err;
 }
 

--- a/packages/robocar/unified/main/gemini_backend.h
+++ b/packages/robocar/unified/main/gemini_backend.h
@@ -12,6 +12,7 @@
 #ifndef GEMINI_BACKEND_H
 #define GEMINI_BACKEND_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -63,6 +64,28 @@ esp_err_t gemini_backend_init(void);
  */
 esp_err_t gemini_backend_plan(const uint8_t *jpeg, size_t jpeg_len, goal_t *out_goal,
                               uint32_t *latency_ms_out, char *out_speech, size_t speech_cap);
+
+/**
+ * @brief Phrase on-device status facts into one short spoken line via Gemini.
+ *
+ * A text-only generateContent call to a flash text model (NARRATE_MODEL) that
+ * turns @p facts into a single friendly spoken sentence naming anything that is
+ * not working. Self-contained: it allocates its own HTTP client and response
+ * buffer per call and reads the API key via get_gemini_api_key(), so it does
+ * NOT depend on gemini_backend_init() and is safe to call from a task other
+ * than the planner.
+ *
+ * @param facts    NUL-terminated compact facts string (see self_report).
+ * @param is_update true when re-announcing after a health change — the prompt
+ *                 then asks the model to keep to the delta.
+ * @param out      Output: the spoken line, NUL-terminated and whitespace-
+ *                 trimmed. Set to "" on failure. Must not be NULL.
+ * @param out_len  Size of @p out (e.g. SPEECH_TEXT_MAX). The line is truncated
+ *                 to fit.
+ * @return ESP_OK on success, ESP_FAIL on any HTTP/parse failure (the caller
+ *         should then speak its template fallback).
+ */
+esp_err_t gemini_backend_narrate(const char *facts, bool is_update, char *out, size_t out_len);
 
 /**
  * @brief Release resources allocated by gemini_backend_init().

--- a/packages/robocar/unified/main/i2c_bus.c
+++ b/packages/robocar/unified/main/i2c_bus.c
@@ -97,6 +97,11 @@ esp_err_t i2c_bus_init(void)
     return ESP_OK;
 }
 
+bool i2c_bus_is_ready(void)
+{
+    return s_initialized;
+}
+
 esp_err_t i2c_bus_select_channel(uint8_t channel)
 {
     if (!s_initialized) {

--- a/packages/robocar/unified/main/i2c_bus.h
+++ b/packages/robocar/unified/main/i2c_bus.h
@@ -12,6 +12,7 @@
 #include <esp_err.h>
 #include <i2cdev.h>
 #include <pca9685.h>
+#include <stdbool.h>
 #include "pin_config.h"
 
 /**
@@ -24,6 +25,16 @@
  * @return ESP_OK on success
  */
 esp_err_t i2c_bus_init(void);
+
+/**
+ * @brief Whether the I2C bus (TCA9548A + PCA9685) initialised successfully
+ *
+ * False on a bare board where no I2C hardware responded — the bus degrades
+ * gracefully (see init_hardware) and the PCA9685-backed peripherals fail safe.
+ *
+ * @return true if i2c_bus_init() completed
+ */
+bool i2c_bus_is_ready(void);
 
 /**
  * @brief Select a TCA9548A channel and acquire the bus mutex

--- a/packages/robocar/unified/main/main.c
+++ b/packages/robocar/unified/main/main.c
@@ -42,6 +42,7 @@
 #include "pin_config.h"
 #include "planner_task.h"
 #include "reactive_controller.h"
+#include "self_report.h"
 #include "servo_controller.h"
 #include "speech_queue.h"
 #include "system_state.h"
@@ -492,11 +493,33 @@ void app_main(void)
     ESP_LOGI(TAG, "Firmware version: %s", esp_app_get_description()->version);
 
     ESP_ERROR_CHECK(init_nvs());
+
+    // init_hardware() degrades gracefully (bare board still returns ESP_OK), so
+    // read the real bus state from its accessor for the self-report note.
     ESP_ERROR_CHECK(init_hardware());
-    ESP_ERROR_CHECK(init_camera());
+    self_report_note_init(SELF_REPORT_SUBSYS_I2C_BUS, i2c_bus_is_ready());
+
+    // Camera is non-fatal here so the robot can still boot, connect, and report
+    // "camera not responding" instead of panicking on a board without the Sense
+    // module fitted.
+    esp_err_t cam_ret = init_camera();
+    self_report_note_init(SELF_REPORT_SUBSYS_CAMERA, cam_ret == ESP_OK);
+    if (cam_ret != ESP_OK) {
+        ESP_LOGW(TAG, "Camera init failed (%s) — continuing so status stays reportable",
+                 esp_err_to_name(cam_ret));
+    }
+
     init_network();
     ESP_ERROR_CHECK(init_hierarchical_ai());
+    self_report_note_init(SELF_REPORT_SUBSYS_AUDIO, audio_player_is_ready());
     create_tasks();
+
+    // Spoken self-introduction + status diagnostic (announces once voice-able,
+    // re-announces on health change). Non-fatal: a robot that cannot start the
+    // monitor still drives.
+    if (self_report_start() != ESP_OK) {
+        ESP_LOGW(TAG, "self_report_start failed — no spoken self-report");
+    }
 
     ESP_LOGI(TAG, "=== System ready ===");
 

--- a/packages/robocar/unified/main/reactive_controller.c
+++ b/packages/robocar/unified/main/reactive_controller.c
@@ -301,8 +301,20 @@ static void reactive_task(void *arg)
         s_telemetry.stack_high_water = hwm;
         portEXIT_CRITICAL(&s_telem_mux);
 
-        /* ---- 5. Wait for next period ---- */
-        vTaskDelayUntil(&last_wake, pdMS_TO_TICKS(REACTIVE_LOOP_PERIOD_MS));
+        /* ---- 5. Wait for next period ----
+         * xTaskDelayUntil() returns pdFALSE without blocking when the loop body
+         * already overran the period — e.g. the ultrasonic GPIO poll fallback
+         * busy-waits out its full echo timeout (40 ms > 33 ms) on a board with
+         * no sensor fitted, or with the sensor aimed at open space. A
+         * non-blocking return means this Core-0 task never yields, starving
+         * IDLE0 and tripping the task watchdog. Guarantee at least a one-tick
+         * yield when we have fallen behind, and resync so we don't then fire a
+         * catch-up burst of zero-delay iterations. The healthy path (body fits
+         * the period) still blocks normally, so the 30 Hz cadence is unchanged. */
+        if (xTaskDelayUntil(&last_wake, pdMS_TO_TICKS(REACTIVE_LOOP_PERIOD_MS)) == pdFALSE) {
+            vTaskDelay(1);
+            last_wake = xTaskGetTickCount();
+        }
     }
 
     motor_stop();

--- a/packages/robocar/unified/main/self_report.c
+++ b/packages/robocar/unified/main/self_report.c
@@ -1,0 +1,296 @@
+/**
+ * @file self_report.c
+ * @brief Spoken self-introduction and status self-diagnostic. See the header.
+ */
+
+#include "self_report.h"
+
+#include <string.h>
+
+#include "audio_player.h"
+#include "credentials_loader.h"
+#include "esp_app_desc.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "gemini_backend.h"
+#include "gpio_expander.h"
+#include "i2c_bus.h"
+#include "mqtt_logger.h"
+#include "speech_queue.h"
+#include "wifi_manager.h"
+
+static const char *TAG = "self_report";
+
+/* -------------------------------------------------------------------------- */
+/* Task tuning                                                                 */
+/* -------------------------------------------------------------------------- */
+
+#define STATUS_MONITOR_TASK_STACK_SIZE 4096U
+#define STATUS_MONITOR_TASK_PRIORITY 2U
+#define STATUS_MONITOR_TASK_CORE 1  //!< bursty + network-bound, like the planner
+
+/** How often the monitor samples subsystem health. */
+#define STATUS_POLL_MS 3000U
+
+/** Minimum gap between spoken announcements — guards against chatter when a
+ *  flaky link toggles repeatedly. */
+#define ANNOUNCE_RATE_LIMIT_US (15 * 1000 * 1000)
+
+/* -------------------------------------------------------------------------- */
+/* Boot-recorded results                                                       */
+/* -------------------------------------------------------------------------- */
+
+/* Only the camera is stored: it has no live "is ready" accessor, so its boot
+ * result is the sole source for camera_ok. The I2C bus and audio have live
+ * accessors (i2c_bus_is_ready / audio_player_is_ready) that collect() reads, so
+ * recording them here would be dead state — they are only logged. */
+static bool s_camera_ok = false;
+
+static TaskHandle_t s_monitor_task = NULL;
+
+void self_report_note_init(self_report_subsystem_t subsystem, bool ok)
+{
+    if (subsystem == SELF_REPORT_SUBSYS_CAMERA) {
+        s_camera_ok = ok;
+    }
+    ESP_LOGI(TAG, "init: subsystem=%d ok=%d", (int)subsystem, (int)ok);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Snapshot + facts                                                            */
+/* -------------------------------------------------------------------------- */
+
+void self_report_collect(robocar_status_t *out)
+{
+    if (!out) {
+        return;
+    }
+    memset(out, 0, sizeof(*out));
+
+    /* Boot-recorded (the camera has no live "is ready" accessor). */
+    out->camera_ok = s_camera_ok;
+
+    /* Live accessors — authoritative, and what makes change-detection work. */
+    out->i2c_bus_ok = i2c_bus_is_ready();
+    out->audio_ok = audio_player_is_ready();
+    out->mcp23017_present = gpio_expander_available();
+    out->wifi_up = wifi_is_connected();
+
+    const char *key = get_gemini_api_key();
+    out->key_present = (key != NULL && key[0] != '\0');
+
+    const char *ssid = get_wifi_ssid();
+    strlcpy(out->ssid, (ssid != NULL) ? ssid : "", sizeof(out->ssid));
+
+    const esp_app_desc_t *desc = esp_app_get_description();
+    strlcpy(out->version, (desc != NULL) ? desc->version : "?", sizeof(out->version));
+}
+
+bool self_report_voice_able(const robocar_status_t *status)
+{
+    return status != NULL && status->wifi_up && status->key_present && status->audio_ok;
+}
+
+/** Required-subsystem state word: fault reads differently from "ok". */
+static const char *req_state(bool ok)
+{
+    return ok ? "ok" : "not-responding";
+}
+
+size_t self_report_format_facts(const robocar_status_t *status, char *buf, size_t len)
+{
+    if (!buf || len == 0) {
+        return 0;
+    }
+    if (!status) {
+        buf[0] = '\0';
+        return 0;
+    }
+
+    int n = snprintf(buf, len,
+                     "robot=robocar version=%s wifi=%s ssid=%s camera=%s i2c_peripherals=%s "
+                     "audio=%s mcp23017=%s gemini_key=%s",
+                     status->version, req_state(status->wifi_up),
+                     status->ssid[0] ? status->ssid : "none", req_state(status->camera_ok),
+                     req_state(status->i2c_bus_ok), req_state(status->audio_ok),
+                     status->mcp23017_present ? "present" : "absent(optional)",
+                     status->key_present ? "present" : "absent");
+
+    if (n < 0) {
+        buf[0] = '\0';
+        return 0;
+    }
+    return (size_t)n < len ? (size_t)n : len - 1;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Change detection                                                            */
+/* -------------------------------------------------------------------------- */
+
+/** FNV-1a over the health booleans + ssid. A change in any one flips it. */
+static uint32_t status_signature(const robocar_status_t *s)
+{
+    uint32_t h = 2166136261u;
+#define MIX_BYTE(b)        \
+    do {                   \
+        h ^= (uint8_t)(b); \
+        h *= 16777619u;    \
+    } while (0)
+    MIX_BYTE(s->wifi_up);
+    MIX_BYTE(s->camera_ok);
+    MIX_BYTE(s->i2c_bus_ok);
+    MIX_BYTE(s->mcp23017_present);
+    MIX_BYTE(s->audio_ok);
+    MIX_BYTE(s->key_present);
+    for (const char *p = s->ssid; *p != '\0'; ++p) {
+        MIX_BYTE(*p);
+    }
+#undef MIX_BYTE
+    return h;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Template fallback                                                           */
+/* -------------------------------------------------------------------------- */
+
+/* Spoken when the Gemini text call fails. Deliberately plain; truncated to the
+ * speech buffer. Names only what is wrong so a healthy robot stays brief. */
+static void template_line(const robocar_status_t *s, char *out, size_t len)
+{
+    char faults[128];
+    faults[0] = '\0';
+    if (!s->wifi_up) {
+        strlcat(faults, " WiFi", sizeof(faults));
+    }
+    if (!s->camera_ok) {
+        strlcat(faults, " camera", sizeof(faults));
+    }
+    if (!s->i2c_bus_ok) {
+        strlcat(faults, " motors", sizeof(faults));
+    }
+    if (!s->audio_ok) {
+        strlcat(faults, " audio", sizeof(faults));
+    }
+
+    if (faults[0] == '\0') {
+        strlcpy(out, "Hi, I'm Robocar and all my systems are online.", len);
+    } else {
+        snprintf(out, len, "Hi, I'm Robocar. These parts are not responding:%s.", faults);
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Narrate + post                                                              */
+/* -------------------------------------------------------------------------- */
+
+static void narrate_and_post(const robocar_status_t *status, const char *facts, bool is_update)
+{
+    char line[SPEECH_TEXT_MAX];
+    line[0] = '\0';
+
+    esp_err_t ret = gemini_backend_narrate(facts, is_update, line, sizeof(line));
+    if (ret != ESP_OK || line[0] == '\0') {
+        ESP_LOGW(TAG, "narrate failed (%s) — speaking template line", esp_err_to_name(ret));
+        template_line(status, line, sizeof(line));
+    }
+
+    esp_err_t sp = speech_queue_post(line);
+    if (sp == ESP_OK) {
+        ESP_LOGI(TAG, "self-report%s: \"%s\"", is_update ? " (update)" : "", line);
+    } else if (sp == ESP_ERR_NO_MEM) {
+        ESP_LOGD(TAG, "speech queue full — dropped self-report: \"%s\"", line);
+    } else {
+        ESP_LOGW(TAG, "speech_queue_post failed: %s", esp_err_to_name(sp));
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Monitor task                                                                */
+/* -------------------------------------------------------------------------- */
+
+static void status_monitor_task(void *arg)
+{
+    (void)arg;
+    ESP_LOGI(TAG, "status monitor started on core %d, poll %u ms", xPortGetCoreID(),
+             (unsigned)STATUS_POLL_MS);
+
+    robocar_status_t status;
+    char facts[SELF_REPORT_FACTS_MAX];
+
+    bool announced = false;       /* has the first announcement fired? */
+    uint32_t announced_sig = 0;   /* signature of the last spoken state */
+    uint32_t pending_sig = 0;     /* a change seen once, awaiting confirm */
+    bool have_pending = false;    /* one-cycle debounce armed */
+    int64_t last_announce_us = 0; /* for the rate limit */
+
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(STATUS_POLL_MS));
+
+        self_report_collect(&status);
+        const uint32_t sig = status_signature(&status);
+
+        /* The diagnostic is always logged (and published) so it is observable
+         * even while the robot cannot talk. */
+        self_report_format_facts(&status, facts, sizeof(facts));
+        ESP_LOGI(TAG, "status: %s", facts);
+        if (mqtt_logger_is_connected()) {
+            mqtt_logger_publish_status(facts);
+        }
+
+        if (!self_report_voice_able(&status)) {
+            /* Not able to speak yet. Drop any armed change so we don't fire a
+             * stale "update" the instant voice comes up — the first-announce
+             * path already covers "here is my status" at that moment. */
+            have_pending = false;
+            continue;
+        }
+
+        const int64_t now = esp_timer_get_time();
+
+        /* First announcement, the moment the robot becomes voice-able. */
+        if (!announced) {
+            narrate_and_post(&status, facts, false);
+            announced = true;
+            announced_sig = sig;
+            last_announce_us = now;
+            have_pending = false;
+            continue;
+        }
+
+        /* Re-announce on health change: debounce one cycle, then rate-limit. */
+        if (sig != announced_sig) {
+            if (!have_pending || pending_sig != sig) {
+                pending_sig = sig;
+                have_pending = true;
+                continue;  // confirm it is stable next cycle
+            }
+            if (now - last_announce_us < ANNOUNCE_RATE_LIMIT_US) {
+                continue;  // stable, but too soon — retry next cycle
+            }
+            narrate_and_post(&status, facts, true);
+            announced_sig = sig;
+            last_announce_us = now;
+            have_pending = false;
+        } else {
+            have_pending = false;  // reverted before it could be confirmed
+        }
+    }
+}
+
+esp_err_t self_report_start(void)
+{
+    if (s_monitor_task != NULL) {
+        return ESP_OK;
+    }
+
+    BaseType_t ok = xTaskCreatePinnedToCore(
+        status_monitor_task, "self_report", STATUS_MONITOR_TASK_STACK_SIZE, NULL,
+        STATUS_MONITOR_TASK_PRIORITY, &s_monitor_task, STATUS_MONITOR_TASK_CORE);
+    if (ok != pdPASS) {
+        ESP_LOGE(TAG, "failed to create status monitor task");
+        return ESP_FAIL;
+    }
+    return ESP_OK;
+}

--- a/packages/robocar/unified/main/self_report.h
+++ b/packages/robocar/unified/main/self_report.h
@@ -1,0 +1,111 @@
+/**
+ * @file self_report.h
+ * @brief Spoken self-introduction and status self-diagnostic.
+ *
+ * The robot has a voice (MAX98357A + Gemini TTS, ADR-019) but until now only
+ * spoke when the vision planner emitted a `speak`. This module makes it
+ * announce itself the moment it becomes *able to speak*, and re-announce when a
+ * subsystem's health changes — so a silent, part-populated board can tell you
+ * what came up and what didn't.
+ *
+ * Design (see the plan / ADR-019):
+ *   - Facts are gathered deterministically on-device (never hallucinated).
+ *   - A lightweight Gemini *text* call phrases them into one spoken line
+ *     (gemini_backend_narrate); on failure an on-device template speaks instead.
+ *   - The line is posted to the existing speech_queue — the same path the
+ *     planner's `speak` uses, so the two never collide (drop-newest queue).
+ *   - Cadence: once when first voice-able, then on health change (debounced +
+ *     rate-limited). The facts are always logged (and MQTT-published when up)
+ *     so the diagnostic is observable even while the robot cannot talk.
+ *
+ * The monitor is independent of the camera/planner, so it can report
+ * "camera not responding" even when the planner cannot run.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "credentials_loader.h"  // MAX_SSID_LENGTH
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Subsystems whose boot result is recorded by main.c's init phases. */
+typedef enum {
+    SELF_REPORT_SUBSYS_CAMERA = 0,
+    SELF_REPORT_SUBSYS_I2C_BUS,  //!< mux + PCA9685: motors, servos, LEDs
+    SELF_REPORT_SUBSYS_AUDIO,
+} self_report_subsystem_t;
+
+/**
+ * @brief A snapshot of the robot's subsystem health.
+ *
+ * Booleans plus a little context. Each is rendered into the facts string as
+ * OK / not-responding (expected) / absent (optional) so a genuine fault reads
+ * differently from optional hardware that simply isn't fitted.
+ */
+typedef struct {
+    bool wifi_up;                //!< STA connected
+    char ssid[MAX_SSID_LENGTH];  //!< SSID when known, else ""
+    bool camera_ok;              //!< OV2640 init succeeded (boot-recorded)
+    bool i2c_bus_ok;             //!< TCA9548A + PCA9685 up (motors/servos/LEDs)
+    bool mcp23017_present;       //!< optional GPIO expander detected
+    bool audio_ok;               //!< I2S player task + ring ready
+    bool key_present;            //!< Gemini API key available
+    char version[32];            //!< firmware version
+} robocar_status_t;
+
+/** Longest facts string produced by self_report_format_facts(), incl. NUL. */
+#define SELF_REPORT_FACTS_MAX 256
+
+/**
+ * @brief Record a subsystem's boot result. Called from main.c init phases.
+ *
+ * Only the fields without a live runtime accessor (currently the camera) are
+ * read back from here; the rest are refreshed live in self_report_collect().
+ * Recording all three still feeds the boot-time summary log.
+ */
+void self_report_note_init(self_report_subsystem_t subsystem, bool ok);
+
+/**
+ * @brief Fill @p out with the current health snapshot.
+ *
+ * Refreshes the dynamic bits from live accessors (wifi_is_connected,
+ * i2c_bus_is_ready, audio_player_is_ready, gpio_expander_available,
+ * get_gemini_api_key) and folds in the boot-recorded camera result.
+ */
+void self_report_collect(robocar_status_t *out);
+
+/**
+ * @brief Whether the robot can currently speak: WiFi + API key + audio.
+ */
+bool self_report_voice_able(const robocar_status_t *status);
+
+/**
+ * @brief Render the snapshot as a compact `key=state` facts line.
+ *
+ * Used for BOTH the Gemini narration prompt and the on-device template
+ * fallback, and for the serial/MQTT diagnostic log.
+ *
+ * @return strlen of the written string (may be truncated to @p len - 1).
+ */
+size_t self_report_format_facts(const robocar_status_t *status, char *buf, size_t len);
+
+/**
+ * @brief Start the status monitor task (Core 1).
+ *
+ * Polls ~every 3 s: logs (and MQTT-publishes) the facts, and — when voice-able
+ * and either announcing for the first time or the health signature changed —
+ * narrates a spoken line and posts it to the speech_queue. Idempotent.
+ *
+ * @return ESP_OK, or ESP_FAIL if the task could not be created.
+ */
+esp_err_t self_report_start(void);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## What

When the robocar becomes *able to speak*, it now introduces itself and narrates its subsystem status in natural language — and re-announces when a subsystem's health changes. This closes a real gap surfaced during bring-up: a bare board with no I2C hardware was silent, with no feedback about what came up.

## Why

The voice pipeline (MAX98357A + Gemini TTS, ADR-019) previously only spoke when the vision planner emitted a `speak`. There was no way for the robot to tell you it's alive or which subsystems initialized.

## How

A new `self_report` module gathers each subsystem's real state deterministically, detects the "voice-able" edge + health changes, asks Gemini to phrase the live facts as one short spoken line, and posts it to the existing `speech_queue`.

- **Facts are never hallucinated.** They're gathered on-device; a lightweight Gemini **text** call only *phrases* them, with an on-device **template fallback** if the call fails.
- **Cadence:** once when first voice-able, then re-announce on a health-signature change (debounced one cycle, rate-limited ~15 s).
- **Always observable:** facts are logged (and MQTT-published when connected) even while the robot can't talk.
- **Camera-independent:** the monitor task can report "camera not responding" even when the planner can't run.

### Changes
- New `main/self_report.{h,c}` — snapshot struct, boot-result note, live `collect`, voice-able edge, compact facts string, Core-1 monitor task.
- `gemini_backend_narrate()` — text-only `generateContent` to a flash text model (`gemini-flash-latest`), self-contained (own HTTP client + response buffer + key), so it never races the planner's shared response buffer.
- Health accessors: `i2c_bus_is_ready()`, `audio_player_is_ready()`. The MCP23017 reuses the existing `gpio_expander_available()`.
- `main.c` wiring: record each init phase result, make camera init non-fatal so status stays reportable, start the monitor after the speech path is up.

Independent of #418 (boot fixes, merged) and the #420 I2C migration — touches none of the same lines.

## Verification
- [x] `just robocar-unified::build` (containerized ESP-IDF v5.4) — compiles clean; binary uses 32% of the app partition (68% free).
- [x] `clang-format` + `cppcheck` clean on changed files.
- [ ] **Hardware (manual, pending):** flash (erase NVS first per the compiled-key precedence gotcha), then on a bare board confirm the spoken intro names working parts + "motors/I2C not responding"; drop/restore WiFi to see a re-announce; point `NARRATE_MODEL` at a bad id to confirm the template fallback still speaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)