### PR TITLE
feat(robocar-unified): working Finnish voice — audio-static, Gemini-API, rate-limit fixes + voice personas

### DIFF
--- a/.claude/rules/gemini-api.md
+++ b/.claude/rules/gemini-api.md
@@ -1,0 +1,84 @@
+# Gemini API: Model-ID / thinkingConfig / Token-Budget Drift, and Prompted TTS Style
+
+The Google Gemini API (`generativelanguage.googleapis.com`) is called from
+several projects here — `robocar/unified`, `robocar/camera`,
+`camera-vision/gemini-vision`, `thinkpack/brainbox`, `games/nfc-scavenger-hunt`.
+Its request surface **moves under you**: ids get suffixes, config fields get
+renamed, and moving aliases (`*-latest`) repoint to newer model generations with
+different rules. Firmware written against an older shape then fails with a fast,
+authoritative HTTP error — categorically different from a network hang, and the
+fix is always *ask the API*, never *reason from memory of its shape*. Every item
+below cost a debugging loop in the robocar-unified bring-up (2026-07).
+
+## 1. Model ids drift — verify against ListModels, never guess
+
+A bare `gemini-robotics-er-1.6` **404s** on `v1beta`
+(`"... is not found for API version v1beta, or is not supported for
+generateContent"`); the real id is `gemini-robotics-er-1.6-preview`.
+`gemini-flash-latest` is a *moving alias* now resolving to a Gemini 3-era model.
+Don't invent a suffix — list what the key can actually reach:
+
+```sh
+curl -s -H "x-goog-api-key: $KEY" \
+  "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000" \
+  | jq -r '.models[] | select(.supportedGenerationMethods[]? == "generateContent") | .name'
+```
+
+A 404 with a JSON error body naming `generateContent` is a **wrong id**, not a
+down endpoint. Confirm the id against this list before touching anything else.
+
+## 2. `thinkingConfig`: it's `thinkingLevel`, not `thinkingBudget`
+
+Gemini 3-era models **reject** the numeric `thinkingConfig.thinkingBudget` with a
+bare `HTTP 400 "Request contains an invalid argument"` that names no field. Use
+the string form instead:
+
+```jsonc
+"generationConfig": { "thinkingConfig": { "thinkingLevel": "low" } }
+```
+
+The 400 is opaque by default because it names nothing — **log the response body
+at ERROR level**, not DEBUG, or you get a status code and no clue which field the
+API rejected. (robocar-unified's narrate path hid this at `ESP_LOGD` for exactly
+that reason.)
+
+## 3. `maxOutputTokens` is a *combined* budget — thinking is spent first, and varies
+
+`maxOutputTokens` covers **thinking tokens + reply tokens**, and Gemini 3-era
+models always think. Too small a cap spends the whole budget thinking and returns
+`finishReason: MAX_TOKENS` with the reply truncated mid-word — or empty. Thinking
+is **variable**: measured 487–745 thought tokens for a *24-token* reply, and a
+non-English / persona-styled prompt costs more than plain English (~395). Size
+generously (e.g. 2048 for a one-sentence reply); raising the cap is nearly free
+because thinking tokens are billed whether or not the cap truncates the reply —
+the cap only decides whether the sentence survives. Size from **measurement**
+(`usageMetadata.thoughtsTokenCount`), not a guess.
+
+## 4. Free-tier quota is per-model RPM — pace fixed-rate loops under it
+
+Free tier is a per-model requests-per-minute cap (e.g.
+`gemini-robotics-er-1.6-preview` = **5 req/min**, quota
+`GenerateRequestsPerMinutePerProjectPerModel-FreeTier`). A fixed-rate polling
+loop (robocar's 1 Hz planner = 60 RPM) self-inflicts continuous `HTTP 429`, and
+the `retryDelay` in the body **grows while you keep asking** — so retrying at
+full rate lengthens the outage. Pace the loop under the cap and back off on 429.
+
+## 5. TTS delivery style is *prompted*, not a parameter
+
+For speech generation (`gemini-3.1-flash-tts-preview` etc.) there is no
+style/accent/era field. Delivery is steered by prefixing a natural-language
+directive to the text: `"<style directive>: <text to speak>"`. The directive is
+**interpreted, not read aloud** (verified: a ~40-word directive, 12 s if spoken,
+added 0.36 s of audio). Language is `speechConfig.languageCode` (BCP-47 — `fi-FI`
+works). The prebuilt voices (`Kore`, `Puck`, `Charon`, …) are **language-agnostic**;
+the locale-specific `fi-FI-Chirp3-HD-*` names are **Cloud TTS**, a different
+product, and **404** on the Gemini `generateContent` endpoint — do not put one in
+a request without testing it against `:generateContent` first.
+
+## Meta
+
+An API `404`/`400`/`429` returns a fast, authoritative JSON error body. Read it
+(`jq .error.message`), and for anything id- or capability-shaped, re-derive the
+truth from ListModels — the shape in your head is stale. This is
+`diagnose-at-the-failure-point` applied to a remote API: the failing call's own
+response is the source of truth, above any remembered request shape.

--- a/.claude/skills/audio-static-debugging/SKILL.md
+++ b/.claude/skills/audio-static-debugging/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: audio-static-debugging
+description: Debug static, hiss, or noise on embedded I2S audio (ESP32 + MAX98357A / PCM DACs), especially streamed PCM. Measure the signal at each pipeline stage instead of guessing at the amp. Use when audio plays but sounds wrong.
+user-invocable: true
+argument-hint: "[symptom: static before speech / during / throughout]"
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Debugging Embedded Audio Static / Streaming-PCM Noise
+
+Static on an I2S speaker (MAX98357A, PCM510x, etc.) has several distinct causes
+that sound similar to the human reporting them, and the wrong ones are seductive
+because they're about *hardware* — the amp, the clock, the ground. This skill
+exists because in the robocar-unified voice bring-up (2026-07) **two hardware
+theories were wrong** (uninitialised DMA content; BCLK stop/start pops) and cost
+several reflash cycles each. The fix only came from **measuring the actual
+samples** at each stage. Measure first; theorise last.
+
+## The one law
+
+**You cannot hear the audio; the user can, and the samples can.** Do not reason
+about the amp/clock/DMA from the symptom word "static." Get the PCM bytes and
+compute statistics on them — that localises the corruption to a pipeline stage
+in one pass, with no hardware and no guessing.
+
+## Step 1 — get a precise symptom from the user (it discriminates the cause)
+
+"Terrible static" underdetermines everything. Ask which:
+
+| Symptom | Most likely stage |
+|---|---|
+| Static **before/after** the line, silence-adjacent | Amp idle / clock-gating / floating DIN (analog) |
+| Speech **intelligible but with static bursts**, or alternating clean↔noise | **Sample misalignment** in the transport (see Step 3) |
+| Speech **fully garbled**, no words | Format mismatch: endianness, bit width, or sample rate |
+| Faint constant hiss under clean speech | Amp noise floor / gain / power rail |
+
+## Step 2 — prove whether the *source* data is clean (before blaming the pipeline)
+
+Capture the PCM the device receives (e.g. the base64 `inlineData` from a TTS
+response, or a dump from the decode buffer) and characterise it. Clean speech
+and byte-swapped/garbage have unmistakably different statistics:
+
+```sh
+python3 - <<'PY'
+import json, base64, struct, math
+raw = base64.b64decode(json.load(open("resp.json"))
+        ["candidates"][0]["content"]["parts"][0]["inlineData"]["data"])
+n = len(raw)//2
+def stats(fmt, label):
+    s = struct.unpack(("<" if fmt=="LE" else ">")+"%dh"%n, raw[:n*2])
+    rms = math.sqrt(sum(x*x for x in s)/n)
+    big = sum(1 for x in s if abs(x) > 16384)/n            # fraction past half-scale
+    zc  = sum(1 for i in range(1,n) if (s[i-1]>=0)!=(s[i]>=0))/(n-1)  # zero-cross rate
+    print(f"{label}: RMS={rms:7.0f}  >half-scale={big*100:4.1f}%  zero-cross={zc*100:4.1f}%")
+stats("LE","little-endian"); stats("BE","big-endian")
+PY
+```
+
+- **Clean speech**: low zero-cross rate (~5–15%), few samples past half-scale
+  (~1–3%), moderate RMS. The interpretation that yields this is the correct one.
+- **Byte-swapped / garbage**: zero-cross ~40–50% (near-random), ~40% past
+  half-scale, high RMS.
+
+Real finding: Gemini TTS advertises `audio/L16` (nominally **big-endian** per
+RFC) but actually returns **little-endian** — the LE stats were clean, BE was
+noise. **Verify endianness from the data before swapping bytes**; a "fix" based
+on the label would have broken working audio. If the source is clean, the
+corruption is downstream — go to Step 3.
+
+## Step 3 — the streaming-PCM alignment trap (the robocar root cause)
+
+**16-bit samples must never be split across a transport boundary.** The classic
+break, and the one that produced "speech + terrible static, alternating":
+
+- A FreeRTOS `RINGBUF_TYPE_BYTEBUF` (byte-granular) carries the PCM.
+- The producer feeds it **odd-length** chunks — a base64 decoder emits **3-byte**
+  groups per quartet, and 3 is odd.
+- The consumer reads `got` bytes and does `samples = got / sizeof(int16_t)`, then
+  returns the whole item — so an **odd `got` drops the straggler byte**.
+- That drop shifts every subsequent sample by one byte. The shift is
+  **cumulative**: after an even number of drops the stream is re-aligned (clean),
+  after an odd number it's misaligned (static) — hence the audio oscillates
+  between clean speech and loud static, which is the tell.
+
+**Fix — keep the ring 16-bit aligned end to end.** Hold back an odd trailing
+byte in the writer and prepend it to the next write, so only even-length runs
+enter the ring (splice the carried byte + the first new byte into one 2-byte
+sample, send the even remainder, carry any new odd tail). Reset the carry at
+utterance end/abort so a half-sample can't bleed into the next utterance. With
+even writes into an even-sized buffer and even-sized reads, alignment holds
+through wraps. See `packages/robocar/unified/main/audio_player.c`
+(`audio_player_write`) for the reference implementation.
+
+Related sizing gotcha found the same day: the speech text buffer
+(`SPEECH_TEXT_MAX`) must fit the *rendered* sentence — Finnish words are long, so
+a 25-word line ran ~250 chars and a 160-char buffer truncated both text and
+audio mid-word. Size for the language.
+
+## Step 4 — only now consider the analog side
+
+If the source is clean AND the transport is aligned AND it still hisses/pops in
+the **silence around** speech, it's the amp: the MAX98357A has no shutdown GPIO
+on this board (budget full), so it amplifies continuously; gating BCLK / letting
+DIN float between utterances pops. Options, in order: drive continuous zeros
+(keep the channel enabled, feed silence when idle — trades pop for a possible
+faint hiss), or gate the amp's SD pin via a freed/expander GPIO. Judge by ear —
+this is the one part only the user can settle.
+
+## Rationale
+
+Every wrong turn in this bug was a *hardware* theory reasoned from the word
+"static"; every correct step was a *measurement* of the bytes. The statistics
+test in Step 2 costs one `python3` run and tells you which stage is lying. This
+is `diagnose-at-the-failure-point` for audio: the samples at each stage are the
+authoritative source, above any theory about the amp.

--- a/packages/robocar/unified/main/CMakeLists.txt
+++ b/packages/robocar/unified/main/CMakeLists.txt
@@ -15,6 +15,7 @@ idf_component_register(
         "speech_queue.c"
         "audio_player.c"
         "gemini_tts.c"
+        "voice_persona.c"
         "ultrasonic.c"
         "reactive_controller.c"
         "planner_task.c"

--- a/packages/robocar/unified/main/audio_player.c
+++ b/packages/robocar/unified/main/audio_player.c
@@ -92,10 +92,36 @@ static void mono_to_stereo(const int16_t *mono, size_t count, int16_t *stereo)
     }
 }
 
