### PR TITLE
feat(robocar-unified): give the robot a memory of what it said, and ration how often it speaks

### DIFF
--- a/packages/robocar/unified/CLAUDE.md
+++ b/packages/robocar/unified/CLAUDE.md
@@ -46,7 +46,7 @@ The MCP23017 (1953W breakout, address 0x20) is exercised from the serial console
 |---------|--------|
 | `F` `B` `L` `R` `C` `W` `S` | Manual drive / rotate / stop — a ~1 s lease via `reactive_controller_manual()`, still subject to the obstacle reflex |
 | `gpio …` | MCP23017 expander (see above) |
-| `voice …` | Persona / TTS voice switching and auditioning; `voice vary` shows a drawn variation directive |
+| `voice …` | Persona / TTS voice switching and auditioning; `voice vary` shows a drawn variation directive, `voice said` the recall ring, `voice quiet`/`budget`/`repeat` the speech rationing |
 | `snap [n]` | Dump the next `n` planner frames over the console as base64 JPEG — see "Seeing what the camera sends" |
 | `cam …` | Read live sensor gain/exposure; `cam gainceiling 0-6`, `cam ae -2..2`, `cam brightness -2..2` tune exposure without a reflash |
 | `sound beep\|melody\|alert` | Buzzer |
@@ -124,6 +124,22 @@ Full API surface, including the multi-speaker config that exists but is unused a
 
 The trap it exists to prevent: a phrase named in `text_brief` gets used *every single time*. Naming the period construction "Asianlaita on oikeastaan niin, että ..." there made it the opening of practically every spoken line. Put such a phrase in the `openers` pool, where it turns up on its share of lines and the pool can also say "no opener at all". `voice vary` on the console prints a freshly drawn directive so pools can be tuned without waiting out a 15 s planner period per sample.
 
+### The robot remembers what it said, and is rationed on how often it says anything
+
+Every planner request is **stateless** — one image, one prompt, no previous frame and no record of having spoken. So the prompt's "remark only when the scene changes" and "narrating every time would be tiresome" were asking for a judgement the model had no information to make: it arrives as a first-time observer on every call. Pointed at a bench that is not moving, it remarked on the same unmoving thing every 15 s, and the three-word avoid-list let it do so with a fresh opening each time.
+
+Three mechanisms, in the order they act on a cycle:
+
+- **The `speak` tool is withheld, not discouraged** (`speech_budget.c`). A minimum gap (60 s) and a rolling cap (3 per 5 min) decide whether `build_tools()` declares `speak` at all. On a quiet cycle the whole speech half of the prompt — persona brief, variation directive, recall list — is omitted too, so the muted request is also the cheaper one. Withholding beats instructing because there is no wording that makes an unknowable fact ("how long since I last spoke") knowable.
+- **The last few whole utterances go into the prompt** (`dialogue_style.c`, `DIALOGUE_RECALL_SLOTS`). Distinct from the avoid-list, which constrains only the first `DIALOGUE_OPENING_WORDS` words — a model can honour that and still reorder the same sentence forever, which is exactly what it did.
+- **The answer is re-checked on-device.** `dialogue_style_is_repetitive()` scores the candidate against the recall ring (Sørensen–Dice over word sets, ASCII-case- and punctuation-insensitive, so reordering does not evade it) and `planner_task.c` drops it above the threshold. An instruction the model can quietly ignore is not a guarantee.
+
+Only *generated* lines are screened. `voice say` is an audition and is meant to repeat on demand; a self-report whose facts have not changed is supposed to read the same.
+
+The three thresholds are console knobs (`voice quiet`, `voice budget`, `voice repeat`) for the same reason `cam gainceiling` is: whether the robot is pleasantly laconic or annoyingly mute is a judgement that needs somebody in the room, and a reflash per trial is far too slow a loop. They deliberately do **not** persist to NVS — a boot should come up at the documented default, not at whatever last night's experiment left behind. `voice` with no argument prints the live budget state (`used=`, next-allowed countdown) and `voice said` prints the recall ring.
+
+None of this survives a reboot: the rings are `.bss`. Persisting them is worth doing if bench reflashes make the first line after every boot the model's favourite phrasing again.
+
 Two hardware consequences worth knowing before touching this:
 
 - **The microSD slot is gone.** GPIO7/8/9 are the Sense expansion board's SPI bus. No alternative pins exist — I2S needs a real peripheral, so it cannot move behind the PCA9685 or MCP23017.
@@ -176,6 +192,9 @@ Key settings that matter:
 - Don't fold speech into `goal_t` — see the Voice section above and `speech_queue.h`
 - Don't put a specific phrase, opener or filler word in a persona's `text_brief` — everything named there is said every time. Phrase-shaped flavour goes in the `openers`/`shapes` pools; see `dialogue_style.h`
 - Don't name an *era* in `tts_style` and expect the delivery to follow — "1950s Finnish film" produced flat contemporary Finnish. Name the audible traits instead (enunciation, tempo, `yleiskieli` forms, tapped /r/, held geminates). Note the ceiling: the era's *recording chain* (~100 Hz–5 kHz) is a filter, not a speaking style, and no prompt adds it
+- Don't try to fix repetition by wording the prompt harder ("do not repeat yourself", "only if the scene changed"). Every request is stateless, so those name facts the model cannot check. Withhold the `speak` declaration instead, and re-check the answer against the recall ring — see the Voice section
+- Don't screen `voice say` or the self-report through `dialogue_style_is_repetitive()`. An audition is supposed to repeat on demand, and a status report whose facts have not changed is supposed to read the same; suppressing either turns a working command into one that silently does nothing
+- Don't grow `GEMINI_SYSTEM_PROMPT_MAX`, a persona brief, or `DIALOGUE_RECALL_*` without looking at `PLANNER_TASK_STACK_SIZE` — the prompt is assembled in one frame on the planner stack. The recall clause is sized against the room left so the closing "function calls only" instruction cannot be the thing truncated away; keep that reserve if you reorder the clauses
 - Don't move delivery tags into a `dialogue_pool_t` — they're model-placed because they must fit the sentence, and the random pools exist for things that don't. Don't drop the allow-list filter either; unknown tags get read out loud
 - Don't switch the TTS call back to `:generateContent` — it costs ~5 s of perceived latency (see the Voice section)
 - Don't "normalise" the audio path to 16 kHz to match the ThinkPack projects — 24 kHz is Gemini TTS's native rate, and matching it avoids a resampling stage entirely

--- a/packages/robocar/unified/main/CMakeLists.txt
+++ b/packages/robocar/unified/main/CMakeLists.txt
@@ -14,6 +14,7 @@ idf_component_register(
         "gemini_http.c"
         "gemini_parse.c"
         "goal_state.c"
+        "speech_budget.c"
         "speech_queue.c"
         "speech_tags.c"
         "audio_player.c"

--- a/packages/robocar/unified/main/dialogue_style.c
+++ b/packages/robocar/unified/main/dialogue_style.c
@@ -79,11 +79,19 @@ static char s_recent[DIALOGUE_RECENT_SLOTS][DIALOGUE_OPENING_MAX];
 static size_t s_recent_head;
 static size_t s_recent_used;
 
+/* Ring of the last few whole lines, same discipline. */
+static char s_recall[DIALOGUE_RECALL_SLOTS][DIALOGUE_RECALL_MAX];
+static size_t s_recall_head;
+static size_t s_recall_used;
+
 void dialogue_style_reset_recent(void)
 {
     memset(s_recent, 0, sizeof(s_recent));
     s_recent_head = 0;
     s_recent_used = 0;
+    memset(s_recall, 0, sizeof(s_recall));
+    s_recall_head = 0;
+    s_recall_used = 0;
 }
 
 /** True for characters that end a clause and should not survive in an opening. */
@@ -94,15 +102,16 @@ static int is_trailing_punct(char c)
 }
 
 /**
- * Copy the first DIALOGUE_OPENING_WORDS words of @p line into @p out.
+ * Copy at most @p max_words words of @p line into @p out (0 = no word limit).
  *
  * Byte-oriented on purpose: the input is UTF-8 and the cap could land mid
  * sequence, so the copy stops at the last completed *word* rather than at the
  * byte cap whenever a boundary is available. A single word longer than the cap
  * is dropped entirely rather than cut into invalid UTF-8 — a mangled fragment
- * in the avoid-list would be worse than no entry at all.
+ * in the avoid-list, or in the recalled-lines list, would be worse than no
+ * entry at all.
  */
