### PR TITLE
ci: run the release-please job on ubuntu-slim

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,7 +20,8 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    # Pure GitHub-API job (no build) — 1-CPU slim runner is 3x cheaper.
+    runs-on: ubuntu-slim
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       prs_created: ${{ steps.release.outputs.prs_created }}


### PR DESCRIPTION
## What

Switch the `release-please` job from `ubuntu-latest` to `ubuntu-slim`. One line; no other job in the workflow is touched.

## Why

`ubuntu-slim` is $0.002/min vs $0.006/min for `ubuntu-latest` — 3x cheaper. The `release-please` job is a pure GitHub-API call (`create-github-app-token` + `googleapis/release-please-action`); it does no build work and needs nothing beyond what slim ships (bash, git, Node 24, `gh`, jq).

Any downstream `build` / `publish` job in the same workflow deliberately stays on `ubuntu-latest` — those need toolchains and, in some repos, a Docker daemon that slim does not have.

## Verification

Not speculative: `laurigates/claude-plugins` has run its `release-please` job on `ubuntu-slim` since 2026-03 with no failures.

Portfolio-wide sweep; the shared reusable workflows got the same treatment in laurigates/.github#44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UuZtyXzArr3RU2APRD6Q31