+/** Fill the TX DMA buffers with silence while the channel is still in READY
+ *  state. i2s_channel_enable() starts clocking the DMA buffers out immediately,
+ *  before the first i2s_channel_write() can land — so without this the amp
+ *  reproduces whatever those buffers happen to hold: uninitialised memory on
+ *  the first utterance, and the stale tail of the previous clip on every one
+ *  after (the channel is disabled mid-buffer at end of utterance). That is a
+ *  burst of full-scale static in front of every clip. chan_cfg.auto_clear does
+ *  not cover this: it zeroes on *underrun*, not at enable time.
+ *  i2s_channel_preload_data() is only valid before enable, which is why this
+ *  runs here rather than after. */
+static void preload_silence(void)
+{
+    static const int16_t silence[PLAYER_CHUNK_SAMPLES * 2] = {0};
+    size_t loaded = 0;
+    do {
+        loaded = 0;
+        if (i2s_channel_preload_data(s_tx_chan, silence, sizeof(silence), &loaded) != ESP_OK) {
+            return;
+        }
+        // A short load means the DMA buffers are full.
+    } while (loaded == sizeof(silence));
+}
+
 static void channel_set_active(bool active)
 {
     if (active == s_channel_active) {
         return;
+    }
+    if (active) {
+        preload_silence();
     }
     const esp_err_t err = active ? i2s_channel_enable(s_tx_chan) : i2s_channel_disable(s_tx_chan);
     if (err != ESP_OK) {

--- a/packages/robocar/unified/main/audio_player.c
+++ b/packages/robocar/unified/main/audio_player.c
@@ -36,6 +36,11 @@ static TaskHandle_t s_task = NULL;
 static volatile bool s_channel_active = false;
 static volatile bool s_utterance_ended = false;
 
+/* Odd trailing byte held back from the previous audio_player_write so only
+ * 16-bit-aligned runs enter the ring. See audio_player_write. */
+static uint8_t s_carry = 0;
+static bool s_have_carry = false;
+
 /* ------------------------------------------------------------------ */
 /* I2S setup                                                           */
 /* ------------------------------------------------------------------ */
@@ -207,6 +212,20 @@ esp_err_t audio_player_init(void)
     return ESP_OK;
 }
 
+static esp_err_t ring_send(const uint8_t *p, size_t n, uint32_t timeout_ms)
+{
+    if (n == 0) {
+        return ESP_OK;
+    }
+    // Blocking send is deliberate backpressure: the download must not outrun
+    // real-time playback, or a long utterance would need unbounded PSRAM.
+    if (xRingbufferSend(s_ring, p, n, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
+        ESP_LOGW(TAG, "ring full for %ums — dropping %u bytes", (unsigned)timeout_ms, (unsigned)n);
+        return ESP_ERR_TIMEOUT;
+    }
+    return ESP_OK;
+}
+
 esp_err_t audio_player_write(const uint8_t *pcm, size_t bytes, uint32_t timeout_ms)
 {
     if (!s_ring) {
@@ -218,20 +237,43 @@ esp_err_t audio_player_write(const uint8_t *pcm, size_t bytes, uint32_t timeout_
 
     s_utterance_ended = false;
 
-    // Blocking send is deliberate backpressure: the download must not outrun
-    // real-time playback, or a long utterance would need unbounded PSRAM.
-    if (xRingbufferSend(s_ring, pcm, bytes, pdMS_TO_TICKS(timeout_ms)) != pdTRUE) {
-        ESP_LOGW(TAG, "ring full for %ums — dropping %u bytes", (unsigned)timeout_ms,
-                 (unsigned)bytes);
-        return ESP_ERR_TIMEOUT;
+    /* Keep the byte ring 16-bit aligned. The base64 decoder emits 3-byte
+     * groups, so `bytes` is frequently odd; sending odd-length runs into a
+     * RINGBUF_TYPE_BYTEBUF lets a 16-bit sample straddle a read boundary, and
+     * the player (got / sizeof(int16_t), then returns the whole item) drops the
+     * straggler byte and shifts every following sample by one — loud static.
+     * Because the shift is cumulative, the stream oscillates between aligned
+     * (clean) and misaligned (static) as the drops accumulate. Holding the odd
+     * trailing byte back until the next write keeps only even runs in the ring,
+     * so no sample is ever split. Producer-side (TTS task) only — the player
+     * merely reads — so s_carry needs no lock. */
+    esp_err_t err;
+    if (s_have_carry) {
+        const uint8_t splice[2] = {s_carry, pcm[0]};  // complete the straddled sample
+        if ((err = ring_send(splice, 2, timeout_ms)) != ESP_OK) {
+            return err;
+        }
+        s_have_carry = false;
+        pcm++;
+        bytes--;
     }
-
+    const size_t even = bytes & ~(size_t)1;
+    if ((err = ring_send(pcm, even, timeout_ms)) != ESP_OK) {
+        return err;
+    }
+    if (bytes & 1) {
+        s_carry = pcm[even];
+        s_have_carry = true;
+    }
     return ESP_OK;
 }
 
 void audio_player_end_utterance(void)
 {
     s_utterance_ended = true;
+    // Drop a dangling half-sample (≤1 byte, inaudible) so it cannot prepend to,
+    // and misalign, the next utterance.
+    s_have_carry = false;
 }
 
 void audio_player_abort(void)
@@ -239,6 +281,8 @@ void audio_player_abort(void)
     if (!s_ring) {
         return;
     }
+
+    s_have_carry = false;  // discard any half-sample so the next utterance starts aligned
 
     // Drain whatever is queued without playing it.
     for (;;) {

--- a/packages/robocar/unified/main/config.h
+++ b/packages/robocar/unified/main/config.h
@@ -48,6 +48,16 @@
 // gemini_backend.c owns its own URL and model constants; nothing to configure here.
 
 // ========================================
+// Voice Persona
+// ========================================
+// Language + delivery style of everything the robot says. This is only the
+// boot default — the persona and the TTS voice are switchable at runtime with
+// the `voice` console command and persist in NVS, so tuning by ear does not
+// need a reflash. See voice_persona.h for how a persona reaches the words, the
+// audio, and the offline fallback line.
+#define VOICE_PERSONA_DEFAULT VOICE_PERSONA_FI_1950
+
+// ========================================
 // MQTT Remote Logging Configuration
 // ========================================
 #define MQTT_LOGGING_ENABLED 1

--- a/packages/robocar/unified/main/gemini_backend.c
+++ b/packages/robocar/unified/main/gemini_backend.c
@@ -35,7 +35,11 @@ static const char *TAG = "gemini_backend";
 /* Constants                                                                   */
 /* -------------------------------------------------------------------------- */
 
-#define GEMINI_MODEL "gemini-robotics-er-1.6"
+/* Model id must carry the "-preview" suffix — the bare "gemini-robotics-er-1.6"
+ * 404s on v1beta ("not found ... or is not supported for generateContent").
+ * Verified against ListModels (2026-07): the API advertises
+ * gemini-robotics-er-1.6-preview and gemini-robotics-er-1.5-preview. */
+#define GEMINI_MODEL "gemini-robotics-er-1.6-preview"
 #define GEMINI_BASE_URL \
     "https://generativelanguage.googleapis.com/v1beta/models/" GEMINI_MODEL ":generateContent"
 
@@ -50,9 +54,20 @@ static const char *TAG = "gemini_backend";
  *  buffer. A one-sentence reply is tiny; 4 kB also absorbs an error body. */
 #define NARRATE_RESPONSE_BUF_SIZE (4 * 1024)
 #define NARRATE_TIMEOUT_MS 15000
-/** Ample for one ≤25-word sentence; keeps thinking-capable models from
- *  spending the whole budget before emitting text. */
-#define NARRATE_MAX_OUTPUT_TOKENS 128
+/** Must cover thinking tokens *plus* the sentence: maxOutputTokens is the
+ *  combined budget, and thinking is spent first. gemini-flash-latest resolves to
+ *  a Gemini 3-era model that always thinks, so too small a value spends the whole
+ *  budget on thinking and returns finishReason=MAX_TOKENS with a sentence cut off
+ *  mid-word — or no text at all.
+ *
+ *  Sized from measurement, not guesswork, because thinking is *variable*: the
+ *  same prompt used 487–745 thought tokens across runs (a persona brief costs
+ *  more than plain English — that same prompt cost 395 in English). 512
+ *  truncated every time; 1024 happened to pass but leaves too little margin
+ *  above an observed 745. Raising the ceiling is close to free — thinking tokens
+ *  are billed whether or not the cap truncates the reply, so the cap only
+ *  decides if the sentence survives. */
+#define NARRATE_MAX_OUTPUT_TOKENS 2048
 
 /** HTTP response buffer.  16 kB matches the reference client; function-call
  *  responses are much smaller but the buffer is also used to absorb error
@@ -528,10 +543,15 @@ static char *build_narrate_json(const char *facts, bool is_update)
     cJSON *gen_config = cJSON_AddObjectToObject(root, "generationConfig");
     cJSON_AddNumberToObject(gen_config, "maxOutputTokens", NARRATE_MAX_OUTPUT_TOKENS);
     cJSON_AddNumberToObject(gen_config, "temperature", 0.7);
-    /* Disable thinking so the token budget is spent on the reply, not silent
-     * reasoning (a flash text model would otherwise risk an empty completion). */
+    /* Hold thinking down so most of the token budget reaches the reply.
+     * NOTE: the field is "thinkingLevel", not "thinkingBudget" — the numeric
+     * thinkingBudget is rejected outright by the Gemini 3-era model behind
+     * gemini-flash-latest, which is what made every narrate call fail with a
+     * bare HTTP 400 "Request contains an invalid argument". These models
+     * always think, so thinking cannot be switched off entirely; budget for it
+     * via NARRATE_MAX_OUTPUT_TOKENS instead. */
     cJSON *thinking = cJSON_AddObjectToObject(gen_config, "thinkingConfig");
-    cJSON_AddNumberToObject(thinking, "thinkingBudget", 0);
+    cJSON_AddStringToObject(thinking, "thinkingLevel", "low");
 
     char *body = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -650,7 +670,10 @@ esp_err_t gemini_backend_narrate(const char *facts, bool is_update, char *out, s
     if (err != ESP_OK || status != 200) {
         ESP_LOGW(TAG, "narrate request failed: %s status=%d", esp_err_to_name(err), status);
         if (acc.len > 0) {
-            ESP_LOGD(TAG, "narrate error body: %.*s", (int)acc.len, acc.buf);
+            /* Error at E, matching the planner path: at D this body is hidden
+             * at the default log level, which left a 400 showing only its
+             * status code and no indication of which field the API rejected. */
+            ESP_LOGE(TAG, "narrate error body: %.*s", (int)acc.len, acc.buf);
         }
         err = ESP_FAIL;
         goto cleanup;

--- a/packages/robocar/unified/main/gemini_backend.c
+++ b/packages/robocar/unified/main/gemini_backend.c
@@ -28,6 +28,8 @@
 #include "esp_timer.h"
 #include "gemini_parse.h"
 #include "goal_state.h"
+#include "planner_task.h"  /* PLANNER_LOOP_PERIOD_MS — keeps the stated cadence honest */
+#include "voice_persona.h"
 
 static const char *TAG = "gemini_backend";
 
@@ -309,17 +311,25 @@ static cJSON *build_tools(void)
  */
 static char *build_request_json(const char *b64_image)
 {
-    static const char *SYSTEM_PROMPT =
-        "You are the planning brain of a small wheeled robot. "
-        "Examine the image and choose exactly one movement for the robot to take next "
-        "by calling one of: drive, track, rotate, or stop. "
-        "Prefer 'track' when a target object is visible and centred in the frame. "
-        "Call 'stop' when the path is blocked or the scene is ambiguous. "
-        "You may ALSO call 'speak' in the same response to say one short sentence out "
-        "loud — do so only when the scene has changed in a way worth remarking on, not "
-        "on every frame. You are consulted about once per second, so narrating "
-        "continuously would be incoherent. "
-        "Respond ONLY with function calls — no prose, no markdown.";
+    /* Built per call rather than static: the spoken register follows the active
+     * persona, which is switchable at runtime. The cadence is stated from
+     * PLANNER_LOOP_PERIOD_MS so the model's sense of how often it is consulted
+     * cannot drift from the loop that actually calls it. */
+    char system_prompt[1536];
+    snprintf(system_prompt, sizeof(system_prompt),
+             "You are the planning brain of a small wheeled robot. "
+             "Examine the image and choose exactly one movement for the robot to take next "
+             "by calling one of: drive, track, rotate, or stop. "
+             "Prefer 'track' when a target object is visible and centred in the frame. "
+             "Call 'stop' when the path is blocked or the scene is ambiguous. "
+             "You may ALSO call 'speak' in the same response to say one short sentence out "
+             "loud — do so only when the scene has changed in a way worth remarking on, not "
+             "on every frame. You are consulted about every %u seconds, so narrating "
+             "every time would be tiresome. "
+             "When you do call 'speak', the spoken text MUST follow this voice: %s "
+             "Respond ONLY with function calls — no prose, no markdown.",
+             PLANNER_LOOP_PERIOD_MS / 1000U, voice_persona_get()->text_brief);
+    const char *SYSTEM_PROMPT = system_prompt;
 
     cJSON *root = cJSON_CreateObject();
 
@@ -515,15 +525,16 @@ cleanup:
 /** Build the text-only generateContent body for a spoken status line. */
 static char *build_narrate_json(const char *facts, bool is_update)
 {
-    char prompt[1024];
+    char prompt[2048];
     snprintf(prompt, sizeof(prompt),
              "You are a small wheeled robot named Robocar, speaking aloud. "
+             "Voice and language to use: %s\n\n"
              "Here are your live on-device subsystem facts:\n%s\n\n"
              "%s"
              "Write ONE short, friendly spoken sentence (at most 25 words, plain text only — "
              "no markdown, no emoji, no quotes) %s and stating your status, naming anything that "
              "is not responding. Report only the facts above; do not invent hardware.",
-             facts,
+             voice_persona_get()->text_brief, facts,
              is_update ? "This is a status UPDATE: a subsystem's health just changed — keep to "
                          "what changed. "
                        : "",

--- a/packages/robocar/unified/main/gemini_tts.c
+++ b/packages/robocar/unified/main/gemini_tts.c
@@ -21,6 +21,7 @@
 #include "freertos/task.h"
 #include "pin_config.h"
 #include "speech_queue.h"
+#include "voice_persona.h"
 
 static const char *TAG = "gemini_tts";
 
@@ -35,8 +36,8 @@ static const char *TAG = "gemini_tts";
 #define TTS_URL \
     "https://generativelanguage.googleapis.com/v1beta/models/" TTS_MODEL ":generateContent"
 
-/** Prebuilt voice name. */
-#define TTS_VOICE "Kore"
+/* Voice name and language now come from the active persona (voice_persona.h),
+ * so they can be switched at runtime rather than pinned here. */
 
 /** Longer than the planner's budget: synthesis plus transferring a few
  *  hundred kB of base64 is slower than a function-call response. */
@@ -136,11 +137,19 @@ static char *build_request_json(const char *text)
         return NULL;
     }
 
+    const voice_persona_t *persona = voice_persona_get();
+
+    /* Delivery style is prompted, not parameterised — Gemini has no style/accent
+     * field, so the documented form is "<style directive>: <text to speak>".
+     * The directive is interpreted rather than read aloud (measured: a ~40-word
+     * directive, 12+ s if spoken, added 0.36 s of audio). */
     cJSON *contents = cJSON_AddArrayToObject(root, "contents");
     cJSON *content = cJSON_CreateObject();
     cJSON *parts = cJSON_AddArrayToObject(content, "parts");
     cJSON *part = cJSON_CreateObject();
-    cJSON_AddStringToObject(part, "text", text);
+    char styled[SPEECH_TEXT_MAX + 256];
+    snprintf(styled, sizeof(styled), "%s: %s", persona->tts_style, text);
+    cJSON_AddStringToObject(part, "text", styled);
     cJSON_AddItemToArray(parts, part);
     cJSON_AddItemToArray(contents, content);
 
@@ -149,9 +158,12 @@ static char *build_request_json(const char *text)
     cJSON_AddItemToArray(modalities, cJSON_CreateString("AUDIO"));
 
     cJSON *speech_cfg = cJSON_AddObjectToObject(gen_cfg, "speechConfig");
+    cJSON_AddStringToObject(speech_cfg, "languageCode", persona->language_code);
     cJSON *voice_cfg = cJSON_AddObjectToObject(speech_cfg, "voiceConfig");
     cJSON *prebuilt = cJSON_AddObjectToObject(voice_cfg, "prebuiltVoiceConfig");
-    cJSON_AddStringToObject(prebuilt, "voiceName", TTS_VOICE);
+    char voice[VOICE_PERSONA_VOICE_MAX];
+    voice_persona_effective_voice(voice, sizeof(voice));
+    cJSON_AddStringToObject(prebuilt, "voiceName", voice);
 
     char *json = cJSON_PrintUnformatted(root);
     cJSON_Delete(root);
@@ -246,6 +258,9 @@ esp_err_t gemini_tts_start(void)
         return ESP_FAIL;
     }
 
-    ESP_LOGI(TAG, "TTS task started (model=%s voice=%s)", TTS_MODEL, TTS_VOICE);
+    char voice[VOICE_PERSONA_VOICE_MAX];
+    voice_persona_effective_voice(voice, sizeof(voice));
+    ESP_LOGI(TAG, "TTS task started (model=%s persona=%s lang=%s voice=%s)", TTS_MODEL,
+             voice_persona_get()->slug, voice_persona_get()->language_code, voice);
     return ESP_OK;
 }

--- a/packages/robocar/unified/main/goal_state.h
+++ b/packages/robocar/unified/main/goal_state.h
@@ -88,8 +88,16 @@ typedef struct {
  * Constants
  * ========================================================================= */
 
-/** Default freshness window in milliseconds (1.5× the 1 Hz planner period). */
-#define GOAL_STATE_DEFAULT_TTL_MS 1500U
+/** Default freshness window in milliseconds (1.5× PLANNER_LOOP_PERIOD_MS).
+ *
+ *  Tracks the planner period — see the quota note in planner_task.h. The 1.5×
+ *  ratio absorbs per-request latency (2–4 s observed) so a goal does not expire
+ *  in the gap between plans; at 1× the executor would stop-start every cycle.
+ *  Consequence of the slower planner: the robot may act on vision up to ~22 s
+ *  old, so the ultrasonic reflex in reactive_controller.c is what keeps a stale
+ *  drive goal from driving into something. Move this with the planner period,
+ *  never independently. */
+#define GOAL_STATE_DEFAULT_TTL_MS 22500U
 
 /* =========================================================================
  * Public API

--- a/packages/robocar/unified/main/main.c
+++ b/packages/robocar/unified/main/main.c
@@ -45,6 +45,7 @@
 #include "self_report.h"
 #include "servo_controller.h"
 #include "speech_queue.h"
+#include "voice_persona.h"
 #include "system_state.h"
 #include "wifi_manager.h"
 
@@ -243,6 +244,73 @@ static void dispatch_sound(const char *sound)
 //   gpio set <pin> 0|1       - drive an output pin
 //   gpio get <pin>           - read one pin
 // ========================================
+/* `voice`                  — show current persona/voice and list the options
+ * `voice <slug>`           — switch persona (e.g. `voice fi-1950`)
+ * `voice say <text>`       — speak a line now, to audition the persona
+ * `voice name <VoiceName>` — override the prebuilt voice (`voice name -` clears)
+ *
+ * Switching and auditioning are runtime rather than compile-time because only a
+ * listener can judge a voice; a reflash per candidate is far too slow a loop. */
+static void handle_voice_cmd(const char *buf)
+{
+    char op[24] = {0};
+    const int n = sscanf(buf, "voice %23s", op);
+
+    if (n <= 0) {
+        char voice[VOICE_PERSONA_VOICE_MAX];
+        voice_persona_effective_voice(voice, sizeof(voice));
+        const voice_persona_t *cur = voice_persona_get();
+        printf("voice: persona=%s lang=%s voice=%s\n", cur->slug, cur->language_code, voice);
+        for (size_t i = 0;; ++i) {
+            const voice_persona_t *p = voice_persona_at(i);
+            if (!p) {
+                break;
+            }
+            printf("  %c %-12s %s\n", (p == cur) ? '*' : ' ', p->slug, p->label);
+        }
+        printf("  usage: voice <slug> | voice say <text> | voice name <VoiceName|->\n");
+        return;
+    }
+
+    if (strcmp(op, "say") == 0) {
+        const char *text = strstr(buf, "say");
+        text = text ? text + 3 : NULL;
+        while (text && *text == ' ') {
+            ++text;
+        }
+        if (!text || *text == '\0') {
+            printf("voice: usage: voice say <text>\n");
+            return;
+        }
+        printf("voice: speaking \"%s\"\n", text);
+        if (speech_queue_post(text) != ESP_OK) {
+            printf("voice: speech queue busy\n");
+        }
+        return;
+    }
+
+    if (strcmp(op, "name") == 0) {
+        char name[VOICE_PERSONA_VOICE_MAX] = {0};
+        if (sscanf(buf, "voice name %23s", name) != 1) {
+            printf("voice: usage: voice name <VoiceName|->\n");
+            return;
+        }
+        const bool clear = (strcmp(name, "-") == 0);
+        if (voice_persona_set_voice(clear ? NULL : name, true) == ESP_OK) {
+            printf("voice: voice=%s\n", clear ? "(persona default)" : name);
+        } else {
+            printf("voice: could not set voice\n");
+        }
+        return;
+    }
+
+    if (voice_persona_set(op, true) == ESP_OK) {
+        printf("voice: persona=%s\n", op);
+    } else {
+        printf("voice: unknown persona '%s'\n", op);
+    }
+}
+
 static void handle_gpio_cmd(const char *buf)
 {
     if (!gpio_expander_available()) {
@@ -352,6 +420,8 @@ static void command_task(void *pvParameters)
                     }
                 } else if (strncmp(buf, "gpio", 4) == 0) {
                     handle_gpio_cmd(buf);
+                } else if (strncmp(buf, "voice", 5) == 0) {
+                    handle_voice_cmd(buf);
                 }
 
                 buf_pos = 0;
@@ -444,6 +514,10 @@ static esp_err_t init_hierarchical_ai(void)
 
     // goal_state must be initialised before reactive_controller and planner_task
     ESP_RETURN_ON_ERROR(goal_state_init(), TAG, "goal_state_init failed");
+
+    // Persona must load before the planner and TTS tasks start, since both read
+    // it while building their first request. Needs NVS, which Phase 0 set up.
+    voice_persona_init();
 
     // Speech path: queue and player must exist before the planner can emit a
     // `speak` call. Both are non-fatal — a robot that cannot talk should still

--- a/packages/robocar/unified/main/planner_task.c
+++ b/packages/robocar/unified/main/planner_task.c
@@ -69,6 +69,13 @@ static void planner_task(void *pvParameters)
 
     TickType_t last_wake_time = xTaskGetTickCount();
 
+    /* Extra periods to wait after a failed plan. Gemini answers a quota
+     * overrun with HTTP 429 and a retryDelay that *grows* while the client
+     * keeps asking (observed climbing 19 s -> 31 s under a 1 Hz loop), so
+     * retrying at full rate makes the outage longer. Capped so recovery stays
+     * bounded; reset on the first success. */
+    uint32_t backoff_periods = 0;
+
     while (1) {
         /* ---- 1. Capture frame ---- */
         camera_fb_t *fb = camera_capture();
@@ -108,16 +115,33 @@ static void planner_task(void *pvParameters)
             }
             ESP_LOGI(TAG, "Goal: %s | latency: %" PRIu32 " ms", goal_kind_name(goal.kind),
                      latency_ms);
+            backoff_periods = 0;
         } else {
-            ESP_LOGW(TAG, "gemini_backend_plan failed (%s) — forcing stop", esp_err_to_name(ret));
+            backoff_periods = (backoff_periods == 0) ? 1
+                              : (backoff_periods < PLANNER_MAX_BACKOFF_PERIODS)
+                                  ? backoff_periods * 2
+                                  : PLANNER_MAX_BACKOFF_PERIODS;
+            ESP_LOGW(TAG, "gemini_backend_plan failed (%s) — forcing stop, backing off %" PRIu32
+                          " extra period(s)",
+                     esp_err_to_name(ret), backoff_periods);
             goal_state_force_stop();
         }
 
         /* ---- 5. Return framebuffer ---- */
         camera_return_fb(fb);
 
-        /* ---- 6. Sleep until next period ---- */
-        vTaskDelayUntil(&last_wake_time, pdMS_TO_TICKS(PLANNER_LOOP_PERIOD_MS));
+        /* ---- 6. Sleep until next period ----
+         * A request slower than the period (a 21 s DNS timeout beats a 15 s
+         * period) leaves the wake deadline in the past, and xTaskDelayUntil
+         * then returns immediately — so the loop would spin at full tilt
+         * exactly when the backend is already struggling. Resync on overrun
+         * so the pacing holds. */
+        if (xTaskDelayUntil(&last_wake_time,
+                            pdMS_TO_TICKS(PLANNER_LOOP_PERIOD_MS * (1 + backoff_periods))) ==
+            pdFALSE) {
+            vTaskDelay(pdMS_TO_TICKS(PLANNER_LOOP_PERIOD_MS));
+            last_wake_time = xTaskGetTickCount();
+        }
     }
 }
 

--- a/packages/robocar/unified/main/planner_task.h
+++ b/packages/robocar/unified/main/planner_task.h
@@ -26,9 +26,26 @@
 extern "C" {
 #endif
 
-/** Planner loop period in milliseconds. Override at compile time if needed. */
+/** Planner loop period in milliseconds. Override at compile time if needed.
+ *
+ *  Bounded by the Gemini free-tier quota, not by control-loop preference:
+ *  gemini-robotics-er-1.6-preview allows 5 requests/minute
+ *  (GenerateRequestsPerMinutePerProjectPerModel-FreeTier). The ~1 Hz rate
+ *  ADR-016 describes is 60 RPM and drove the API into continuous HTTP 429s,
+ *  where every plan failed and the executor was force-stopped. 15 s = 4 RPM
+ *  leaves one request of headroom.
+ *
+ *  GOAL_STATE_DEFAULT_TTL_MS must stay >= this period, or goals expire between
+ *  plans and the robot stop-starts. Raise both together, and on a paid tier
+ *  lower both together. */
 #ifndef PLANNER_LOOP_PERIOD_MS
-#define PLANNER_LOOP_PERIOD_MS 1000U
+#define PLANNER_LOOP_PERIOD_MS 15000U
+#endif
+
+/** Cap on the exponential backoff after a failed plan, in extra loop periods.
+ *  Bounds worst-case recovery at (1 + this) * PLANNER_LOOP_PERIOD_MS. */
+#ifndef PLANNER_MAX_BACKOFF_PERIODS
+#define PLANNER_MAX_BACKOFF_PERIODS 4U
 #endif
 
 /**

--- a/packages/robocar/unified/main/self_report.c
+++ b/packages/robocar/unified/main/self_report.c
@@ -19,6 +19,7 @@
 #include "i2c_bus.h"
 #include "mqtt_logger.h"
 #include "speech_queue.h"
+#include "voice_persona.h"
 #include "wifi_manager.h"
 
 static const char *TAG = "self_report";
@@ -163,25 +164,31 @@ static uint32_t status_signature(const robocar_status_t *s)
  * speech buffer. Names only what is wrong so a healthy robot stays brief. */
 static void template_line(const robocar_status_t *s, char *out, size_t len)
 {
-    char faults[128];
+    /* Wording and subsystem names come from the active persona: this line is
+     * spoken exactly when the narrate call failed, and a hardcoded English
+     * sentence there would break character precisely when the robot is already
+     * degraded. */
+    const voice_persona_t *persona = voice_persona_get();
+
+    char faults[160];
     faults[0] = '\0';
     if (!s->wifi_up) {
-        strlcat(faults, " WiFi", sizeof(faults));
+        strlcat(faults, persona->fault_wifi, sizeof(faults));
     }
     if (!s->camera_ok) {
-        strlcat(faults, " camera", sizeof(faults));
+        strlcat(faults, persona->fault_camera, sizeof(faults));
     }
     if (!s->i2c_bus_ok) {
-        strlcat(faults, " motors", sizeof(faults));
+        strlcat(faults, persona->fault_motors, sizeof(faults));
     }
     if (!s->audio_ok) {
-        strlcat(faults, " audio", sizeof(faults));
+        strlcat(faults, persona->fault_audio, sizeof(faults));
     }
 
     if (faults[0] == '\0') {
-        strlcpy(out, "Hi, I'm Robocar and all my systems are online.", len);
+        strlcpy(out, persona->fallback_ok, len);
     } else {
-        snprintf(out, len, "Hi, I'm Robocar. These parts are not responding:%s.", faults);
+        snprintf(out, len, persona->fallback_fmt, faults);
     }
 }
 

--- a/packages/robocar/unified/main/speech_queue.h
+++ b/packages/robocar/unified/main/speech_queue.h
@@ -37,11 +37,14 @@ extern "C" {
 
 /** Longest utterance accepted, including the NUL.
  *
- *  Sized for one or two spoken sentences.  Gemini TTS bills per character and
- *  the robot narrates continuously, so this is a cost guard as much as a
- *  memory one — the planner prompt also asks for short lines.
+ *  Sized for one spoken sentence. Gemini TTS bills per character and the robot
+ *  narrates continuously, so this is a cost guard as much as a memory one — the
+ *  planner prompt also asks for short lines. But it must fit the *rendered*
+ *  sentence: 160 truncated a 25-word Finnish persona line mid-word (both text
+ *  and audio cut at ~148 chars, observed on hardware). Finnish words are long,
+ *  so a 25-word line reaches ~250 chars — size for the language, not English.
  */
-#define SPEECH_TEXT_MAX 160
+#define SPEECH_TEXT_MAX 320
 
 /** Pending utterances held before the TTS fetch. Small on purpose. */
 #define SPEECH_QUEUE_DEPTH 2

--- a/packages/robocar/unified/main/voice_persona.c
+++ b/packages/robocar/unified/main/voice_persona.c
@@ -1,0 +1,210 @@
+/**
+ * @file voice_persona.c
+ * @brief Voice persona table, runtime selection, and NVS persistence.
+ */
+
+#include "voice_persona.h"
+
+#include <string.h>
+
+#include "config.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+static const char *TAG = "voice_persona";
+
+#define NVS_NAMESPACE "voice"
+#define NVS_KEY_PERSONA "persona"
+#define NVS_KEY_VOICE "voice"
+
+/* -------------------------------------------------------------------------- */
+/* Table                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/* The Finnish brief is a *register* brief, not a script: the model composes each
+ * line, so the robot still comments on what it actually sees. The period markers
+ * below are grounded in 1950s-60s Finnish film dialogue rather than invented —
+ * chiefly the Komisario Palmu films (Mika Waltari / Matti Kassila), whose
+ * hallmarks are consistent teitittely, "herra/rouva/neiti" address, the
+ * sententious formal construction "Asianlaita on oikeastaan niin, että ...",
+ * and the hesitation opener "Jaah" / "Jaahas".
+ *
+ * "ehtoo" (archaic/eastern-dialect *evening*) and the filler "tuota" come from
+ * the examples this feature was requested with. Note they are dialectal/archaic
+ * rather than standard 1950s written Finnish, so they are offered to the model
+ * as flavour it *may* use, not as mandatory openers — forcing them into every
+ * line reads as caricature. Adjust the brief freely; it is data, not logic. */
+static const voice_persona_t s_personas[VOICE_PERSONA_COUNT] = {
+    [VOICE_PERSONA_EN_DEFAULT] =
+        {
+            .slug = "en-default",
+            .label = "English, plain contemporary",
+            .language_code = "en-US",
+            .voice = "Kore",
+            .tts_style = "Say in a friendly, natural tone",
+            .text_brief = "Speak plain, friendly contemporary English.",
+            .fallback_ok = "Hi, I'm Robocar and all my systems are online.",
+            .fallback_fmt = "Hi, I'm Robocar. These parts are not responding:%s.",
+            .fault_wifi = " WiFi",
+            .fault_camera = " camera",
+            .fault_motors = " motors",
+            .fault_audio = " audio",
+        },
+    [VOICE_PERSONA_FI_1950] =
+        {
+            .slug = "fi-1950",
+            .label = "Finnish, 1950s film register",
+            .language_code = "fi-FI",
+            .voice = "Charon",
+            .tts_style = "Puhu rauhallisesti, kohteliaasti ja hieman juhlallisesti, "
+                         "1950-luvun suomalaisen elokuvan ja radiokuuluttajan tapaan",
+            .text_brief =
+                "Puhu kuin 1950-luvun suomalaisen elokuvan hahmo (vrt. komisario Palmu): "
+                "kohteliasta, hieman vanhahtavaa yleiskieltä, teitittelyä ja herrasmiesmäistä "
+                "sävyä. Saat käyttää ajan täytesanoja ja empimistä, kuten \"tuota\", \"jaahas\" "
+                "ja \"no niin\", sekä vanhahtavia sanoja kuten \"ehtoo\" (ilta) — mausteena, et "
+                "joka lauseessa. Ajan tapaan muotoiltu rakenne, esimerkiksi \"Asianlaita on "
+                "oikeastaan niin, että ...\", sopii hyvin. Vältä nykyslangia, anglismeja, "
+                "lyhenteitä ja emojeita. Kirjoita yksi lyhyt puhuttu lause.",
+            .fallback_ok = "Hyvää päivää, minä olen Robocar, ja kaikki järjestelmät ovat kunnossa.",
+            .fallback_fmt = "Hyvää päivää, minä olen Robocar. Asianlaita on tuota niin, "
+                            "että nämä osat eivät vastaa:%s.",
+            .fault_wifi = " verkkoyhteys",
+            .fault_camera = " kamera",
+            .fault_motors = " moottorit",
+            .fault_audio = " ääni",
+        },
+};
+
+/* -------------------------------------------------------------------------- */
+/* State                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/* Single-word selection: readers (planner, TTS, self-report tasks) never lock,
+ * and a switch lands atomically. */
+static volatile voice_persona_id_t s_current = VOICE_PERSONA_DEFAULT;
+
+/* The override is mutable storage rather than a literal, so it needs a lock —
+ * a reader must not copy a half-written name into a request body. */
+static char s_voice_override[VOICE_PERSONA_VOICE_MAX];
+static SemaphoreHandle_t s_lock;
+
+static esp_err_t nvs_store(const char *key, const char *value)
+{
+    nvs_handle_t h;
+    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "nvs_open failed: %s", esp_err_to_name(err));
+        return err;
+    }
+    err = (value && value[0] != '\0') ? nvs_set_str(h, key, value) : nvs_erase_key(h, key);
+    if (err == ESP_OK) {
+        err = nvs_commit(h);
+    } else if (err == ESP_ERR_NVS_NOT_FOUND) {
+        err = ESP_OK; /* erasing an absent key is not a failure */
+    }
+    nvs_close(h);
+    return err;
+}
+
+/* -------------------------------------------------------------------------- */
+/* API                                                                         */
+/* -------------------------------------------------------------------------- */
+
+void voice_persona_init(void)
+{
+    if (!s_lock) {
+        s_lock = xSemaphoreCreateMutex();
+    }
+
+    nvs_handle_t h;
+    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &h) != ESP_OK) {
+        ESP_LOGI(TAG, "no stored persona — using default '%s'", s_personas[s_current].slug);
+        return;
+    }
+
+    char slug[24] = {0};
+    size_t len = sizeof(slug);
+    if (nvs_get_str(h, NVS_KEY_PERSONA, slug, &len) == ESP_OK) {
+        for (size_t i = 0; i < VOICE_PERSONA_COUNT; ++i) {
+            if (strcmp(s_personas[i].slug, slug) == 0) {
+                s_current = (voice_persona_id_t)i;
+                break;
+            }
+        }
+    }
+
+    len = sizeof(s_voice_override);
+    if (nvs_get_str(h, NVS_KEY_VOICE, s_voice_override, &len) != ESP_OK) {
+        s_voice_override[0] = '\0';
+    }
+    nvs_close(h);
+
+    ESP_LOGI(TAG, "persona '%s' (%s), voice %s", s_personas[s_current].slug,
+             s_personas[s_current].language_code,
+             s_voice_override[0] ? s_voice_override : s_personas[s_current].voice);
+}
+
+const voice_persona_t *voice_persona_get(void)
+{
+    voice_persona_id_t id = s_current;
+    if (id >= VOICE_PERSONA_COUNT) {
+        id = VOICE_PERSONA_EN_DEFAULT;
+    }
+    return &s_personas[id];
+}
+
+void voice_persona_effective_voice(char *out, size_t out_len)
+{
+    if (!out || out_len == 0) {
+        return;
+    }
+    const voice_persona_t *p = voice_persona_get();
+
+    if (s_lock && xSemaphoreTake(s_lock, pdMS_TO_TICKS(100)) == pdTRUE) {
+        strlcpy(out, s_voice_override[0] ? s_voice_override : p->voice, out_len);
+        xSemaphoreGive(s_lock);
+    } else {
+        /* Lock unavailable: the persona default is a literal and always safe. */
+        strlcpy(out, p->voice, out_len);
+    }
+}
+
+esp_err_t voice_persona_set(const char *slug, bool persist)
+{
+    if (!slug) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    for (size_t i = 0; i < VOICE_PERSONA_COUNT; ++i) {
+        if (strcmp(s_personas[i].slug, slug) == 0) {
+            s_current = (voice_persona_id_t)i;
+            ESP_LOGI(TAG, "persona -> '%s' (%s)", s_personas[i].slug, s_personas[i].language_code);
+            return persist ? nvs_store(NVS_KEY_PERSONA, slug) : ESP_OK;
+        }
+    }
+    return ESP_ERR_NOT_FOUND;
+}
+
+esp_err_t voice_persona_set_voice(const char *voice, bool persist)
+{
+    if (s_lock && xSemaphoreTake(s_lock, pdMS_TO_TICKS(100)) == pdTRUE) {
+        if (voice && voice[0] != '\0') {
+            strlcpy(s_voice_override, voice, sizeof(s_voice_override));
+        } else {
+            s_voice_override[0] = '\0';
+        }
+        xSemaphoreGive(s_lock);
+    } else {
+        return ESP_ERR_TIMEOUT;
+    }
+    ESP_LOGI(TAG, "voice -> %s", (voice && voice[0]) ? voice : "(persona default)");
+    return persist ? nvs_store(NVS_KEY_VOICE, voice) : ESP_OK;
+}
+
+const voice_persona_t *voice_persona_at(size_t index)
+{
+    return (index < VOICE_PERSONA_COUNT) ? &s_personas[index] : NULL;
+}

--- a/packages/robocar/unified/main/voice_persona.h
+++ b/packages/robocar/unified/main/voice_persona.h
@@ -1,0 +1,115 @@
+/**
+ * @file voice_persona.h
+ * @brief Language + delivery style of everything the robot says.
+ *
+ * One table, three consumers — keep them in sync by going through here rather
+ * than hardcoding a language or voice at any call site:
+ *
+ *   - gemini_backend.c  picks the *words*  (register/idiom brief injected into
+ *                       the planner `speak` prompt and the narrate prompt)
+ *   - gemini_tts.c      picks the *sound*  (speechConfig languageCode + voice,
+ *                       plus a delivery directive prefixed to the spoken text)
+ *   - self_report.c     picks the *fallback* (the canned line used when the
+ *                       narrate call fails, so an API outage does not drop the
+ *                       robot back into another language mid-character)
+ *
+ * How style actually reaches the TTS model: Gemini exposes no style/accent/era
+ * parameter — delivery is steered by natural-language prompting, i.e. the
+ * documented "Say cheerfully: <text>" form. `tts_style` is that prefix.
+ * Verified against the live API (2026-07) that the prefix is *interpreted*, not
+ * spoken: swapping a ~40-word directive (12+ s if read aloud) for a 3-word one
+ * changed the rendered audio by 0.36 s, while the requested delivery did change
+ * the duration. Language comes from speechConfig.languageCode (BCP-47).
+ *
+ * Voice names are the Gemini prebuilt set (Kore, Puck, Charon, Aoede, …) and are
+ * language-agnostic. The locale-specific Cloud TTS names (fi-FI-Chirp3-HD-*)
+ * are a *different product* and 404 on this endpoint — do not put one in the
+ * table without testing it against :generateContent first.
+ */
+
+#ifndef VOICE_PERSONA_H
+#define VOICE_PERSONA_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Longest accepted prebuilt voice name, including NUL. */
+#define VOICE_PERSONA_VOICE_MAX 24
+
+typedef enum {
+    VOICE_PERSONA_EN_DEFAULT = 0, /**< Plain contemporary English. */
+    VOICE_PERSONA_FI_1950,        /**< 1950s Finnish film register. */
+    VOICE_PERSONA_COUNT
+} voice_persona_id_t;
+
+/** Immutable table entry. All strings are string literals with static storage,
+ *  so a pointer handed out here stays valid for the life of the program and can
+ *  be read from any task without locking. */
+typedef struct {
+    const char *slug;          /**< Stable id for console + NVS ("fi-1950"). */
+    const char *label;         /**< Human description for `voice` listing. */
+    const char *language_code; /**< BCP-47 for speechConfig.languageCode. */
+    const char *voice;         /**< Default Gemini prebuilt voice name. */
+    const char *tts_style;     /**< Delivery directive; prefixed as "<style>: <text>". */
+    const char *text_brief;    /**< Register/idiom brief for text generation. */
+    const char *fallback_ok;   /**< Canned line: everything healthy. */
+    const char *fallback_fmt;  /**< Canned line with one %s for the fault list. */
+    const char *fault_wifi;    /**< Localised subsystem names for the fault list. */
+    const char *fault_camera;
+    const char *fault_motors;
+    const char *fault_audio;
+} voice_persona_t;
+
+/**
+ * @brief Load the persisted persona/voice from NVS, falling back to
+ *        VOICE_PERSONA_DEFAULT (config.h) when nothing is stored.
+ *
+ * Safe to call before NVS init fails — a read error just leaves the default.
+ * Call once during startup, before the planner and TTS tasks are created.
+ */
+void voice_persona_init(void);
+
+/**
+ * @brief Currently selected persona. Never NULL.
+ *
+ * Lock-free: the returned pointer is a const table entry, and selection is a
+ * single word write, so a concurrent switch yields either the old or the new
+ * persona — never a torn mix.
+ */
+const voice_persona_t *voice_persona_get(void);
+
+/**
+ * @brief Effective TTS voice: the runtime override when set, else the current
+ *        persona's default. Copied out under a lock because the override is
+ *        mutable storage, unlike the table's literals.
+ */
+void voice_persona_effective_voice(char *out, size_t out_len);
+
+/** @brief Select a persona by slug. @return ESP_ERR_NOT_FOUND on unknown slug. */
+esp_err_t voice_persona_set(const char *slug, bool persist);
+
+/**
+ * @brief Override the prebuilt voice name, independent of persona.
+ *
+ * Exists so the voice can be A/B'd by ear at runtime: only a listener can judge
+ * whether a voice suits a persona, and a reflash per candidate is too slow a
+ * loop for that. Pass NULL or "" to clear and fall back to the persona default.
+ * The name is not validated here — an unknown name surfaces as an HTTP 400/404
+ * from the TTS call, which is logged.
+ */
+esp_err_t voice_persona_set_voice(const char *voice, bool persist);
+
+/** @brief Table entry at @p index, or NULL when out of range (for listing). */
+const voice_persona_t *voice_persona_at(size_t index);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VOICE_PERSONA_H */

--- a/packages/robocar/unified/main/wifi_manager.c
+++ b/packages/robocar/unified/main/wifi_manager.c
@@ -46,7 +46,23 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
         }
     } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
         ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
-        ESP_LOGI(TAG, "Got IP:" IPSTR, IP2STR(&event->ip_info.ip));
+        ESP_LOGI(TAG, "Got IP:" IPSTR ", mask:" IPSTR ", gw:" IPSTR,
+                 IP2STR(&event->ip_info.ip), IP2STR(&event->ip_info.netmask),
+                 IP2STR(&event->ip_info.gw));
+        /* Log the resolver(s) DHCP installed. Purely diagnostic — the firmware
+         * uses whatever DHCP supplies. This exists because a broken resolver
+         * presents as a silent getaddrinfo() EAI_FAIL from deep inside esp-tls,
+         * with nothing naming the resolver actually in use; printing it at
+         * connect time is what distinguishes a link/router fault from a
+         * firmware bug. A 0.0.0.0 entry means the AP offered no DNS server. */
+        esp_netif_dns_info_t dns = {0};
+        if (esp_netif_get_dns_info(event->esp_netif, ESP_NETIF_DNS_MAIN, &dns) == ESP_OK) {
+            ESP_LOGI(TAG, "DNS main (DHCP):" IPSTR, IP2STR(&dns.ip.u_addr.ip4));
+        }
+        if (esp_netif_get_dns_info(event->esp_netif, ESP_NETIF_DNS_BACKUP, &dns) == ESP_OK &&
+            dns.ip.u_addr.ip4.addr != 0) {
+            ESP_LOGI(TAG, "DNS backup (DHCP):" IPSTR, IP2STR(&dns.ip.u_addr.ip4));
+        }
         s_retry_num = 0;
         xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
     }


### PR DESCRIPTION
## Summary

Gets the robocar-unified robot **talking** — a working Finnish voice with clean
audio — by fixing the chain of failures found during hardware bring-up on real
hardware, plus a runtime voice-persona system. All nine commits are verified
end-to-end on-device (planner → goal + Finnish `speak` → TTS render → clean I2S
audio, and the AI-narrated self-report happy path).

## What's in here

| Commit | Change |
|---|---|
| `fix` | **Audio static** — 16-bit PCM was split at odd boundaries in the byte ring (base64's 3-byte chunks) and the player dropped the straggler, misaligning the stream cumulatively. Carry the odd byte across writes to keep it aligned. **This is the real static fix.** |
| `fix` | **Speech buffer** sized for Finnish (160 → 320) — long words truncated a 25-word line mid-word. |
| `feat` | **Runtime voice personas** (`en-default`, `fi-1950`) — single source of truth for language, TTS voice, delivery style, and offline fallback; switchable + NVS-persisted via a `voice` console command (`voice say` to audition). 1950s Finnish grounded in Komisario Palmu dialogue. |
| `docs` | `.claude/rules/gemini-api.md` — Gemini API drift gotchas (model-id ListModels check, `thinkingLevel`, token budget, prompted TTS style, per-model quotas). |
| `fix` | **Gemini 404/400** — planner model id needs `-preview`; narrate needs `thinkingLevel` (not `thinkingBudget`) and a larger `maxOutputTokens` (thinking is a variable, combined budget). |
| `fix` | **Planner paced to quota** — 1 Hz (60 RPM) drove continuous 429s; now 15 s loop, matched TTL, exponential backoff, overrun resync. |
| `refactor` | **Drop the ineffective DNS override** — measurement showed public and DHCP resolvers failed identically on the broken VLAN; redundant on a healthy network. |
| `docs` | `audio-static-debugging` skill — the method that solved the static after two wrong hardware theories: measure the PCM at each stage, don't guess at the amp. |

## Verification

Flashed and confirmed on hardware (XIAO ESP32-S3 Sense, on the main WiFi):
- Planner returns `HTTP 200` with real goals; Finnish `speak` lines render and play **clean** (static gone, confirmed by ear).
- AI-narrated self-report speaks a complete in-persona Finnish line (not the template).
- DNS uses the DHCP resolver directly; persona loads (`fi-1950` / `Charon`); 429 backoff is non-escalating.

## Note for review

Commit `c58d01b`'s message ("eliminate audio-onset static by preloading I2S
silence") **overclaims** — that was the first of two wrong theories; the actual
static fix is the ring-alignment commit. The preload is retained as harmless
I2S hygiene. A squash-merge collapses this cleanly.

The Gemini free-tier **daily** quota (planner ~20/day, TTS 10/day) was exhausted
during testing; final verification used billing. A powered idle robot makes
continuous billed calls (~15 s planner + a TTS render per line).

## Follow-ups (tracked separately)

- I2C bus / TCA9548A timeout → motors/servos/LEDs disabled (unrelated).
- IoT VLAN 30 has no working DNS egress for clients (infra, not firmware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiickaojZLyNwVUk9NuU4y