-static void extract_opening(const char *line, char *out, size_t out_len)
+static void extract_words(const char *line, char *out, size_t out_len, size_t max_words)
 {
     out[0] = '\0';
     if (line == NULL || out_len < 2u) {
@@ -119,11 +128,11 @@ static void extract_opening(const char *line, char *out, size_t out_len)
     size_t written = 0;
     size_t last_boundary = 0; /* length of the longest prefix ending a word */
 
-    while (line[i] != '\0' && written < cap && words < DIALOGUE_OPENING_WORDS) {
+    while (line[i] != '\0' && written < cap && (max_words == 0u || words < max_words)) {
         if (line[i] == ' ') {
             last_boundary = written;
             ++words;
-            if (words >= DIALOGUE_OPENING_WORDS) {
+            if (max_words != 0u && words >= max_words) {
                 break;
             }
             out[written++] = ' ';
@@ -149,18 +158,33 @@ static void extract_opening(const char *line, char *out, size_t out_len)
 
 void dialogue_style_note_spoken(const char *line)
 {
-    /* Delivery tags are stripped before the opening is extracted. A line
-     * beginning "[sighs] Jaahas" would otherwise be remembered as opening with
-     * the tag, and the next prompt would ask the model to avoid *sighing*
-     * rather than to avoid the word "Jaahas" — the mechanism would quietly
-     * start policing the wrong axis. See speech_tags.h. */
+    /* Delivery tags are stripped before anything is extracted. A line beginning
+     * "[sighs] Jaahas" would otherwise be remembered as opening with the tag,
+     * and the next prompt would ask the model to avoid *sighing* rather than to
+     * avoid the word "Jaahas" — the mechanism would quietly start policing the
+     * wrong axis. The recall ring wants the same treatment for the same reason:
+     * two identical sentences differing only in their tag are a repeat.
+     * See speech_tags.h. */
     char words[DIALOGUE_STYLE_MAX];
     speech_tags_strip(line, words, sizeof(words));
 
     char opening[DIALOGUE_OPENING_MAX];
-    extract_opening(words, opening, sizeof(opening));
+    extract_words(words, opening, sizeof(opening), DIALOGUE_OPENING_WORDS);
     if (opening[0] == '\0') {
         return;
+    }
+
+    /* The whole line, for the recall ring. Stored unconditionally — unlike the
+     * openings ring below, a near-repeat here is exactly what the next
+     * repetition check needs to see. */
+    char whole[DIALOGUE_RECALL_MAX];
+    extract_words(words, whole, sizeof(whole), 0u);
+    if (whole[0] != '\0') {
+        memcpy(s_recall[s_recall_head], whole, strlen(whole) + 1u);
+        s_recall_head = (s_recall_head + 1u) % DIALOGUE_RECALL_SLOTS;
+        if (s_recall_used < DIALOGUE_RECALL_SLOTS) {
+            ++s_recall_used;
+        }
     }
 
     /* A phrase the model keeps returning to would otherwise fill every slot and
@@ -179,7 +203,17 @@ void dialogue_style_note_spoken(const char *line)
     }
 }
 
-size_t dialogue_style_recent_openings(char *out, size_t out_len)
+/**
+ * Render a ring as a quoted, comma-separated list, newest first.
+ *
+ * Newest first because a buffer too small for the whole ring should keep the
+ * most recent entries — those are the ones a listener would notice being
+ * repeated. An entry that does not fit whole is skipped rather than cut: half a
+ * quoted string in a prompt reads as a mangled instruction (and could split a
+ * UTF-8 sequence on its way into a JSON body).
+ */
+static size_t render_ring(const char *ring, size_t slots, size_t stride, size_t head, size_t used,
+                          char *out, size_t out_len)
 {
     if (out == NULL || out_len == 0u) {
         return 0;
@@ -187,16 +221,15 @@ size_t dialogue_style_recent_openings(char *out, size_t out_len)
     out[0] = '\0';
 
     size_t written = 0;
-    for (size_t n = 0; n < s_recent_used; ++n) {
-        /* Newest first: the most recent opening is the one most worth avoiding
-         * if the list has to be truncated to fit. */
-        const size_t idx = (s_recent_head + DIALOGUE_RECENT_SLOTS - 1u - n) % DIALOGUE_RECENT_SLOTS;
-        const char *item = s_recent[idx];
+    for (size_t n = 0; n < used; ++n) {
+        const size_t idx = (head + slots - 1u - n) % slots;
+        const char *item = ring + (idx * stride);
         if (item[0] == '\0') {
             continue;
         }
 
-        const size_t need = (written > 0u ? 2u : 0u) + 2u + strlen(item);
+        const size_t item_len = strlen(item);
+        const size_t need = (written > 0u ? 2u : 0u) + 2u + item_len;
         if (written + need >= out_len) {
             break;
         }
@@ -205,12 +238,175 @@ size_t dialogue_style_recent_openings(char *out, size_t out_len)
             written += 2u;
         }
         out[written++] = '"';
-        memcpy(out + written, item, strlen(item));
-        written += strlen(item);
+        memcpy(out + written, item, item_len);
+        written += item_len;
         out[written++] = '"';
         out[written] = '\0';
     }
     return written;
+}
+
+size_t dialogue_style_recent_openings(char *out, size_t out_len)
+{
+    return render_ring(&s_recent[0][0], DIALOGUE_RECENT_SLOTS, DIALOGUE_OPENING_MAX, s_recent_head,
+                       s_recent_used, out, out_len);
+}
+
+size_t dialogue_style_recent_lines(char *out, size_t out_len)
+{
+    return render_ring(&s_recall[0][0], DIALOGUE_RECALL_SLOTS, DIALOGUE_RECALL_MAX, s_recall_head,
+                       s_recall_used, out, out_len);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Repetition check                                                            */
+/* -------------------------------------------------------------------------- */
+
+static uint8_t s_repeat_pct = DIALOGUE_REPEAT_PCT_DEFAULT;
+
+void dialogue_style_set_repeat_pct(uint8_t pct)
+{
+    if (pct >= 1u && pct <= 100u) {
+        s_repeat_pct = pct;
+    }
+}
+
+uint8_t dialogue_style_repeat_pct(void)
+{
+    return s_repeat_pct;
+}
+
+/** Anything that separates words. Bytes >= 0x80 are word characters, so UTF-8
+ *  sequences stay whole and are compared bytewise. */
+static int is_word_sep(char c)
+{
+    const unsigned char u = (unsigned char)c;
+    return u <= (unsigned char)' ' || u == ',' || u == '.' || u == ';' || u == ':' || u == '!' ||
+           u == '?' || u == '-' || u == '"' || u == '\'' || u == '(' || u == ')';
+}
+
+/**
+ * Advance @p cursor to the next word. @return its start, or NULL at end.
+ */
+static const char *next_word(const char **cursor, size_t *len)
+{
+    const char *p = *cursor;
+    while (*p != '\0' && is_word_sep(*p)) {
+        ++p;
+    }
+    if (*p == '\0') {
+        *cursor = p;
+        return NULL;
+    }
+    const char *start = p;
+    while (*p != '\0' && !is_word_sep(*p)) {
+        ++p;
+    }
+    *cursor = p;
+    *len = (size_t)(p - start);
+    return start;
+}
+
+/** ASCII-case-insensitive word equality. See the header for why only ASCII. */
+static int word_eq(const char *a, size_t alen, const char *b, size_t blen)
+{
+    if (alen != blen) {
+        return 0;
+    }
+    for (size_t i = 0; i < alen; ++i) {
+        unsigned char ca = (unsigned char)a[i];
+        unsigned char cb = (unsigned char)b[i];
+        if (ca >= 'A' && ca <= 'Z') {
+            ca = (unsigned char)(ca + 32);
+        }
+        if (cb >= 'A' && cb <= 'Z') {
+            cb = (unsigned char)(cb + 32);
+        }
+        if (ca != cb) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+/** True when @p w occurs in @p s before @p limit (NULL = whole string). */
+static int contains_word(const char *s, const char *limit, const char *w, size_t wlen)
+{
+    const char *cur = s;
+    const char *tok = NULL;
+    size_t tlen = 0;
+    while ((tok = next_word(&cur, &tlen)) != NULL) {
+        if (limit != NULL && tok >= limit) {
+            break;
+        }
+        if (word_eq(tok, tlen, w, wlen)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+unsigned dialogue_style_similarity(const char *a, const char *b)
+{
+    if (a == NULL || b == NULL) {
+        return 0;
+    }
+
+    /* Sørensen–Dice over the two *sets* of words: 2|A∩B| / (|A|+|B|). Sets
+     * rather than multisets so a filler word repeated inside one sentence does
+     * not inflate the score. O(n*m) with n,m ≈ 20 — nothing worth indexing. */
+    unsigned uniq_a = 0;
+    unsigned uniq_b = 0;
+    unsigned common = 0;
+
+    const char *cur = a;
+    const char *tok = NULL;
+    size_t tlen = 0;
+    while ((tok = next_word(&cur, &tlen)) != NULL) {
+        if (contains_word(a, tok, tok, tlen)) {
+            continue; /* already counted this word */
+        }
+        ++uniq_a;
+        if (contains_word(b, NULL, tok, tlen)) {
+            ++common;
+        }
+    }
+
+    cur = b;
+    while ((tok = next_word(&cur, &tlen)) != NULL) {
+        if (!contains_word(b, tok, tok, tlen)) {
+            ++uniq_b;
+        }
+    }
+
+    if (uniq_a + uniq_b == 0u) {
+        return 0;
+    }
+    return (unsigned)((200u * common) / (uniq_a + uniq_b));
+}
+
+bool dialogue_style_is_repetitive(const char *line)
+{
+    if (line == NULL || line[0] == '\0') {
+        return false;
+    }
+
+    char words[DIALOGUE_STYLE_MAX];
+    speech_tags_strip(line, words, sizeof(words));
+    if (words[0] == '\0') {
+        return false;
+    }
+
+    for (size_t n = 0; n < s_recall_used; ++n) {
+        const size_t idx = (s_recall_head + DIALOGUE_RECALL_SLOTS - 1u - n) % DIALOGUE_RECALL_SLOTS;
+        if (s_recall[idx][0] == '\0') {
+            continue;
+        }
+        if (dialogue_style_similarity(words, s_recall[idx]) >= (unsigned)s_repeat_pct) {
+            return true;
+        }
+    }
+    return false;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/robocar/unified/main/dialogue_style.h
+++ b/packages/robocar/unified/main/dialogue_style.h
@@ -31,6 +31,15 @@
  *      with these" — the only mechanism here that reacts to what the model
  *      really produced rather than to what it was asked for.
  *
+ *   4. **A recall ring of whole lines, and a repetition check against it.**
+ *      The avoid-list above constrains only the first DIALOGUE_OPENING_WORDS
+ *      words, so a model can honour it and still say the same thing in a
+ *      different order forever — which is exactly what it did.  The recall ring
+ *      keeps the last few *complete* utterances: they go into the prompt as
+ *      "you already said these", and dialogue_style_is_repetitive() re-checks
+ *      the answer against them on-device, because an instruction the model can
+ *      quietly ignore is not a guarantee.
+ *
  * The same pools also back the canned fallback lines, so an API outage does not
  * collapse the robot back onto one fixed sentence.
  *
@@ -49,6 +58,7 @@
 #ifndef DIALOGUE_STYLE_H
 #define DIALOGUE_STYLE_H
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -68,6 +78,32 @@ extern "C" {
 
 /** Words of a spoken line treated as its "opening". */
 #define DIALOGUE_OPENING_WORDS 3
+
+/** How many whole spoken lines are remembered and shown back to the model.
+ *
+ *  Storage is DIALOGUE_RECALL_SLOTS * DIALOGUE_RECALL_MAX bytes of .bss, and
+ *  the rendered list is prompt payload on every planner request — so this trades
+ *  DRAM and tokens for how far back the robot's memory of itself reaches. Five
+ *  lines at a ~60 s speaking floor covers roughly the last five minutes. */
+#define DIALOGUE_RECALL_SLOTS 5
+
+/** Longest remembered line, including NUL.
+ *
+ *  Shorter than SPEECH_TEXT_MAX (320) on purpose: the tail of a sentence is the
+ *  least useful part for "have I said this already", and five full-length slots
+ *  would put 1.6 kB into every prompt. A line longer than this is stored cut at
+ *  a word boundary — never mid multi-byte sequence, since the stored text goes
+ *  straight into a JSON request body. */
+#define DIALOGUE_RECALL_MAX 160
+
+/** Default similarity (percent) at or above which a candidate line counts as a
+ *  repeat of something already said. Sørensen–Dice over the two word sets, so
+ *  100 is "same words", 0 is "nothing in common".
+ *
+ *  60 is a starting point, not a derived constant — how much repetition is
+ *  tolerable is a judgement only somebody listening to the robot can make, which
+ *  is why dialogue_style_set_repeat_pct() exists and the console exposes it. */
+#define DIALOGUE_REPEAT_PCT_DEFAULT 60
 
 /**
  * @brief A pool of interchangeable strings, one of which is drawn per use.
@@ -143,17 +179,65 @@ size_t dialogue_style_directive(const dialogue_pool_t *openers, const dialogue_p
 
 /**
  * @brief Record a line the robot actually spoke, so the next prompt can ask
- *        for a different opening.
+ *        for a different opening — and so the line itself can be recalled.
  *
- * Stores only the first DIALOGUE_OPENING_WORDS words, with trailing
- * punctuation trimmed.  A repeat of the newest stored opening is ignored
- * rather than stored twice — otherwise one stubborn phrase would fill the ring
- * and crowd out the older openings that still need avoiding.
+ * Feeds two rings: the openings ring (first DIALOGUE_OPENING_WORDS words, with
+ * trailing punctuation trimmed) and the recall ring (the whole line, cut at a
+ * word boundary to DIALOGUE_RECALL_MAX).  A repeat of the newest stored opening
+ * is ignored rather than stored twice — otherwise one stubborn phrase would
+ * fill the ring and crowd out the older openings that still need avoiding.
  *
  * Call it for lines the robot generates, not for lines a human typed at the
  * console (`voice say`), which are auditions rather than dialogue.
  */
 void dialogue_style_note_spoken(const char *line);
+
+/**
+ * @brief The remembered whole lines as a quoted, comma-separated list.
+ *
+ * Newest first, so a truncating buffer keeps the most recent — the ones the
+ * listener would notice being repeated. Writes "" and returns 0 when nothing
+ * has been recorded, which the caller must treat as "omit the clause entirely"
+ * rather than emitting a dangling lead-in.
+ */
+size_t dialogue_style_recent_lines(char *out, size_t out_len);
+
+/**
+ * @brief How similar @p a and @p b are, 0..100 (Sørensen–Dice over word sets).
+ *
+ * Word comparison ignores punctuation and ASCII case. Non-ASCII bytes are
+ * compared as-is: case-folding Finnish ä/ö would need a table, and the only
+ * place it would matter is a sentence-initial capital, which changes one word
+ * out of a dozen. Exposed mainly so the threshold can be judged from real
+ * transcripts in a host test.
+ */
+unsigned dialogue_style_similarity(const char *a, const char *b);
+
+/**
+ * @brief True when @p line repeats something in the recall ring.
+ *
+ * The on-device half of the anti-repetition contract: the prompt *asks* the
+ * model not to repeat itself, this *checks*. Delivery tags are stripped before
+ * comparing, so re-saying a line with a different `[sighs]` still counts as a
+ * repeat.
+ *
+ * Apply it to model-generated lines only. A status report whose facts have not
+ * changed is supposed to read the same, and a console audition is meant to be
+ * repeatable on demand.
+ */
+bool dialogue_style_is_repetitive(const char *line);
+
+/**
+ * @brief Set the similarity percentage that counts as a repeat (1..100).
+ *
+ * Values outside the range are ignored. 100 effectively means "only reject a
+ * verbatim repeat". Tunable at runtime because the right value is a matter of
+ * taste — see DIALOGUE_REPEAT_PCT_DEFAULT.
+ */
+void dialogue_style_set_repeat_pct(uint8_t pct);
+
+/** @brief Current repeat threshold, as set by dialogue_style_set_repeat_pct(). */
+uint8_t dialogue_style_repeat_pct(void);
 
 /**
  * @brief The remembered openings as a quoted, comma-separated list.
@@ -163,7 +247,7 @@ void dialogue_style_note_spoken(const char *line);
  */
 size_t dialogue_style_recent_openings(char *out, size_t out_len);
 
-/** @brief Forget all recorded openings (persona switch, or tests). */
+/** @brief Forget all recorded openings and lines (persona switch, or tests). */
 void dialogue_style_reset_recent(void);
 
 #ifdef __cplusplus

--- a/packages/robocar/unified/main/gemini_backend.c
+++ b/packages/robocar/unified/main/gemini_backend.c
@@ -16,6 +16,8 @@
 
 #include "gemini_backend.h"
 
+#include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -30,6 +32,7 @@
 #include "gemini_parse.h"
 #include "goal_state.h"
 #include "planner_task.h" /* PLANNER_LOOP_PERIOD_MS — keeps the stated cadence honest */
+#include "speech_budget.h"
 #include "voice_persona.h"
 
 static const char *TAG = "gemini_backend";
@@ -84,6 +87,41 @@ static const char *TAG = "gemini_backend";
 
 #define GEMINI_THINKING_BUDGET 0
 
+/** Planner system prompt buffer.
+ *
+ *  Lives on the planner task stack, so it is sized deliberately rather than
+ *  generously: ~800 bytes of fixed instruction, plus the persona's text_brief
+ *  (~450) and tag_brief (~350), plus a variation directive (up to
+ *  DIALOGUE_STYLE_MAX) and the recalled-lines clause (GEMINI_RECALL_LIST_MAX).
+ *  PLANNER_TASK_STACK_SIZE is set with this frame in mind — grow them together.
+ */
+#define GEMINI_SYSTEM_PROMPT_MAX 3072
+
+/** Cap on the rendered "you already said these" list.
+ *
+ *  Bounds prompt cost, not correctness: dialogue_style_recent_lines() drops
+ *  whole entries (newest first is kept) rather than truncating one, so a
+ *  smaller cap simply means a shorter memory in the prompt. The on-device
+ *  repetition check still sees the full ring. */
+#define GEMINI_RECALL_LIST_MAX 768
+
+/* The two prompt clauses whose length is not fixed at compile time are the
+ * recall list and the persona briefs, and they are assembled *before* the
+ * closing "function calls only" instruction. Left to saturate, a long persona
+ * would silently truncate that instruction away and the model would start
+ * answering in prose — a failure with no obvious cause. So the recall list is
+ * sized against the room actually left, minus exactly what the closing sentence
+ * and this clause's own wrapper need. Both are measured with sizeof from the
+ * literals themselves so editing the wording cannot put the arithmetic out of
+ * date. */
+static const char k_prompt_closing[] = "Respond ONLY with function calls — no prose, no markdown.";
+static const char k_prompt_recall_fmt[] =
+    "You have already said these recently: %s. Do not repeat any of them, and do not restate "
+    "the same observation in different words — if all you would do is say one of them again, "
+    "do not call 'speak' at all. ";
+#define GEMINI_RECALL_CLAUSE_OVERHEAD (sizeof(k_prompt_recall_fmt) - 3u) /* less "%s", less NUL */
+#define GEMINI_PROMPT_TAIL_RESERVE (sizeof(k_prompt_closing) + GEMINI_RECALL_CLAUSE_OVERHEAD)
+
 /* -------------------------------------------------------------------------- */
 /* Module state                                                                 */
 /* -------------------------------------------------------------------------- */
@@ -133,13 +171,19 @@ static esp_err_t http_event_handler(esp_http_client_event_t *evt)
  * of drive / track / rotate / stop function calls, optionally accompanied by a
  * speak call (which is not a motion goal — see the note at its declaration).
  *
+ * @param allow_speak When false the `speak` declaration is omitted entirely, so
+ *        the model *cannot* produce an utterance on this cycle. Withholding the
+ *        tool rather than asking for restraint is the point: a stateless model
+ *        has no way to know how recently it last spoke, so "use it sparingly"
+ *        is advice it cannot act on. See speech_budget.h.
+ *
  * Schema follows the Gemini API "functionDeclarations" format:
  *   https://ai.google.dev/api/generate-content#v1beta.Tool
  *
  * Box coordinates use the ER 1.6 convention: [ymin, xmin, ymax, xmax]
  * integers normalised 0..1000.
  */
-static cJSON *build_tools(void)
+static cJSON *build_tools(bool allow_speak)
 {
     cJSON *tools_arr = cJSON_CreateArray();
 
@@ -256,14 +300,14 @@ static cJSON *build_tools(void)
      * *alongside* one, and travels to the TTS task via speech_queue rather
      * than goal_state. See speech_queue.h for why the two cannot share a
      * lifetime. The parser recovers both from the same response. */
-    {
+    if (allow_speak) {
         cJSON *fn = cJSON_CreateObject();
         cJSON_AddStringToObject(fn, "name", "speak");
         cJSON_AddStringToObject(fn, "description",
                                 "Say something out loud through the robot's speaker. Call this "
-                                "IN ADDITION to a movement function, not instead of one. Use it "
-                                "sparingly — only when the scene changes in a way worth "
-                                "remarking on.");
+                                "IN ADDITION to a movement function, not instead of one. Omit it "
+                                "entirely unless this frame shows something you have not already "
+                                "remarked on — saying nothing is the normal case.");
         cJSON *params = cJSON_AddObjectToObject(fn, "parameters");
         cJSON_AddStringToObject(params, "type", "OBJECT");
         cJSON *props = cJSON_AddObjectToObject(params, "properties");
@@ -300,6 +344,24 @@ static cJSON *build_tools(void)
  *   }
  * }
  */
+/** snprintf-append into @p buf, saturating rather than overrunning.
+ *  @return the new length, always < @p cap. */
+__attribute__((format(printf, 4, 5))) static size_t append_prompt(char *buf, size_t cap, size_t pos,
+                                                                  const char *fmt, ...)
+{
+    if (pos + 1u >= cap) {
+        return cap - 1u;
+    }
+    va_list ap;
+    va_start(ap, fmt);
+    const int n = vsnprintf(buf + pos, cap - pos, fmt, ap);
+    va_end(ap);
+    if (n < 0) {
+        return pos;
+    }
+    return (pos + (size_t)n >= cap) ? (cap - 1u) : (pos + (size_t)n);
+}
+
 static char *build_request_json(const char *b64_image)
 {
     /* Built per call rather than static: the spoken register follows the active
@@ -308,30 +370,69 @@ static char *build_request_json(const char *b64_image)
      * cannot drift from the loop that actually calls it. */
     const voice_persona_t *persona = voice_persona_get();
 
-    /* Drawn fresh per request — this is the whole anti-repetition mechanism.
-     * The persona brief is constant, so without a directive that differs call
-     * to call the model converges on one favourite opening and keeps it. */
-    char variation[DIALOGUE_STYLE_MAX];
-    const size_t vlen = dialogue_style_directive(&persona->openers, &persona->shapes,
-                                                 persona->avoid_lead, variation, sizeof(variation));
+    /* The speech half of the prompt — and the `speak` declaration itself — is
+     * assembled only on a cycle where the budget permits an utterance. Every
+     * request is stateless, so this is the only place the robot's own recent
+     * history exists; see speech_budget.h. */
+    const uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+    const bool may_speak = speech_budget_allows(now_ms);
 
-    char system_prompt[2048];
-    snprintf(system_prompt, sizeof(system_prompt),
-             "You are the planning brain of a small wheeled robot. "
-             "Examine the image and choose exactly one movement for the robot to take next "
-             "by calling one of: drive, track, rotate, or stop. "
-             "Prefer 'track' when a target object is visible and centred in the frame. "
-             "Call 'stop' when the path is blocked or the scene is ambiguous. "
-             "You may ALSO call 'speak' in the same response to say one short sentence out "
-             "loud — do so only when the scene has changed in a way worth remarking on, not "
-             "on every frame. You are consulted about every %u seconds, so narrating "
-             "every time would be tiresome. "
-             "When you do call 'speak', the spoken text MUST follow this voice: %s "
-             "%s%s%s%s%s"
-             "Respond ONLY with function calls — no prose, no markdown.",
-             PLANNER_LOOP_PERIOD_MS / 1000U, persona->text_brief,
-             vlen ? "For this one line only: " : "", variation, vlen ? " " : "",
-             persona->tag_brief ? persona->tag_brief : "", persona->tag_brief ? " " : "");
+    char system_prompt[GEMINI_SYSTEM_PROMPT_MAX];
+    size_t pos = 0;
+
+    pos = append_prompt(system_prompt, sizeof(system_prompt), pos,
+                        "You are the planning brain of a small wheeled robot. "
+                        "Examine the image and choose exactly one movement for the robot to take "
+                        "next by calling one of: drive, track, rotate, or stop. "
+                        "Prefer 'track' when a target object is visible and centred in the frame. "
+                        "Call 'stop' when the path is blocked or the scene is ambiguous. ");
+
+    if (may_speak) {
+        /* Drawn fresh per request — this is the whole anti-repetition mechanism.
+         * The persona brief is constant, so without a directive that differs call
+         * to call the model converges on one favourite opening and keeps it. */
+        char variation[DIALOGUE_STYLE_MAX];
+        const size_t vlen = dialogue_style_directive(
+            &persona->openers, &persona->shapes, persona->avoid_lead, variation, sizeof(variation));
+
+        pos = append_prompt(system_prompt, sizeof(system_prompt), pos,
+                            "You may ALSO call 'speak' in the same response to say one short "
+                            "sentence out loud — do so only if this frame shows something worth "
+                            "remarking on, and stay silent otherwise. You are consulted about "
+                            "every %u seconds, so narrating every time would be tiresome. "
+                            "When you do call 'speak', the spoken text MUST follow this voice: %s ",
+                            PLANNER_LOOP_PERIOD_MS / 1000U, persona->text_brief);
+
+        if (vlen) {
+            pos = append_prompt(system_prompt, sizeof(system_prompt), pos,
+                                "For this one line only: %s ", variation);
+        }
+        if (persona->tag_brief) {
+            pos =
+                append_prompt(system_prompt, sizeof(system_prompt), pos, "%s ", persona->tag_brief);
+        }
+
+        /* What the robot has actually said, last because it is the instruction
+         * most worth having close to the answer — and the one clause that can be
+         * shortened without losing anything the others carry. The avoid-list
+         * inside `variation` only constrains the first few *words*; this is what
+         * stops the model from re-serving the same observation rearranged. */
+        size_t room = sizeof(system_prompt) - GEMINI_PROMPT_TAIL_RESERVE;
+        room = (pos < room) ? (room - pos) : 0u;
+        if (room > GEMINI_RECALL_LIST_MAX) {
+            room = GEMINI_RECALL_LIST_MAX;
+        }
+
+        char recall[GEMINI_RECALL_LIST_MAX];
+        if (room > 0u && dialogue_style_recent_lines(recall, room) > 0u) {
+            pos = append_prompt(system_prompt, sizeof(system_prompt), pos, k_prompt_recall_fmt,
+                                recall);
+        }
+    }
+
+    pos = append_prompt(system_prompt, sizeof(system_prompt), pos, "%s", k_prompt_closing);
+    (void)pos;
+
     const char *SYSTEM_PROMPT = system_prompt;
 
     cJSON *root = cJSON_CreateObject();
@@ -357,7 +458,7 @@ static char *build_request_json(const char *b64_image)
     /* tools — one tool object containing all five function declarations */
     cJSON *tools_arr = cJSON_AddArrayToObject(root, "tools");
     cJSON *tool_obj = cJSON_CreateObject();
-    cJSON *fn_decls = build_tools(); /* array of function objects */
+    cJSON *fn_decls = build_tools(may_speak); /* array of function objects */
     cJSON_AddItemToObject(tool_obj, "functionDeclarations", fn_decls);
     cJSON_AddItemToArray(tools_arr, tool_obj);
 

--- a/packages/robocar/unified/main/main.c
+++ b/packages/robocar/unified/main/main.c
@@ -50,6 +50,7 @@
 #include "reactive_controller.h"
 #include "self_report.h"
 #include "servo_controller.h"
+#include "speech_budget.h"
 #include "speech_queue.h"
 #include "voice_persona.h"
 #include "wifi_manager.h"
@@ -314,11 +315,15 @@ static void handle_periph_cmd(const char *buf)
 //   gpio set <pin> 0|1       - drive an output pin
 //   gpio get <pin>           - read one pin
 // ========================================
-/* `voice`                  — show current persona/voice and list the options
- * `voice <slug>`           — switch persona (e.g. `voice fi-1950`)
- * `voice say <text>`       — speak a line now, to audition the persona
- * `voice name <VoiceName>` — override the prebuilt voice (`voice name -` clears)
- * `voice vary`             — draw and print a variation directive (see below)
+/* `voice`                      — show current persona/voice/budget and options
+ * `voice <slug>`               — switch persona (e.g. `voice fi-1950`)
+ * `voice say <text>`           — speak a line now, to audition the persona
+ * `voice name <VoiceName>`     — override the prebuilt voice (`voice name -` clears)
+ * `voice vary`                 — draw and print a variation directive (see below)
+ * `voice said`                 — print what the robot remembers saying
+ * `voice quiet <seconds>`      — minimum gap between utterances (0 = none)
+ * `voice budget <n> <seconds>` — at most n utterances per window (n=0 mutes)
+ * `voice repeat <pct>`         — similarity at which a line counts as a repeat
  *
  * Switching and auditioning are runtime rather than compile-time because only a
  * listener can judge a voice; a reflash per candidate is far too slow a loop.
@@ -326,7 +331,13 @@ static void handle_periph_cmd(const char *buf)
  * `voice vary` exists for the same reason one step further in: the variation
  * pools (dialogue_style.h) only pay off if their entries read naturally in the
  * persona's language, and the alternative way to see what the model is being
- * told is to wait out a 15 s planner period per sample. */
+ * told is to wait out a 15 s planner period per sample.
+ *
+ * `quiet` / `budget` / `repeat` are the same argument again: how talkative and
+ * how repetitive the robot is allowed to be are judgements that need a person in
+ * the room, and every trial otherwise costs a rebuild plus a flash. They are not
+ * persisted — a boot comes up at the documented default rather than at whatever
+ * an experiment left behind. */
 static void handle_voice_cmd(const char *buf)
 {
     char op[24] = {0};
@@ -344,8 +355,75 @@ static void handle_voice_cmd(const char *buf)
             }
             printf("  %c %-12s %s\n", (p == cur) ? '*' : ' ', p->slug, p->label);
         }
-        printf(
-            "  usage: voice <slug> | voice say <text> | voice name <VoiceName|-> | voice vary\n");
+
+        uint32_t gap_ms = 0;
+        uint32_t window_ms = 0;
+        uint8_t max_per = 0;
+        speech_budget_get(&gap_ms, &max_per, &window_ms);
+        const uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000);
+        const uint32_t wait_ms = speech_budget_wait_ms(now_ms);
+        printf("  budget: quiet=%us max=%u/%us used=%u repeat=%u%%\n", (unsigned)(gap_ms / 1000U),
+               (unsigned)max_per, (unsigned)(window_ms / 1000U),
+               (unsigned)speech_budget_used(now_ms), (unsigned)dialogue_style_repeat_pct());
+        if (wait_ms == UINT32_MAX) {
+            printf("  speech: muted\n");
+        } else {
+            printf("  speech: %s (next in %us)\n", wait_ms ? "waiting" : "allowed now",
+                   (unsigned)(wait_ms / 1000U));
+        }
+
+        printf("  usage: voice <slug> | say <text> | name <VoiceName|-> | vary | said\n");
+        printf("         voice quiet <s> | voice budget <n> <s> | voice repeat <pct>\n");
+        return;
+    }
+
+    if (strcmp(op, "said") == 0) {
+        char lines[DIALOGUE_RECALL_SLOTS * (DIALOGUE_RECALL_MAX + 4)];
+        printf("voice: said %s\n",
+               dialogue_style_recent_lines(lines, sizeof(lines)) ? lines : "(nothing yet)");
+        return;
+    }
+
+    if (strcmp(op, "quiet") == 0) {
+        unsigned secs = 0;
+        if (sscanf(buf, "voice quiet %u", &secs) != 1) {
+            printf("voice: usage: voice quiet <seconds>\n");
+            return;
+        }
+        uint32_t window_ms = 0;
+        uint8_t max_per = 0;
+        speech_budget_get(NULL, &max_per, &window_ms);
+        speech_budget_configure(secs * 1000U, max_per, window_ms);
+        printf("voice: quiet=%us\n", secs);
+        return;
+    }
+
+    if (strcmp(op, "budget") == 0) {
+        unsigned max_per = 0;
+        unsigned secs = 0;
+        if (sscanf(buf, "voice budget %u %u", &max_per, &secs) != 2 || max_per > UINT8_MAX) {
+            printf("voice: usage: voice budget <n> <window seconds>  (n=0 mutes)\n");
+            return;
+        }
+        uint32_t gap_ms = 0;
+        speech_budget_get(&gap_ms, NULL, NULL);
+        speech_budget_configure(gap_ms, (uint8_t)max_per, secs * 1000U);
+        /* Read back rather than echo the argument: the cap is clamped to the
+         * history ring, and a silently ignored value is worse than none. */
+        uint8_t applied = 0;
+        speech_budget_get(NULL, &applied, NULL);
+        printf("voice: budget=%u/%us\n", (unsigned)applied, secs);
+        return;
+    }
+
+    if (strcmp(op, "repeat") == 0) {
+        unsigned pct = 0;
+        if (sscanf(buf, "voice repeat %u", &pct) != 1 || pct < 1U || pct > 100U) {
+            printf("voice: usage: voice repeat <1..100>  (percent word overlap)\n");
+            return;
+        }
+        dialogue_style_set_repeat_pct((uint8_t)pct);
+        printf("voice: repeat=%u%%\n", (unsigned)dialogue_style_repeat_pct());
         return;
     }
 
@@ -769,6 +847,11 @@ static esp_err_t init_hierarchical_ai(void)
     // Persona must load before the planner and TTS tasks start, since both read
     // it while building their first request. Needs NVS, which Phase 0 set up.
     voice_persona_init();
+
+    // How often the planner is even offered the `speak` tool. Must be reset
+    // before the planner task starts, since it reads the budget while building
+    // its first request.
+    speech_budget_init();
 
     // Speech path: queue and player must exist before the planner can emit a
     // `speak` call. Both are non-fatal — a robot that cannot talk should still

--- a/packages/robocar/unified/main/planner_task.c
+++ b/packages/robocar/unified/main/planner_task.c
@@ -13,11 +13,13 @@
 #include "camera.h"
 #include "dialogue_style.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "frame_dump.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "gemini_backend.h"
 #include "goal_state.h"
+#include "speech_budget.h"
 #include "speech_queue.h"
 
 static const char *TAG = "planner";
@@ -26,7 +28,12 @@ static const char *TAG = "planner";
  * Task constants
  * ========================================================================= */
 
-#define PLANNER_TASK_STACK_SIZE 8192U
+/* 10 KB rather than 8: gemini_backend.c's build_request_json() frame holds the
+ * system prompt (GEMINI_SYSTEM_PROMPT_MAX) plus the variation directive and the
+ * recalled-lines list, which together grew past 4 KB when the robot gained a
+ * memory of what it had said. Grow this with those buffers, not after a stack
+ * overflow reports it. */
+#define PLANNER_TASK_STACK_SIZE 10240U
 #define PLANNER_TASK_PRIORITY 3U
 #define PLANNER_TASK_CORE 1
 
@@ -107,14 +114,25 @@ static void planner_task(void *pvParameters)
          * Posted before the goal is written and regardless of whether the
          * motion goal parsed, so the robot can speak while holding position.
          * Non-blocking: a full queue drops the line rather than stalling the
-         * planner loop. */
+         * planner loop.
+         *
+         * The prompt already carries what was recently said and asks for
+         * something new; this re-checks the answer, because a request is not a
+         * guarantee. Only generated lines are screened — console auditions and
+         * status reports go straight to the queue. See dialogue_style.h. */
+        if (speech[0] != '\0' && dialogue_style_is_repetitive(speech)) {
+            ESP_LOGI(TAG, "Suppressed near-repeat: \"%s\"", speech);
+            speech[0] = '\0';
+        }
         if (speech[0] != '\0') {
             const esp_err_t sp_ret = speech_queue_post(speech);
             if (sp_ret == ESP_OK) {
-                /* Feeds the next prompt's "do not begin with" list. Only on a
-                 * successful post: a line dropped by a full queue is never
-                 * heard, so it is not a repetition anyone can notice. */
+                /* Feeds the next prompt's recall list and avoid-list, and spends
+                 * the speaking budget. Only on a successful post: a line dropped
+                 * by a full queue is never heard, so it is neither a repetition
+                 * anyone can notice nor an utterance worth rationing. */
                 dialogue_style_note_spoken(speech);
+                speech_budget_note((uint32_t)(esp_timer_get_time() / 1000));
                 ESP_LOGI(TAG, "Speech: \"%s\"", speech);
             } else if (sp_ret == ESP_ERR_NO_MEM) {
                 ESP_LOGD(TAG, "still speaking — dropped: \"%s\"", speech);

--- a/packages/robocar/unified/main/speech_budget.c
+++ b/packages/robocar/unified/main/speech_budget.c
@@ -1,0 +1,153 @@
+/**
+ * @file speech_budget.c
+ * @brief Speech rationing. See the header for why this is enforced on-device.
+ *
+ * Pure C by design — no FreeRTOS, no ESP-IDF — so test/test_speech_budget.c
+ * builds it on the host with no shims.
+ */
+
+#include "speech_budget.h"
+
+#include <string.h>
+
+/* -------------------------------------------------------------------------- */
+/* State                                                                       */
+/* -------------------------------------------------------------------------- */
+
+static uint32_t s_min_gap_ms = SPEECH_BUDGET_MIN_GAP_MS_DEFAULT;
+static uint32_t s_window_ms = SPEECH_BUDGET_WINDOW_MS_DEFAULT;
+static uint8_t s_max_per_window = SPEECH_BUDGET_MAX_PER_WINDOW_DEFAULT;
+
+/* Ring of utterance timestamps, newest at (head - 1). */
+static uint32_t s_hist[SPEECH_BUDGET_HISTORY];
+static uint8_t s_head;
+static uint8_t s_used;
+
+void speech_budget_init(void)
+{
+    s_min_gap_ms = SPEECH_BUDGET_MIN_GAP_MS_DEFAULT;
+    s_window_ms = SPEECH_BUDGET_WINDOW_MS_DEFAULT;
+    s_max_per_window = SPEECH_BUDGET_MAX_PER_WINDOW_DEFAULT;
+    memset(s_hist, 0, sizeof(s_hist));
+    s_head = 0;
+    s_used = 0;
+}
+
+void speech_budget_configure(uint32_t min_gap_ms, uint8_t max_per_window, uint32_t window_ms)
+{
+    s_min_gap_ms = min_gap_ms;
+    s_window_ms = window_ms;
+    /* Clamped rather than rejected: a cap larger than the history ring would
+     * silently never bind, which reads as "the limit is off" when it is really
+     * "the limit cannot be counted". */
+    s_max_per_window =
+        (max_per_window > SPEECH_BUDGET_HISTORY) ? (uint8_t)SPEECH_BUDGET_HISTORY : max_per_window;
+}
+
+void speech_budget_get(uint32_t *min_gap_ms, uint8_t *max_per_window, uint32_t *window_ms)
+{
+    if (min_gap_ms) {
+        *min_gap_ms = s_min_gap_ms;
+    }
+    if (max_per_window) {
+        *max_per_window = s_max_per_window;
+    }
+    if (window_ms) {
+        *window_ms = s_window_ms;
+    }
+}
+
+/** Newest timestamp, or false when nothing has been spoken yet. */
+static bool newest(uint32_t *out)
+{
+    if (s_used == 0u) {
+        return false;
+    }
+    const uint8_t idx = (uint8_t)((s_head + SPEECH_BUDGET_HISTORY - 1u) % SPEECH_BUDGET_HISTORY);
+    *out = s_hist[idx];
+    return true;
+}
+
+uint8_t speech_budget_used(uint32_t now_ms)
+{
+    if (s_window_ms == 0u) {
+        return 0;
+    }
+    uint8_t count = 0;
+    for (uint8_t n = 0; n < s_used; ++n) {
+        const uint8_t idx =
+            (uint8_t)((s_head + SPEECH_BUDGET_HISTORY - 1u - n) % SPEECH_BUDGET_HISTORY);
+        /* Unsigned difference: correct across the uint32 ms wrap. Entries walk
+         * newest-first, so the first one outside the window ends the scan. */
+        if ((uint32_t)(now_ms - s_hist[idx]) >= s_window_ms) {
+            break;
+        }
+        ++count;
+    }
+    return count;
+}
+
+bool speech_budget_allows(uint32_t now_ms)
+{
+    if (s_max_per_window == 0u) {
+        return false; /* muted */
+    }
+
+    uint32_t last = 0;
+    if (s_min_gap_ms > 0u && newest(&last) && (uint32_t)(now_ms - last) < s_min_gap_ms) {
+        return false;
+    }
+
+    if (s_window_ms > 0u && speech_budget_used(now_ms) >= s_max_per_window) {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t speech_budget_wait_ms(uint32_t now_ms)
+{
+    if (s_max_per_window == 0u) {
+        return UINT32_MAX;
+    }
+    if (speech_budget_allows(now_ms)) {
+        return 0;
+    }
+
+    uint32_t wait = 0;
+
+    uint32_t last = 0;
+    if (s_min_gap_ms > 0u && newest(&last)) {
+        const uint32_t since = (uint32_t)(now_ms - last);
+        if (since < s_min_gap_ms) {
+            wait = s_min_gap_ms - since;
+        }
+    }
+
+    /* Window-limited: the block lifts when the oldest in-window entry ages out.
+     * That is the (max_per_window)-th newest — one slot further back than the
+     * cap, counting from zero. */
+    if (s_window_ms > 0u && speech_budget_used(now_ms) >= s_max_per_window) {
+        const uint8_t nth = (uint8_t)(s_max_per_window - 1u);
+        if (nth < s_used) {
+            const uint8_t idx =
+                (uint8_t)((s_head + SPEECH_BUDGET_HISTORY - 1u - nth) % SPEECH_BUDGET_HISTORY);
+            const uint32_t age = (uint32_t)(now_ms - s_hist[idx]);
+            const uint32_t until = (age < s_window_ms) ? (s_window_ms - age) : 0u;
+            if (until > wait) {
+                wait = until;
+            }
+        }
+    }
+
+    return wait;
+}
+
+void speech_budget_note(uint32_t now_ms)
+{
+    s_hist[s_head] = now_ms;
+    s_head = (uint8_t)((s_head + 1u) % SPEECH_BUDGET_HISTORY);
+    if (s_used < SPEECH_BUDGET_HISTORY) {
+        ++s_used;
+    }
+}

--- a/packages/robocar/unified/main/speech_budget.h
+++ b/packages/robocar/unified/main/speech_budget.h
@@ -1,0 +1,116 @@
+/**
+ * @file speech_budget.h
+ * @brief How often the robot is allowed to say anything at all.
+ *
+ * The problem
+ * -----------
+ * The planner prompt asks the model to speak "only when the scene has changed in
+ * a way worth remarking on" and reminds it that it is consulted every
+ * PLANNER_LOOP_PERIOD_MS.  Neither instruction is *evaluable*: every planner
+ * request is a fresh, stateless call with one image and no record of the
+ * previous frame or of having spoken.  So the model behaves like a first-time
+ * observer every time — which, pointed at an unchanging bench scene, means it
+ * remarks on the same unchanging thing every cycle.
+ *
+ * The approach
+ * ------------
+ * Ration speech on-device and enforce it by *withholding the tool*: on a quiet
+ * cycle gemini_backend.c omits the `speak` function declaration from the request
+ * altogether, so the model cannot call it.  An instruction is advisory; a
+ * missing tool is not.  Two independent limits, either of which can veto:
+ *
+ *   - a **minimum gap** between utterances (the "stop chattering" knob), and
+ *   - a **cap per rolling window** (the "do not monologue for five minutes
+ *     straight" knob), which a minimum gap alone cannot express.
+ *
+ * Both are runtime-tunable from the console rather than compile-time, for the
+ * same reason the camera gain ceiling is: whether a robot is pleasantly laconic
+ * or annoyingly mute is a judgement only somebody in the room can make, and a
+ * reflash per trial is far too slow a loop.  They are deliberately *not*
+ * persisted — a boot should come up at the documented default rather than at
+ * whatever last night's experiment left behind.
+ *
+ * Time and concurrency
+ * --------------------
+ * The caller passes the clock in (`now_ms`, from esp_timer_get_time()/1000) so
+ * this module stays free of ESP-IDF and FreeRTOS and can be unit-tested on the
+ * host — same discipline as dialogue_style.c's externally seeded PRNG.  All
+ * comparisons are unsigned differences, which are correct across the ~49.7-day
+ * uint32 millisecond wrap as long as no single interval exceeds ~24.8 days.
+ *
+ * State is unlocked.  The planner is the only writer; the console reads it to
+ * print status.  A torn read can only misreport a count by one for one line.
+ */
+
+#ifndef SPEECH_BUDGET_H
+#define SPEECH_BUDGET_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Minimum gap between two utterances, ms. Four planner periods at the 15 s
+ *  default — enough that the robot reads as commenting rather than narrating. */
+#define SPEECH_BUDGET_MIN_GAP_MS_DEFAULT 60000u
+
+/** Rolling window for the cap, ms. */
+#define SPEECH_BUDGET_WINDOW_MS_DEFAULT 300000u
+
+/** Utterances allowed per window. */
+#define SPEECH_BUDGET_MAX_PER_WINDOW_DEFAULT 3u
+
+/** Timestamps retained. Only the newest SPEECH_BUDGET_MAX_PER_WINDOW_DEFAULT-ish
+ *  matter, but the cap is runtime-tunable, so keep headroom for a raised one. */
+#define SPEECH_BUDGET_HISTORY 12
+
+/**
+ * @brief Reset to the compiled-in defaults and forget all history.
+ *
+ * Call once at boot, before the planner starts.
+ */
+void speech_budget_init(void);
+
+/**
+ * @brief Set both limits.
+ *
+ * @param min_gap_ms     0 disables the gap check.
+ * @param max_per_window 0 mutes the robot entirely (no cycle ever offers
+ *                       `speak`); values above SPEECH_BUDGET_HISTORY are
+ *                       clamped, since the window count cannot see further back.
+ * @param window_ms      0 disables the window check.
+ */
+void speech_budget_configure(uint32_t min_gap_ms, uint8_t max_per_window, uint32_t window_ms);
+
+/** @brief Read back the configured limits. Any pointer may be NULL. */
+void speech_budget_get(uint32_t *min_gap_ms, uint8_t *max_per_window, uint32_t *window_ms);
+
+/**
+ * @brief Whether an utterance is permitted right now.
+ *
+ * @param now_ms Monotonic milliseconds (esp_timer_get_time() / 1000).
+ */
+bool speech_budget_allows(uint32_t now_ms);
+
+/** @brief Record that the robot spoke at @p now_ms. Call only on lines that
+ *         actually reached the speech queue — a dropped line was never heard. */
+void speech_budget_note(uint32_t now_ms);
+
+/**
+ * @brief Milliseconds until speech is permitted again, 0 when it already is.
+ *
+ * For logging and the console. Returns UINT32_MAX when muted
+ * (max_per_window == 0), i.e. "not on any schedule".
+ */
+uint32_t speech_budget_wait_ms(uint32_t now_ms);
+
+/** @brief Utterances inside the current window, for the console status line. */
+uint8_t speech_budget_used(uint32_t now_ms);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPEECH_BUDGET_H */

--- a/packages/robocar/unified/test/CMakeLists.txt
+++ b/packages/robocar/unified/test/CMakeLists.txt
@@ -127,6 +127,19 @@ target_link_libraries(test_dialogue_style PRIVATE Threads::Threads m)
 add_test(NAME dialogue_style COMMAND test_dialogue_style)
 
 # -----------------------------------------------------------------------------
+# speech_budget rationing (how often the robot is offered the `speak` tool)
+#
+# Pure C with an injected clock, so the uint32 millisecond wrap is reachable in
+# a test instead of only after 49 days of uptime.
+# -----------------------------------------------------------------------------
+add_executable(test_speech_budget
+    "${MAIN_SRC_DIR}/speech_budget.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_speech_budget.c"
+)
+target_link_libraries(test_speech_budget PRIVATE Threads::Threads m)
+add_test(NAME speech_budget COMMAND test_speech_budget)
+
+# -----------------------------------------------------------------------------
 # gemini parse (Phase 5, gate G1, issue #228)
 #
 # Only built when cJSON is available. Skipped (with a message) otherwise so

--- a/packages/robocar/unified/test/test_dialogue_style.c
+++ b/packages/robocar/unified/test/test_dialogue_style.c
@@ -329,6 +329,182 @@ static void test_recent_openings_respects_a_small_buffer(void)
 }
 
 /* =========================================================================
+ * Recalled whole lines
+ * ========================================================================= */
+
+static void test_recall_keeps_whole_lines(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("Edessä on pöydän jalka ja johtoja.");
+
+    char buf[512];
+    ASSERT(dialogue_style_recent_lines(buf, sizeof(buf)) > 0);
+    /* The trailing full stop is trimmed with any other clause punctuation; what
+     * matters is that the whole sentence survived, not just its opening. */
+    ASSERT(strcmp(buf, "\"Edessä on pöydän jalka ja johtoja\"") == 0);
+}
+
+static void test_recall_lists_newest_first_and_evicts(void)
+{
+    fresh(1u);
+    for (int i = 1; i <= DIALOGUE_RECALL_SLOTS + 1; ++i) {
+        char line[64];
+        snprintf(line, sizeof(line), "line number %d here", i);
+        dialogue_style_note_spoken(line);
+    }
+
+    char buf[1024];
+    (void)dialogue_style_recent_lines(buf, sizeof(buf));
+    char newest[64];
+    snprintf(newest, sizeof(newest), "line number %d here", DIALOGUE_RECALL_SLOTS + 1);
+    ASSERT(strncmp(buf + 1, newest, strlen(newest)) == 0); /* newest first, after the quote */
+    ASSERT(strstr(buf, "line number 1 here") == NULL);     /* pushed out of the ring */
+}
+
+static void test_recall_keeps_near_repeats(void)
+{
+    /* The openings ring drops a repeat of its newest entry so one phrase cannot
+     * flood it. The recall ring must NOT do that: a near-repeat is precisely
+     * what the next repetition check has to be able to see. */
+    fresh(1u);
+    dialogue_style_note_spoken("Alpha beta gamma delta");
+    dialogue_style_note_spoken("Alpha beta gamma epsilon");
+
+    char buf[1024];
+    (void)dialogue_style_recent_lines(buf, sizeof(buf));
+    ASSERT(strstr(buf, "delta") != NULL);
+    ASSERT(strstr(buf, "epsilon") != NULL);
+}
+
+static void test_recall_strips_delivery_tags(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("[sighs] Tie on yhä tukossa");
+
+    char buf[512];
+    (void)dialogue_style_recent_lines(buf, sizeof(buf));
+    ASSERT(strstr(buf, "sighs") == NULL);
+    ASSERT(strcmp(buf, "\"Tie on yhä tukossa\"") == 0);
+}
+
+static void test_recall_respects_a_small_buffer(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("Alpha alpha alpha");
+    dialogue_style_note_spoken("Beta beta beta");
+    dialogue_style_note_spoken("Gamma gamma gamma");
+
+    for (size_t cap = 1; cap < 80; ++cap) {
+        char buf[96];
+        memset(buf, 0x7F, sizeof(buf));
+        const size_t n = dialogue_style_recent_lines(buf, cap);
+        ASSERT(n < cap);
+        ASSERT(strlen(buf) == n);
+        ASSERT((unsigned char)buf[cap] == 0x7Fu);
+    }
+    ASSERT(dialogue_style_recent_lines(NULL, 16) == 0);
+}
+
+/* =========================================================================
+ * Similarity / repetition
+ * ========================================================================= */
+
+static void test_similarity_extremes(void)
+{
+    ASSERT(dialogue_style_similarity("alpha beta gamma", "alpha beta gamma") == 100);
+    ASSERT(dialogue_style_similarity("alpha beta gamma", "kissa koira hevonen") == 0);
+    ASSERT(dialogue_style_similarity("", "") == 0);
+    ASSERT(dialogue_style_similarity(NULL, "alpha") == 0);
+}
+
+static void test_similarity_ignores_case_and_punctuation(void)
+{
+    /* The failure this guards: the same sentence returned with a different
+     * capital or a comma moved would score 0 and sail through as "novel". */
+    ASSERT(dialogue_style_similarity("Alpha, beta; gamma!", "alpha beta gamma") == 100);
+    ASSERT(dialogue_style_similarity("\"Alpha beta gamma.\"", "gamma beta alpha") == 100);
+}
+
+static void test_similarity_ignores_word_order(void)
+{
+    /* Reordering is the exact dodge the three-word avoid-list allowed. */
+    ASSERT(dialogue_style_similarity("tie on tukossa edessä", "edessä tukossa on tie") == 100);
+}
+
+static void test_similarity_partial_overlap(void)
+{
+    /* 3 shared of 4+4 unique -> 2*3/8 = 75%. */
+    ASSERT(dialogue_style_similarity("alpha beta gamma delta", "alpha beta gamma epsilon") == 75);
+    /* 1 shared of 3+3 -> 2/6 = 33%. */
+    ASSERT(dialogue_style_similarity("alpha beta gamma", "alpha kissa koira") == 33);
+}
+
+static void test_similarity_does_not_double_count_repeats(void)
+{
+    /* Word *sets*, not multisets: a filler word repeated inside one sentence
+     * must not inflate the score toward a false repeat. */
+    ASSERT(dialogue_style_similarity("no no no alpha", "no alpha") == 100);
+}
+
+static void test_is_repetitive_against_the_ring(void)
+{
+    fresh(1u);
+    ASSERT(!dialogue_style_is_repetitive("Edessä on pöydän jalka"));
+
+    dialogue_style_note_spoken("Edessä on pöydän jalka");
+    ASSERT(dialogue_style_is_repetitive("Edessä on pöydän jalka"));
+    ASSERT(dialogue_style_is_repetitive("Pöydän jalka on edessä.")); /* reordered */
+    ASSERT(!dialogue_style_is_repetitive("Vasemmalla näkyy avoin ovi"));
+}
+
+static void test_is_repetitive_ignores_delivery_tags(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("Tie on tukossa");
+    ASSERT(dialogue_style_is_repetitive("[sighs] Tie on tukossa"));
+}
+
+static void test_is_repetitive_honours_the_threshold(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("alpha beta gamma delta");
+
+    /* 75% similar (see test_similarity_partial_overlap). */
+    dialogue_style_set_repeat_pct(70);
+    ASSERT(dialogue_style_is_repetitive("alpha beta gamma epsilon"));
+    dialogue_style_set_repeat_pct(80);
+    ASSERT(!dialogue_style_is_repetitive("alpha beta gamma epsilon"));
+    ASSERT(dialogue_style_is_repetitive("alpha beta gamma delta")); /* verbatim, always */
+
+    /* Out-of-range values are ignored rather than clamped to something silly. */
+    dialogue_style_set_repeat_pct(0);
+    ASSERT(dialogue_style_repeat_pct() == 80);
+    dialogue_style_set_repeat_pct(101);
+    ASSERT(dialogue_style_repeat_pct() == 80);
+    dialogue_style_set_repeat_pct(DIALOGUE_REPEAT_PCT_DEFAULT);
+}
+
+static void test_is_repetitive_handles_empty_input(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("alpha beta gamma");
+    ASSERT(!dialogue_style_is_repetitive(NULL));
+    ASSERT(!dialogue_style_is_repetitive(""));
+    ASSERT(!dialogue_style_is_repetitive("[sighs]")); /* nothing but a tag */
+}
+
+static void test_reset_clears_the_recall_ring(void)
+{
+    fresh(1u);
+    dialogue_style_note_spoken("alpha beta gamma");
+    dialogue_style_reset_recent();
+
+    char buf[256];
+    ASSERT(dialogue_style_recent_lines(buf, sizeof(buf)) == 0);
+    ASSERT(!dialogue_style_is_repetitive("alpha beta gamma"));
+}
+
+/* =========================================================================
  * Composed directive
  * ========================================================================= */
 
@@ -456,6 +632,25 @@ int main(void)
     test_run("utf-8 opening survives intact", test_utf8_opening_survives_intact);
     test_run("recent_openings respects a small buffer",
              test_recent_openings_respects_a_small_buffer);
+
+    test_run("recall keeps whole lines", test_recall_keeps_whole_lines);
+    test_run("recall lists newest first and evicts", test_recall_lists_newest_first_and_evicts);
+    test_run("recall keeps near-repeats", test_recall_keeps_near_repeats);
+    test_run("recall strips delivery tags", test_recall_strips_delivery_tags);
+    test_run("recall respects a small buffer", test_recall_respects_a_small_buffer);
+
+    test_run("similarity extremes", test_similarity_extremes);
+    test_run("similarity ignores case and punctuation",
+             test_similarity_ignores_case_and_punctuation);
+    test_run("similarity ignores word order", test_similarity_ignores_word_order);
+    test_run("similarity scores partial overlap", test_similarity_partial_overlap);
+    test_run("similarity does not double-count repeats",
+             test_similarity_does_not_double_count_repeats);
+    test_run("is_repetitive checks the recall ring", test_is_repetitive_against_the_ring);
+    test_run("is_repetitive ignores delivery tags", test_is_repetitive_ignores_delivery_tags);
+    test_run("is_repetitive honours the threshold", test_is_repetitive_honours_the_threshold);
+    test_run("is_repetitive handles empty input", test_is_repetitive_handles_empty_input);
+    test_run("reset clears the recall ring", test_reset_clears_the_recall_ring);
 
     test_run("directive contains an opener and a shape",
              test_directive_contains_an_opener_and_a_shape);

--- a/packages/robocar/unified/test/test_speech_budget.c
+++ b/packages/robocar/unified/test/test_speech_budget.c
@@ -1,0 +1,241 @@
+/**
+ * @file test_speech_budget.c
+ * @brief Host tests for the speech rationing module.
+ *
+ * The module exists to answer one question — "may the robot speak right now?" —
+ * and the expensive failure modes are all arithmetic: an off-by-one that lets a
+ * fourth line through a three-line window, a window that never reopens, or a
+ * comparison that breaks across the uint32 millisecond wrap and mutes the robot
+ * for 49 days. Those are exactly what a host test can pin down and a bench
+ * session cannot: reproducing the wrap on hardware means waiting for it.
+ */
+
+#include "speech_budget.h"
+
+#include <assert.h>
+#include <stdio.h>
+
+/* =========================================================================
+ * Test harness
+ * ========================================================================= */
+
+static int test_count = 0;
+static int test_pass = 0;
+
+static void test_assert(int cond, const char *file, int line, const char *expr)
+{
+    if (!cond) {
+        printf("FAIL: %s:%d assertion failed: %s\n", file, line, expr);
+        assert(cond);
+    }
+}
+
+#define ASSERT(cond) test_assert((cond), __FILE__, __LINE__, #cond)
+
+static void test_run(const char *name, void (*fn)(void))
+{
+    test_count++;
+    printf("[%d] Running: %s...\n", test_count, name);
+    fflush(stdout);
+    fn();
+    test_pass++;
+    printf("     PASS\n");
+}
+
+/* =========================================================================
+ * Defaults
+ * ========================================================================= */
+
+static void test_defaults_allow_the_first_line(void)
+{
+    speech_budget_init();
+    /* A freshly booted robot has said nothing, so nothing should hold it back —
+     * the self-introduction would otherwise be swallowed by its own budget. */
+    ASSERT(speech_budget_allows(0));
+    ASSERT(speech_budget_wait_ms(0) == 0);
+    ASSERT(speech_budget_used(0) == 0);
+}
+
+static void test_defaults_are_reported(void)
+{
+    speech_budget_init();
+    uint32_t gap = 0;
+    uint32_t window = 0;
+    uint8_t max_per = 0;
+    speech_budget_get(&gap, &max_per, &window);
+    ASSERT(gap == SPEECH_BUDGET_MIN_GAP_MS_DEFAULT);
+    ASSERT(window == SPEECH_BUDGET_WINDOW_MS_DEFAULT);
+    ASSERT(max_per == SPEECH_BUDGET_MAX_PER_WINDOW_DEFAULT);
+
+    /* Every pointer is optional — the console reads one field at a time. */
+    speech_budget_get(NULL, NULL, NULL);
+}
+
+/* =========================================================================
+ * Minimum gap
+ * ========================================================================= */
+
+static void test_min_gap_blocks_then_lifts(void)
+{
+    speech_budget_init();
+    speech_budget_configure(10000u, 100u, 0u); /* gap only; window disabled */
+
+    speech_budget_note(1000u);
+    ASSERT(!speech_budget_allows(1000u));
+    ASSERT(!speech_budget_allows(10999u));
+    ASSERT(speech_budget_wait_ms(6000u) == 5000u);
+    ASSERT(speech_budget_allows(11000u)); /* exactly at the gap */
+}
+
+static void test_zero_gap_disables_the_check(void)
+{
+    speech_budget_init();
+    speech_budget_configure(0u, 100u, 0u);
+    speech_budget_note(1000u);
+    ASSERT(speech_budget_allows(1000u));
+}
+
+/* =========================================================================
+ * Rolling window
+ * ========================================================================= */
+
+static void test_window_caps_the_count(void)
+{
+    speech_budget_init();
+    speech_budget_configure(0u, 3u, 100000u); /* window only */
+
+    speech_budget_note(0u);
+    speech_budget_note(10000u);
+    ASSERT(speech_budget_used(20000u) == 2);
+    ASSERT(speech_budget_allows(20000u));
+
+    speech_budget_note(20000u);
+    ASSERT(speech_budget_used(20000u) == 3);
+    ASSERT(!speech_budget_allows(20000u)); /* cap reached */
+
+    /* Reopens when the oldest of the three ages out of the window, not when the
+     * newest does — the off-by-one this test exists for. */
+    ASSERT(!speech_budget_allows(99999u));
+    ASSERT(speech_budget_allows(100000u));
+    ASSERT(speech_budget_wait_ms(50000u) == 50000u);
+}
+
+static void test_window_only_counts_inside_it(void)
+{
+    speech_budget_init();
+    speech_budget_configure(0u, 3u, 10000u);
+    speech_budget_note(0u);
+    speech_budget_note(1000u);
+    ASSERT(speech_budget_used(5000u) == 2);
+    ASSERT(speech_budget_used(10500u) == 1); /* the first has aged out */
+    ASSERT(speech_budget_used(50000u) == 0);
+    /* The window is half-open: an entry exactly window_ms old is already out. */
+    ASSERT(speech_budget_used(9999u) == 2);
+    ASSERT(speech_budget_used(10000u) == 1);
+}
+
+static void test_zero_window_disables_the_check(void)
+{
+    speech_budget_init();
+    speech_budget_configure(0u, 1u, 0u);
+    speech_budget_note(0u);
+    speech_budget_note(1u);
+    ASSERT(speech_budget_allows(2u));
+    ASSERT(speech_budget_used(2u) == 0);
+}
+
+/* =========================================================================
+ * Mute and clamping
+ * ========================================================================= */
+
+static void test_zero_cap_mutes(void)
+{
+    speech_budget_init();
+    speech_budget_configure(0u, 0u, 60000u);
+    ASSERT(!speech_budget_allows(0u));
+    ASSERT(!speech_budget_allows(1000000u));
+    /* UINT32_MAX rather than a huge number of milliseconds: muted is a state,
+     * not a wait, and the console prints the two differently. */
+    ASSERT(speech_budget_wait_ms(0u) == UINT32_MAX);
+}
+
+static void test_cap_is_clamped_to_the_history(void)
+{
+    /* A cap the ring cannot count would silently never bind, which reads as
+     * "the limit is off" when it is really "the limit is unmeasurable". */
+    speech_budget_init();
+    speech_budget_configure(0u, 250u, 60000u);
+    uint8_t max_per = 0;
+    speech_budget_get(NULL, &max_per, NULL);
+    ASSERT(max_per == SPEECH_BUDGET_HISTORY);
+}
+
+/* =========================================================================
+ * Clock wrap
+ * ========================================================================= */
+
+static void test_survives_the_uint32_wrap(void)
+{
+    /* esp_timer_get_time()/1000 wraps every ~49.7 days. A signed or naive
+     * comparison would mute the robot from the wrap onward — a fault nobody
+     * would reproduce on a bench, and which reads as "the voice just stopped". */
+    speech_budget_init();
+    speech_budget_configure(10000u, 3u, 100000u);
+
+    const uint32_t before_wrap = UINT32_MAX - 5000u;
+    speech_budget_note(before_wrap);
+
+    /* Deliberately expressed as an offset from the stored stamp so the wrap is
+     * the compiler's arithmetic, not a hand-counted literal: `before_wrap +
+     * 10000` is 4999 in wrapped time, and both sides must agree on that. */
+    ASSERT(!speech_budget_allows(before_wrap + 9999u));
+    ASSERT(speech_budget_used(before_wrap + 9999u) == 1);
+    ASSERT(speech_budget_allows(before_wrap + 10000u));
+    ASSERT((uint32_t)(before_wrap + 10000u) == 4999u); /* it really did wrap */
+}
+
+/* =========================================================================
+ * Combined
+ * ========================================================================= */
+
+static void test_either_limit_can_veto(void)
+{
+    speech_budget_init(); /* 60 s gap, 3 per 300 s */
+
+    ASSERT(speech_budget_allows(0u));
+    speech_budget_note(0u);
+    ASSERT(!speech_budget_allows(30000u)); /* gap */
+    ASSERT(speech_budget_allows(60000u));
+    speech_budget_note(60000u);
+    speech_budget_note(120000u);
+    ASSERT(!speech_budget_allows(180000u)); /* window, though the gap is clear */
+    ASSERT(speech_budget_allows(300000u));  /* the first has aged out */
+}
+
+/* =========================================================================
+ * Main
+ * ========================================================================= */
+
+int main(void)
+{
+    printf("=== speech_budget host tests ===\n\n");
+
+    test_run("defaults allow the first line", test_defaults_allow_the_first_line);
+    test_run("defaults are reported", test_defaults_are_reported);
+
+    test_run("minimum gap blocks then lifts", test_min_gap_blocks_then_lifts);
+    test_run("zero gap disables the check", test_zero_gap_disables_the_check);
+
+    test_run("window caps the count", test_window_caps_the_count);
+    test_run("window only counts inside it", test_window_only_counts_inside_it);
+    test_run("zero window disables the check", test_zero_window_disables_the_check);
+
+    test_run("zero cap mutes", test_zero_cap_mutes);
+    test_run("cap is clamped to the history", test_cap_is_clamped_to_the_history);
+
+    test_run("survives the uint32 wrap", test_survives_the_uint32_wrap);
+    test_run("either limit can veto", test_either_limit_can_veto);
+
+    printf("\n=== %d/%d passed ===\n", test_pass, test_count);
+    return (test_pass == test_count) ? 0 : 1;
+}


### PR DESCRIPTION
## What

The robot repeated the same handful of spoken lines on every planner cycle. Three additions, none of which costs an extra API call:

1. **`speech_budget.c`** — a minimum gap (60 s) and a rolling cap (3 per 5 min) decide whether `build_tools()` declares the `speak` function *at all*. On a quiet cycle the whole speech half of the prompt is omitted too, so the muted request is also the cheaper one.
2. **A recall ring of whole utterances** in `dialogue_style.c`, fed back into the prompt as "you have already said these".
3. **`dialogue_style_is_repetitive()`** — an on-device re-check of the model's answer against that ring, applied in `planner_task.c`.

## Why

Every planner request is **stateless**: one image, one prompt, no previous frame and no record of having spoken. The prompt already said *"remark only when the scene has changed"* and *"you are consulted every 15 s, so narrating every time would be tiresome"* — but both ask for a judgement the model has no information to make. It arrives as a first-time observer on every call.

Two consequences, both visible on the bench (ESP32-S3 + amp + speaker, no motors, static scene):

- With nothing moving, a first-time observer correctly remarks on the same unmoving thing every time.
- The existing anti-repetition mechanism is an avoid-list of the last three **openings, three words each**. A model can honour it perfectly and still reorder the same sentence forever — which is what it did.

So: withhold the tool rather than word the prompt harder (there is no phrasing that makes an unknowable fact knowable), remember whole sentences rather than prefixes, and verify the answer rather than trust the instruction.

## Design notes

- **Withholding beats instructing.** An omitted function declaration is enforcement; "use it sparingly" is advice the model cannot act on.
- **Only generated lines are screened.** `voice say` is an audition and is meant to repeat on demand; a self-report whose facts have not changed is supposed to read the same. Suppressing either would turn a working command into one that silently does nothing.
- **Similarity is Sørensen–Dice over word *sets*** — case- and punctuation-insensitive, so reordering does not evade it, and a repeated filler word cannot inflate the score toward a false positive.
- **Thresholds are console knobs, not constants.** `voice quiet <s>`, `voice budget <n> <s>`, `voice repeat <pct>`, plus `voice said` to inspect the ring and `voice` to print live budget state. How talkative the robot should be needs a listener in the room, and a reflash per trial is far too slow a loop — the same argument as `cam gainceiling`. They deliberately do **not** persist to NVS.
- **Prompt-buffer arithmetic is exact, not generous.** The recall clause is sized against the room actually left, measured with `sizeof` from the format literals, so a long persona brief cannot silently truncate the closing "respond ONLY with function calls" instruction away and start the model answering in prose. `PLANNER_TASK_STACK_SIZE` grows with the buffers rather than after a stack overflow reports it.

Both new modules are pure C with injected state (clock, PRNG), matching `dialogue_style.c`'s existing discipline, so they unit-test on the host with no shims.

## Verification

```
$ just test
100% tests passed out of 8

$ just build
robocar-unified.bin binary size 0x135050 bytes. Smallest app partition is 0x380000 bytes. 0x24afb0 bytes (66%) free.
Build OK (robocar-unified.bin)
```

- **11 new `speech_budget` cases**: window boundary conditions, either-limit-vetoes, mute, cap clamping, and the uint32 millisecond wrap — a fault that would mute the robot from day 49 onward and that a bench session cannot reach.
- **15 new `dialogue_style` cases**: recall ring eviction and ordering, tag stripping, buffer truncation, and the similarity metric's behaviour on reordering, case, punctuation, and repeated words.
- `just lint` clean on all changed files.

Not verified on hardware yet — the behavioural claim ("the robot stops repeating itself") needs a bench session with the speaker.

## Follow-ups not in this PR

- **Scene-change gate**: `frame_stats_log()` already decodes every planner frame at 1/8 scale; a block-mean fingerprint compared frame to frame would make speech genuinely event-driven rather than merely rationed. This is the root-cause fix for a static scene.
- **NVS persistence** of the recall ring, so a reflash does not make the first line after every boot the model's favourite phrasing again.