### PR TITLE
fix(tools): handle empty ioreg output when no USB devices are attached

### DIFF
--- a/tools/list-usb-devices.py
+++ b/tools/list-usb-devices.py
@@ -104,7 +104,9 @@ def main():
             ["ioreg", "-r", "-c", "IOUSBHostDevice", "-a"],
             stderr=subprocess.DEVNULL,
         )
-        data = plistlib.loads(raw)
+        # ioreg prints nothing at all (not even an empty plist) when no
+        # entries match the class, e.g. no USB devices currently attached.
+        data = plistlib.loads(raw) if raw.strip() else []
     except Exception as e:
         print(f"Error reading USB registry: {e}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## The bug

`ioreg -r -c IOUSBHostDevice -a` prints **nothing at all** when no entries match the class — not an empty plist, *zero bytes*. `plistlib.loads(b"")` then raises `InvalidFileException`, which the blanket `except` reported as:

```
Error reading USB registry: Invalid file
```

…and exited `1`. So the completely ordinary case of *"no board plugged in right now"* surfaced as a registry read failure, pointing suspicion at `ioreg`, at permissions, or at the plist parsing — anywhere but the actual cause, which is that the USB bus is simply empty.

## The fix

Treat empty output as an empty device list. `collect_devices([])` already returns `[]`, which flows into the existing `if not relevant:` branch that prints *"No MCU or USB-serial devices found"* and exits `0`. No other code path changes.

## Verification

This was checked against the live failure rather than reasoned about — with nothing attached to this machine right now, the real command reproduces it exactly:

```
real ioreg output bytes: 0
pre-fix behaviour -> Error reading USB registry: Invalid file (exit 1)
```

Post-fix, the script prints `No MCU or USB-serial devices found` and exits `0`. `ruff check` and `ruff format --check` both clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188BPGezki5ByyVKNffLLQX
