### PR TITLE
docs(rules): ESP-IDF RMT-RX and FreeRTOS task gotchas from robocar bring-up

### DIFF
--- a/.claude/rules/esp-idf-rmt-rx.md
+++ b/.claude/rules/esp-idf-rmt-rx.md
@@ -1,0 +1,69 @@
+# ESP-IDF v5.4 RMT RX: Three Hardware-Register Constraints (and a Fallback That Hides Them)
+
+The RMT RX peripheral (used here for HC-SR04 ultrasonic echo timing) has three
+config constraints enforced against **hardware register widths**. Violating any
+one fails a different call, and — critically — this driver falls back to a
+GPIO-polling mode on RMT failure, so a broken RMT config is **silent**: the
+device still "works" (degraded) and you never see the error unless you read the
+boot log. All three below were latent in `ultrasonic.c` for exactly this reason;
+each was exposed only after fixing the one before it.
+
+Verify these numbers against the container source, never from memory:
+`esp_driver_rmt/src/rmt_rx.c` + `hal/esp32s3/include/hal/rmt_ll.h`.
+
+## 1. `mem_block_symbols` must be even and ≥ 48 (on ESP32-S3)
+
+`rmt_new_rx_channel()` requires `mem_block_symbols` to be **even and at least one
+channel memory block** — 48 on the ESP32-S3 (`SOC_RMT_MEM_WORDS_PER_CHANNEL`). A
+smaller value fails init with:
+
+```
+rmt: rmt_new_rx_channel(...): mem_block_symbols must be even and at least 48
+```
+
+`ESP_ERR_INVALID_ARG` → the driver drops to the GPIO-poll fallback on **every**
+boot. Set it to 48 (one block) even though you only need ~2 symbols per echo.
+
+## 2. `signal_range_*` map onto different clocks with different register widths
+
+`rmt_receive()` converts both bounds to register values and rejects overflow:
+
+| Field | Counted on | Register | Max value | So the ns bound is |
+|---|---|---|---|---|
+| `signal_range_min_ns` (glitch filter) | RMT **source** clock (~80 MHz) | 8-bit | 255 | ≤ ~3187 ns |
+| `signal_range_max_ns` (idle threshold) | **channel** resolution (e.g. 1 MHz) | 15-bit | 32767 | ≤ 32.767 ms |
+
+`10 µs` min mapped to 800 (> 255) → `signal_range_min_ns too big`; `38 ms` max
+mapped to 38000 (> 32767) → `signal_range_max_ns too big`. Note the min bound is
+tighter than intuition suggests because it counts on the fast **source** clock,
+not the divided channel clock. Working values here: `min = 1 µs` (still rejects
+electrical glitches, passes any echo ≥ 58 µs = 1 cm), `max = 30 ms` (covers the
+4 m / ~23 ms max echo under the 32.767 ms cap).
+
+## 3. A no-echo receive wedges the channel — re-arm it on timeout
+
+`rmt_receive()` requires the channel FSM in `RMT_FSM_ENABLE` and moves it to
+`RUN`. When no echo ever completes the receive (no sensor fitted, or target out
+of range) the RX-done callback never fires, so the FSM stays stuck in `RUN` and
+**every subsequent `rmt_receive()` fails** with `ESP_ERR_INVALID_STATE` ("channel
+not in enable state"). One missed reading wedges the sensor **permanently**, even
+with real hardware. Aborting the pending receive is not automatic — do it in the
+timeout branch:
+
+```c
+if (ulTaskNotifyTake(pdTRUE, timeout_ticks) == 0) {  // no echo
+    rmt_disable(s_rx_chan);   // RUN -> INIT (rmt_rx_disable handles the RUN state)
+    rmt_enable(s_rx_chan);    // INIT -> ENABLE, re-armed for the next measurement
+    ...
+}
+```
+
+## Meta-lesson: a fallback path masks the primary path's bugs
+
+The GPIO-poll fallback made all three RMT bugs invisible for a long time, and
+fixing them surfaced in a chain — init → receive-signal-range → channel-rearm —
+each masked by the failure before it. When a driver has a "degraded but working"
+fallback, assume the primary path is **untested** and read the boot log to
+confirm which mode is actually active (`Ultrasonic driver ready (RMT RX mode …)`
+vs `(GPIO poll mode)`). Expect to peel several bugs once you get the primary path
+past its first error.

--- a/.claude/rules/freertos-task-gotchas.md
+++ b/.claude/rules/freertos-task-gotchas.md
@@ -1,0 +1,59 @@
+# FreeRTOS Task Gotchas on ESP-IDF: Yield-on-Overrun and TLS Stack Sizing
+
+Two independent task-authoring traps found bringing up the robocar-unified
+firmware. Both crash (task watchdog / stack overflow), both are intermittent
+enough to pass a quick test and fail later.
+
+## 1. A periodic task above IDLE must guarantee a yield when the loop overruns
+
+`vTaskDelayUntil()` / `xTaskDelayUntil()` returns **without blocking** when the
+loop body already overran the period (the wake deadline is in the past). A task
+pinned above the idle task that overruns *every* iteration therefore never
+yields — it starves IDLE on that core and trips the **Core-N task watchdog**:
+
+```
+task_wdt: ... IDLE0 (CPU 0) ... CPU 0: <your task>
+```
+
+This bites whenever the loop body can take longer than its period: here a 30 Hz
+(33 ms) reactive loop calling an ultrasonic measurement whose GPIO-poll fallback
+busy-waited its 40 ms echo timeout (40 > 33 → guaranteed overrun with no sensor).
+
+**Fix** — guard the overrun case so IDLE always gets a slot; the healthy path is
+unchanged:
+
+```c
+if (xTaskDelayUntil(&last_wake, pdMS_TO_TICKS(PERIOD_MS)) == pdFALSE) {
+    vTaskDelay(1);                    // let IDLE run
+    last_wake = xTaskGetTickCount();  // resync; don't fire a catch-up burst
+}
+```
+
+**Also a lesson about masking:** this watchdog was *exposed* by making
+`init_camera()` non-fatal — the board used to panic at camera init and reboot
+*before* the reactive loop ever ran. Making a system boot further routinely
+surfaces latent bugs downstream of the point that used to abort. Expect them.
+
+## 2. A task that does an HTTPS/TLS call needs ≥ 8 KB stack
+
+`esp_http_client` + mbedTLS + cJSON burns several KB of stack in the **TLS
+handshake**. A 4 KB task stack overflows there:
+
+```
+***ERROR*** A stack overflow in task <name> has been detected.
+```
+
+It's insidiously **intermittent**: a DNS failure short-circuits the request
+*before* the deep handshake path, so the task survives while DNS is broken and
+then crashes every time once DNS resolves. Size any task that makes an HTTPS call
+at **8 KB** (`xTaskCreatePinnedToCore(..., 8192, ...)`), matching the sibling
+task that makes the same call rather than guessing low.
+
+### Related: TLS cert-date validation needs a clock — unless the build disables it
+
+ESP-IDF's cert-bundle TLS validates certificate `notBefore`/`notAfter` only when
+`CONFIG_MBEDTLS_HAVE_TIME_DATE=y`. This firmware builds with it **unset**, so TLS
+skips date validation and works with an **unsynced clock** — no SNTP/NTP client
+is required for HTTPS. Before adding SNTP (or opening an NTP egress rule) to fix a
+TLS failure, check `sdkconfig` for `MBEDTLS_HAVE_TIME_DATE`: if it's off, the
+clock is not your problem.


### PR DESCRIPTION
## What

Two `.claude/rules/` entries distilled from the robocar-unified hardware bring-up session, both verified against ESP-IDF v5.4 source (`esp_driver_rmt/src/rmt_rx.c`, `hal/esp32s3/include/hal/rmt_ll.h`) rather than memory.

### `esp-idf-rmt-rx.md`
The three RMT RX config constraints enforced against hardware register widths, each of which failed a different call and was masked by the GPIO-poll fallback:
- `mem_block_symbols` even & ≥ 48 on S3 (`SOC_RMT_MEM_WORDS_PER_CHANNEL`)
- `signal_range_min_ns` on the ~80 MHz **source** clock (8-bit, ≤255) vs `signal_range_max_ns` on the **channel** clock (15-bit, ≤32767)
- re-arm the channel with `rmt_disable`/`rmt_enable` after a no-echo timeout or a single miss wedges it permanently
- meta-lesson: a "degraded but working" fallback silently masks the primary path's bugs; expect to peel a chain.

### `freertos-task-gotchas.md`
- A periodic task above IDLE must yield on loop overrun — `xTaskDelayUntil` returns without blocking past the deadline → IDLE starvation → task WDT.
- An HTTPS/TLS task needs ≥ 8 KB stack (4 KB overflows in the handshake; intermittent because a DNS failure short-circuits before it).
- Note: `MBEDTLS_HAVE_TIME_DATE` unset ⇒ TLS skips cert-date validation ⇒ no SNTP/NTP needed for HTTPS with an unsynced clock.

## Why
These are non-obvious, repo-wide ESP-IDF/FreeRTOS traps (apply to any ESP32 project in the monorepo, not just robocar) that cost real debugging time this session. Codifying them so the next encounter is a lookup, not a re-derivation.

## Evidence
PRs #422 / #424 (RMT), #425 (self_report stack), and the reactive-loop watchdog fix in #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)