### PR TITLE
fix(robocar-unified): give the self_report task an 8 KB stack for its TLS call

### DIFF
--- a/packages/robocar/unified/main/self_report.c
+++ b/packages/robocar/unified/main/self_report.c
@@ -27,7 +27,11 @@ static const char *TAG = "self_report";
 /* Task tuning                                                                 */
 /* -------------------------------------------------------------------------- */
 
-#define STATUS_MONITOR_TASK_STACK_SIZE 4096U
+/* 8 KB, matching the planner task: this task calls gemini_backend_narrate(),
+ * which opens an HTTPS/TLS connection (esp_http_client + mbedTLS + cJSON). The
+ * TLS handshake alone needs several KB of stack — 4 KB overflowed (crash in the
+ * self_report task the moment narration reached the handshake). */
+#define STATUS_MONITOR_TASK_STACK_SIZE 8192U
 #define STATUS_MONITOR_TASK_PRIORITY 2U
 #define STATUS_MONITOR_TASK_CORE 1  //!< bursty + network-bound, like the planner
 


### PR DESCRIPTION
## What

The status-monitor task crashed the board on the **first spoken announcement**:

```
***ERROR*** A stack overflow in task self_report has been detected.
Rebooting...
```

## Why

`self_report_start()` created the task with a **4 KB** stack, but its narration path calls `gemini_backend_narrate()` → an HTTPS request (`esp_http_client` + mbedTLS + cJSON). A TLS handshake alone needs several KB of stack, so 4 KB overflowed.

It was **intermittent** only because a DNS failure can short-circuit the request before the deep handshake path (the second boot survived because `getaddrinfo` failed first). **Once DNS resolves and a real handshake runs, it overflows every time** — so this blocks the actual Gemini-narrated self-report.

## How

Raise the stack to **8 KB**, matching `planner_task`, which makes the equivalent Gemini HTTPS call (`gemini_backend_plan`) and runs comfortably at that size.

## Evidence
Observed live on a XIAO ESP32-S3 Sense: the `self_report` task overflowed right after its first status line + first narration attempt, followed by a reboot.

## Verification
- [x] Builds clean (containerized ESP-IDF v5.4).
- [ ] **Hardware (manual, pending):** boot no longer reboots on the first announcement; the self-report speaks (template while DNS is still being sorted, real Gemini line once DNS resolves).

Fixes a bug in the self-report feature (#421). Independent of the RMT ultrasonic fixes (#422 / #424).

🤖 Generated with [Claude Code](https://claude.com/claude-code)