### PR TITLE
chore: gitignore macOS .dylib host build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ target/
 *.o
 *.a
 *.so
+# macOS shared-library form of *.so — host test/sim cores build to .dylib here
+# (e.g. kids-audio-toy's sim/libaudio_core.dylib) and would otherwise show up
+# as untracked on every developer's Mac.
+*.dylib
 *.elf
 *.bin
 *.hex


### PR DESCRIPTION
## What

The root ignore list covers `*.so` but not its macOS equivalent, `*.dylib`. Host-built shared libraries therefore sit untracked in `git status` on every developer Mac — currently `packages/audio/kids-audio-toy/sim/libaudio_core.dylib`, a 17 KB host build of the shared audio core.

A stray binary loitering in `git status` is precisely the kind of thing a `git add -A` sweeps into an unrelated commit.

## Safety check

`git ls-files | grep '\.dylib$'` returns nothing — no tracked `.dylib` exists, so the new rule shadows nothing that is currently under version control. After the change, `git check-ignore -v` resolves the artifact to `.gitignore:22:*.dylib` and the working tree is clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188BPGezki5ByyVKNffLLQX
