### PR TITLE
fix(robocar-unified): make the ultrasonic RMT receive path functional (signal ranges + no-echo recovery)

### DIFF
--- a/packages/robocar/unified/main/ultrasonic.c
+++ b/packages/robocar/unified/main/ultrasonic.c
@@ -259,8 +259,16 @@ esp_err_t ultrasonic_measure(uint16_t *distance_cm)
         uint32_t notified = ulTaskNotifyTake(pdTRUE, timeout_ticks);
 
         if (notified == 0) {
-            /* Timeout — cancel any pending receive */
+            /* Timeout — no echo ever completed the receive (no sensor fitted, or
+             * the target is out of range), so the RX-done callback never fired
+             * and the channel FSM is stuck in RMT_FSM_RUN. rmt_receive() requires
+             * RMT_FSM_ENABLE, so without aborting here a single missed echo wedges
+             * the channel and every subsequent receive fails with
+             * ESP_ERR_INVALID_STATE. A disable/enable cycle takes RUN -> INIT ->
+             * ENABLE, re-arming it for the next measurement. */
             s_waiting_task = NULL;
+            rmt_disable(s_rx_chan);
+            rmt_enable(s_rx_chan);
             ESP_LOGD(TAG, "Echo timeout");
             *distance_cm = ULTRASONIC_DIST_ERROR;
             return ESP_FAIL;

--- a/packages/robocar/unified/main/ultrasonic.c
+++ b/packages/robocar/unified/main/ultrasonic.c
@@ -223,13 +223,22 @@ esp_err_t ultrasonic_measure(uint16_t *distance_cm)
     /* ---- RMT path ---- */
     if (s_mode == DRIVER_RMT) {
         /*
-         * Configure the RMT receive window.  We expect:
-         *   - signal_range_min_ns: reject glitches < 10 µs  (10 000 ns)
-         *   - signal_range_max_ns: stop capture at 38 ms    (38 000 000 ns)
+         * Configure the RMT receive window. Both bounds are constrained by the
+         * hardware register widths (ESP-IDF v5.4 rmt_receive validates them):
+         *
+         *   - signal_range_min_ns (glitch filter): counted on the RMT SOURCE
+         *     clock (~80 MHz), whose threshold register is 8-bit (max 255). So
+         *     min_ns must be <= ~3187 ns; the previous 10 000 ns overflowed it
+         *     (800 > 255 -> "signal_range_min_ns too big"). 1 µs still rejects
+         *     electrical glitches and passes any real echo (>= 58 µs = 1 cm).
+         *   - signal_range_max_ns (idle threshold): counted on the 1 MHz channel
+         *     resolution, register max 32767 -> max_ns must be <= 32.767 ms; the
+         *     previous 38 ms overflowed it. 30 ms comfortably covers the 4 m
+         *     (~23.2 ms) max echo (ULTRASONIC_MAX_RANGE_CM) with headroom.
          */
         rmt_receive_config_t recv_cfg = {
-            .signal_range_min_ns = 10000U,    /* 10 µs  */
-            .signal_range_max_ns = 38000000U, /* 38 ms  */
+            .signal_range_min_ns = 1000U,     /* 1 µs glitch filter (hw 8-bit @ source clk) */
+            .signal_range_max_ns = 30000000U, /* 30 ms idle (hw cap 32.767 ms @ 1 MHz)      */
         };
 
         s_echo_us = 0;


### PR DESCRIPTION
## What

Follow-up to #422 (RMT RX buffer size). With the channel initializing, `rmt_receive()` failed — and peeling that back revealed **two** latent bugs in the RMT receive path, both previously masked by the init failure. This PR fixes both so the RMT ultrasonic path actually works end to end.

### 1. Invalid `signal_range_*` values (commit 1)
```
rmt: rmt_receive(414): signal_range_min_ns too big
```
Both bounds exceeded the RMT hardware register widths (ESP-IDF v5.4 validates them in `rmt_receive`):

| Field | Counted on | Reg max | Old → ticks | Fix |
|---|---|---|---|---|
| `signal_range_min_ns` (glitch filter) | RMT **source** clock (~80 MHz) | 255 (8-bit) | 10 µs → **800** | **1 µs** (80) |
| `signal_range_max_ns` (idle threshold) | 1 MHz channel resolution | 32767 (15-bit) | 38 ms → **38000** | **30 ms** (30000) |

1 µs still rejects glitches / passes any real echo (≥ 58 µs); 30 ms still covers the 4 m / ~23.2 ms max echo (`ULTRASONIC_MAX_RANGE_CM`) under the 32.767 ms cap.

### 2. Channel wedged after a no-echo timeout (commit 2)
```
rmt: rmt_receive(419): channel not in enable state
ultrasonic: rmt_receive failed: ESP_ERR_INVALID_STATE
```
`rmt_receive()` requires FSM `RMT_FSM_ENABLE` and moves it to `RUN`. When no echo completes the receive (no sensor, or target out of range) the RX-done callback never fires, so the channel stays stuck in `RUN` and **every subsequent receive fails** — a single missed echo would wedge the sensor permanently even with real hardware. The timeout branch intended to "cancel any pending receive" but only cleared `s_waiting_task`; it never aborted. Added the real abort: a `rmt_disable()`/`rmt_enable()` cycle (`RUN → INIT → ENABLE`, verified against `esp_driver_rmt/src/rmt_rx.c`).

## Evidence
All limits/transitions read from the ESP-IDF v5.4 source (`esp_driver_rmt/src/rmt_rx.c`, `hal/esp32s3/include/hal/rmt_ll.h`), not guessed. Both errors observed live on a XIAO ESP32-S3 Sense during bring-up.

## Verification
- [x] Builds clean (containerized ESP-IDF v5.4).
- [ ] **Hardware (manual, pending):** with an HC-SR04 fitted, confirm no `rmt_receive failed` spam and sane distances in RMT mode. On a sensor-less board it now cleanly times out and re-arms each cycle (no spam, distance = max range).

Together with #422 this is the full RMT-path fix. Without commit 2, #422+commit 1 alone just trade one per-loop error for another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)