### PR TITLE
fix(wireguard-ha): modernize ESPHome config for 2026.7

### DIFF
--- a/packages/networking/wireguard-ha/esp32-wireguard-ha.yaml
+++ b/packages/networking/wireguard-ha/esp32-wireguard-ha.yaml
@@ -1,8 +1,11 @@
 esphome:
   name: esp32-wireguard-ha
   friendly_name: "ESP32 WireGuard HA Example"
-  platform: ESP32
+
+esp32:
   board: esp32dev
+  framework:
+    type: esp-idf
 
 # Enable logging
 logger:
@@ -82,8 +85,9 @@ wireguard:
 binary_sensor:
   # Status of WireGuard connection
   - platform: wireguard
-    name: "WireGuard Status"
-    id: wg_status
+    status:
+      name: "WireGuard Status"
+      id: wg_status
 
   # Built-in status LED indicator
   - platform: status
@@ -104,15 +108,17 @@ sensor:
 
   # WireGuard latest handshake timestamp
   - platform: wireguard
-    name: "WG Latest Handshake"
-    id: wg_handshake
+    latest_handshake:
+      name: "WG Latest Handshake"
+      id: wg_handshake
 
 # Text sensors
 text_sensor:
   # WireGuard VPN address
   - platform: wireguard
-    name: "WG Address"
-    id: wg_address_sensor
+    address:
+      name: "WG Address"
+      id: wg_address_sensor
 
   # Device IP address
   - platform: wifi_info


### PR DESCRIPTION
## Why this exists

The **ESPHome / esp32-wireguard-ha-example** job has been failing on *every* PR that triggers it — including PRs that touch nothing but a Python file. It is not caused by any recent change: the config was last modified in the #232 monorepo reorg, and ESPHome removed the syntax underneath it. It was surfaced while triaging red checks on an unrelated PR.

## Two accumulated upgrade regressions

**1. Legacy platform keys** — `platform: ESP32` / `board: esp32dev` inside the `esphome:` block:

```
Please remove the `platform` key from the [esphome] block and use the
correct platform component. This style of configuration has now been removed.
```

Moved to a top-level `esp32:` block with `framework: type: esp-idf` — the form `audiobook-player` and `presence-detector` already use, so this brings the config in line with the repo's other ESPHome projects.

**2. WireGuard sensor schema** — the platforms take *named sub-blocks*, not a bare `name:`:

```
[name] is an invalid option for [binary_sensor.wireguard].
```

Checked against the **installed component source** rather than from memory:

| Platform | Accepted keys |
|---|---|
| `binary_sensor.wireguard` | `status`, `enabled` |
| `sensor.wireguard` | `latest_handshake` |
| `text_sensor.wireguard` | `address` |

## Compatibility

Entity **names are unchanged**, so `home-assistant-example.yaml`'s `binary_sensor.esp32_wireguard_ha_*` references still resolve. The declared ids (`wg_status`, `wg_handshake`, `wg_address_sensor`) turned out not to be referenced anywhere, but are preserved inside their new blocks rather than dropped.

## Verification

Run locally with `esphome config` against a secrets file derived from `secrets.yaml.example`:

1. Reproduced the exact CI failure (`platform` key) on the unmodified config.
2. Reproduced the second failure (`[name] is an invalid option`) after fixing the first — which is why CI only ever showed one of them.
3. After both fixes: **`INFO Configuration is valid!`**

`secrets.yaml.example` needs no change — it already covers every key the config actually references. (An initial reading suggested `wg_peer_preshared_key` was missing; it is commented out in *both* files consistently, so a plain `cp` of the example works.)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188BPGezki5ByyVKNffLLQX
