### PR TITLE
fix(robocar-unified): size ultrasonic RMT RX block to the SoC minimum (48)

### DIFF
--- a/packages/robocar/unified/main/ultrasonic.c
+++ b/packages/robocar/unified/main/ultrasonic.c
@@ -46,12 +46,17 @@ static const char *TAG = "ultrasonic";
 #define RMT_RESOLUTION_HZ 1000000U
 
 /**
- * Maximum echo pulse the RMT RX FIFO must hold.
- * HC-SR04P echo pulse for 6 m = ~35 000 µs.  One rmt_symbol_word_t stores a
- * single level/duration pair; we only ever see one echo pulse so a buffer of 2
- * symbols is sufficient (echo HIGH + trailing LOW).
+ * RMT RX memory-block size in symbols.
+ *
+ * We only ever need one echo pulse (echo HIGH + trailing LOW = 2 symbols), but
+ * ESP-IDF v5.4's rmt_new_rx_channel() requires mem_block_symbols to be even and
+ * at least one channel memory block — 48 on the ESP32-S3
+ * (SOC_RMT_MEM_WORDS_PER_CHANNEL). A smaller value (this was 4) fails init with
+ * ESP_ERR_INVALID_ARG ("mem_block_symbols must be even and at least 48"), which
+ * silently drops the driver into the slower GPIO polling fallback on every boot.
+ * 48 = exactly one memory block; the same constant sizes s_rx_buf (192 bytes).
  */
-#define RMT_RX_BUFFER_SYMBOLS 4U
+#define RMT_RX_BUFFER_SYMBOLS 48U
 
 /* -------------------------------------------------------------------------
  * Module state


### PR DESCRIPTION
## What

`rmt_new_rx_channel()` fails on **every boot** and the ultrasonic driver silently falls back to GPIO polling:

```
rmt: rmt_new_rx_channel(197): mem_block_symbols must be even and at least 48
ultrasonic: RMT RX channel unavailable (ESP_ERR_INVALID_ARG) — falling back to GPIO poll
```

## Why

`RMT_RX_BUFFER_SYMBOLS` was **4**, but ESP-IDF v5.4 requires `mem_block_symbols` to be **even and ≥ one channel memory block** — **48** on the ESP32-S3 (`SOC_RMT_MEM_WORDS_PER_CHANNEL`). So the RMT RX path never initialized; the driver used its slower GPIO **polling fallback** every boot.

That fallback busy-waits out its echo timeout (40 ms), which is exactly what made the 30 Hz reactive loop overrun its 33 ms period and starve IDLE0 → Core-0 task watchdog on a board with no sensor fitted. (That watchdog is independently guarded by the loop-yield fix in #421; this restores the *intended* path so the busy-wait isn't hit at all.)

## How

Bump `RMT_RX_BUFFER_SYMBOLS` 4 → **48** (exactly one memory block, even). RMT RX now initializes and the driver uses its interrupt-driven, **blocking** path (`ulTaskNotifyTake`), which yields to the scheduler instead of busy-waiting. The same constant sizes `s_rx_buf` (now 192 bytes); we still only read `symbol[0]`.

## Evidence
Decoded live from a XIAO ESP32-S3 Sense boot log during robocar bring-up.

## Verification
- [x] Builds clean (containerized ESP-IDF v5.4).
- [ ] **Hardware (manual, pending):** with a real HC-SR04 fitted, confirm `ultrasonic: Ultrasonic driver ready (RMT RX mode, ...)` instead of the poll-mode line, and that distance measurements are sane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)