### PR TITLE
chore(robocar-unified): add a just recipe for the host unit tests

### DIFF
--- a/packages/robocar/unified/.gitignore
+++ b/packages/robocar/unified/.gitignore
@@ -1,5 +1,8 @@
 # ESP-IDF build artifacts
 build/
+
+# Host unit-test build tree (`just robocar-unified::test`)
+build-host/
 sdkconfig
 sdkconfig.old
 

--- a/packages/robocar/unified/justfile
+++ b/packages/robocar/unified/justfile
@@ -80,6 +80,31 @@ monitor: _s3-monitor
 flash-monitor: flash monitor
 
 ##########
+# Tests
+##########
+
+# Run the host unit tests (native cmake + ctest — no ESP-IDF container).
+#
+# test/CMakeLists.txt compiles the ESP-IDF-free modules straight from main/
+# against the shims in test/include. Nothing here needs the container, and the
+# suites are seconds — run this after touching goal_state, ultrasonic,
+# reactive_controller, base64, speech_tags, dialogue_style or gemini_parse.
+#
+# gemini_parse needs cjson: `brew install cjson` (found via pkg-config, else
+# Homebrew's prefix).
+#
+# NOTE: no CI job runs these yet — `.github/workflows/` only ctests the Pico
+# project. Until that gap is closed this recipe is the *only* thing exercising
+# them, so run it before pushing rather than trusting a green PR.
+[group: "test"]
+test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cmake -S test -B build-host
+    cmake --build build-host
+    ctest --test-dir build-host --output-on-failure
+
+##########
 # Docs
 ##########
 


### PR DESCRIPTION
## What

`just robocar-unified::test` — one command for the seven host suites (goal_state, ultrasonic, reactive_controller, base64_stream, speech_tags, dialogue_style, gemini_parse). `build-host/` gitignored alongside `build/`.

## Why

There was no entry point. Running them meant hand-rolling `cmake -S test -B <somewhere> && cmake --build && ctest --test-dir` from memory each time — mechanical enough to get skipped, and skipping it is cheap because nothing catches it.

**The gap this surfaced:** `.github/workflows/` only ctests the Pico project (`_ci-build-pico.yml`). The robocar-unified host tests run **locally or not at all**, so a regression in any of those seven modules lands on a green PR. The recipe comment says so explicitly rather than implying CI has your back.

Closing the parity gap needs a CI job (and `cjson` on the runner) — deliberately **not** bundled here, since this PR is a one-rung convenience and that's a workflow change with its own review surface. Tracked in taskwarrior against `local-ci-parity.md`.

## Verification

`just robocar-unified::test` → **7/7 passed, 1.85 s** from a clean `build-host/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkDNfPLAhngRS3kRtwYjHB