### PR TITLE
feat(robocar-unified): let someone talk to the robot and get an answer

### DIFF
--- a/packages/robocar/unified/CLAUDE.md
+++ b/packages/robocar/unified/CLAUDE.md
@@ -166,6 +166,20 @@ Note that **`voice loud 0` and `voice sound 0` mean the opposite of `voice scene
 
 None of this survives a reboot: the rings are `.bss`. Persisting them is worth doing if bench reflashes make the first line after every boot the model's favourite phrasing again.
 
+### Talking back: the push-to-talk voice turn
+
+`listen [seconds]` records from the microphone, sends the clip to Gemini, and speaks the reply through the **existing TTS path unchanged** (`voice_turn.c`). It is the opposite of everything above: the planner's speech is unprompted and gated, a voice turn is asked for and answered once.
+
+**It runs on a flash model, not Robotics-ER.** Gemini's free-tier quota is per model and the planner already saturates ER's 5 req/min, so answering someone can never cost the robot its ability to plan a movement.
+
+**The clip is WAV, and that is measured rather than assumed.** A live probe (2026-07) against `gemini-flash-latest:generateContent` with a 0.5 s tone: `mimeType: "audio/wav"` → 200 and a reply; `mimeType: "audio/pcm"` → **HTTP 400 "Request contains an invalid argument"**, naming no field. So `audio_clip.c` builds a canonical 44-byte header on-device, and `test_audio_clip.c` asserts those 44 bytes byte-for-byte — a field-width or byte-order slip there would otherwise surface only as an opaque 400 from a remote server after a ~170 kB upload. Audio costs ~26 tokens/second, so clip length is bounded by **memory**, not by API cost.
+
+**The free order matters more than it looks.** Raw PCM is released as soon as the WAV copy exists, the WAV as soon as base64 exists, and our base64 copy immediately after `cJSON_AddStringToObject` duplicates it. Holding any pair simultaneously roughly doubles the transient to ~800 kB, which does not fit beside the camera framebuffers and the 512 kB TTS ring. The per-turn log prints the upload size and free PSRAM so the claim is checkable rather than trusted.
+
+**A start beep, and then a wait.** The buzzer is GPIO2 — a different peripheral from the I2S amplifier — so `audio_player_is_active()` does not cover it. Without the settle delay and the mic flush, the first fraction of every clip is the robot's own beep, which the model then politely transcribes.
+
+The post-turn bookkeeping is deliberate in both directions. It **does** call `dialogue_style_note_spoken()` (so the planner does not parrot the answer back), `speech_budget_note()` (the robot just talked; a spontaneous remark three seconds later is the chattering the gap exists to stop) and `ambient_audio_mark_spoken()` (the human's voice armed the audio latch — having answered it, the robot must not then volunteer "I heard something"). It **does not** call `scene_change_mark_spoken()`, because answering a question is not remarking on the view and consuming that evidence would silence an observation not yet made; and it does not screen the reply through `dialogue_style_is_repetitive()`, because a direct answer is allowed to repeat — the same exemption `voice say` and the self-report already have.
+
 Two hardware consequences worth knowing before touching this:
 
 - **The microSD slot is gone.** GPIO7/8/9 are the Sense expansion board's SPI bus. No alternative pins exist — I2S needs a real peripheral, so it cannot move behind the PCA9685 or MCP23017.
@@ -225,6 +239,11 @@ Key settings that matter:
 - Don't open the `speak` tool on audio evidence while leaving the prompt saying "only if this frame shows something". On an audio-only cycle the frame shows nothing new by construction, so the model is being told to stay silent in exactly the case the gate opened for. Name the evidence in the prompt — see the Voice section
 - Don't compare the instantaneous audio frame instead of the latched peak. The mic runs ~200x faster than the planner, so a door slam between two planner cycles would never be observed and the gate would look like a threshold problem rather than a sampling one
 - Don't let a failed microphone read reach the gate. An all-zero frame fingerprints as flat silence, which is a legitimate reading, so a run of broken reads would eventually read as a brand-new soundscape and trigger speech about nothing — the same sentinel-zero trap as an unread camera register. `ambient_listener.c` drops them
+- Don't send the recorded clip as `audio/pcm`. Gemini rejects it with an HTTP 400 that names no field; it must be WAV-wrapped and sent as `audio/wav`. This is probed, not inferred — see the Voice section, and `test_audio_clip.c` pins the 44 header bytes so the failure is local instead of remote
+- Don't hold the raw PCM, the WAV copy and the base64 string at the same time. Each is released the moment the next exists, which is what keeps the peak transient near 430 kB instead of ~800 kB; the latter does not fit beside the camera framebuffers and the TTS ring
+- Don't run the voice turn on the planner's Robotics-ER model. Quota is per model and the planner already saturates ER's 5 req/min, so a conversation would start costing the robot its ability to plan a movement
+- Don't screen a voice-turn reply through `dialogue_style_is_repetitive()`, and don't call `scene_change_mark_spoken()` after one. A direct answer is allowed to repeat, and answering a question is not remarking on the view — see the Voice section for the full set of rulings
+- Don't log a Gemini error body at DEBUG. A 400 names no field, so the body *is* the diagnosis; hiding it is what made an earlier call site fail opaquely for a whole debugging round
 - Don't record while the amplifier is sounding, and don't stop at the falling edge either — room reverb and the amp's tail outlive `audio_player_is_active()`, so `ambient_capture_allowed()` quarantines a further `AMBIENT_PLAYBACK_HANGOVER_MS`. An LLM listening to its own voice is a feedback loop with a language model in it
 - Don't re-point the scene reference at the previous frame "so it tracks motion". The reference is the frame the robot last *spoke* about; per-frame comparison lets a slow drift change the whole room without ever tripping the threshold, and marks a just-changed scene as stale before anything has been said about it
 - Don't let an undecodable frame update the scene state. Its fingerprint is all-zero, which is indistinguishable from a flat grey frame, so a run of corrupt captures would read as a completely new view and trigger speech about nothing. `scene_change_note()` drops invalid fingerprints — keep the `valid` flag if you touch that struct

--- a/packages/robocar/unified/main/CMakeLists.txt
+++ b/packages/robocar/unified/main/CMakeLists.txt
@@ -23,6 +23,8 @@ idf_component_register(
         "mic_pdm.c"
         "mic_dump.c"
         "ambient_listener.c"
+        "audio_clip.c"
+        "voice_turn.c"
         "gemini_tts.c"
         "voice_persona.c"
         "dialogue_style.c"

--- a/packages/robocar/unified/main/audio_clip.c
+++ b/packages/robocar/unified/main/audio_clip.c
@@ -1,0 +1,138 @@
+/**
+ * @file audio_clip.c
+ * @brief Sizing, WAV framing and normalisation for a recorded microphone clip.
+ *
+ * Pure C — no ESP-IDF, no FreeRTOS — so the arithmetic and the header layout are
+ * exercised by test_audio_clip.c on the host. See audio_clip.h for why both are
+ * worth isolating.
+ */
+
+#include "audio_clip.h"
+
+#include <string.h>
+
+/** Bytes per sample. Mono 16-bit throughout this firmware; the mic offers
+ *  nothing else and Gemini is happy with it. */
+#define BYTES_PER_SAMPLE 2u
+
+/** Little-endian stores, written out rather than memcpy'd from a struct because
+ *  a struct would need packing attributes and would still not fix byte order on
+ *  a big-endian host test runner. */
+static void put_u32(uint8_t *p, uint32_t v)
+{
+    p[0] = (uint8_t)(v & 0xFFu);
+    p[1] = (uint8_t)((v >> 8) & 0xFFu);
+    p[2] = (uint8_t)((v >> 16) & 0xFFu);
+    p[3] = (uint8_t)((v >> 24) & 0xFFu);
+}
+
+static void put_u16(uint8_t *p, uint16_t v)
+{
+    p[0] = (uint8_t)(v & 0xFFu);
+    p[1] = (uint8_t)((v >> 8) & 0xFFu);
+}
+
+size_t audio_clip_pcm_bytes(uint32_t window_ms, uint32_t sample_rate_hz)
+{
+    if (window_ms == 0u || sample_rate_hz == 0u) {
+        return 0u;
+    }
+
+    /* Check the multiplication BEFORE performing it. Doing it the other way —
+     * multiply, then notice the result looks small — is exactly the bug this
+     * function exists to make impossible: a wrapped product is a perfectly
+     * ordinary-looking small number. */
+    const uint64_t samples = ((uint64_t)window_ms * (uint64_t)sample_rate_hz) / 1000u;
+    const uint64_t bytes = samples * (uint64_t)BYTES_PER_SAMPLE;
+    if (bytes == 0u || bytes > (uint64_t)AUDIO_CLIP_MAX_BYTES) {
+        return 0u;
+    }
+    return (size_t)bytes;
+}
+
+size_t audio_clip_b64_length(size_t pcm_bytes)
+{
+    if (pcm_bytes == 0u || pcm_bytes > AUDIO_CLIP_MAX_BYTES) {
+        return 0u;
+    }
+    /* The header is part of what gets encoded. Omitting it here under-allocates
+     * by 60 characters and corrupts only the tail of the audio — which presents
+     * as a microphone fault, not as an arithmetic one. */
+    const uint64_t total = (uint64_t)pcm_bytes + (uint64_t)AUDIO_CLIP_WAV_HEADER_BYTES;
+    /* 4 chars per 3 bytes, rounded up, plus the NUL. */
+    const uint64_t b64 = ((total + 2u) / 3u) * 4u + 1u;
+    if (b64 > (uint64_t)SIZE_MAX) {
+        return 0u;
+    }
+    return (size_t)b64;
+}
+
+bool audio_clip_wav_header(uint8_t *out, size_t pcm_bytes, uint32_t sample_rate_hz,
+                           uint16_t channels, uint16_t bits)
+{
+    if (!out || pcm_bytes == 0u || sample_rate_hz == 0u || channels == 0u || bits == 0u ||
+        (bits % 8u) != 0u) {
+        return false;
+    }
+
+    const uint16_t block_align = (uint16_t)(channels * (bits / 8u));
+    const uint32_t byte_rate = sample_rate_hz * block_align;
+
+    memcpy(out + 0, "RIFF", 4);
+    put_u32(out + 4, (uint32_t)(36u + pcm_bytes)); /* file size minus the 8-byte RIFF preamble */
+    memcpy(out + 8, "WAVE", 4);
+    memcpy(out + 12, "fmt ", 4);
+    put_u32(out + 16, 16u); /* PCM fmt chunk length */
+    put_u16(out + 20, 1u);  /* audio format: 1 = PCM, uncompressed */
+    put_u16(out + 22, channels);
+    put_u32(out + 24, sample_rate_hz);
+    put_u32(out + 28, byte_rate);
+    put_u16(out + 32, block_align);
+    put_u16(out + 34, bits);
+    memcpy(out + 36, "data", 4);
+    put_u32(out + 40, (uint32_t)pcm_bytes);
+    return true;
+}
+
+void audio_clip_normalise(int16_t *pcm, size_t samples, audio_clip_stats_t *out_stats)
+{
+    audio_clip_stats_t st = {0};
+    if (!pcm || samples == 0u) {
+        if (out_stats) {
+            *out_stats = st;
+        }
+        return;
+    }
+    st.samples = (uint32_t)samples;
+
+    int64_t sum = 0;
+    for (size_t i = 0; i < samples; ++i) {
+        sum += pcm[i];
+    }
+    const int32_t dc = (int32_t)(sum / (int64_t)samples);
+    st.dc = dc;
+
+    for (size_t i = 0; i < samples; ++i) {
+        int32_t v = (int32_t)pcm[i] - dc;
+        /* Saturate rather than wrap. A wrapped sample flips sign at full scale,
+         * which is an audible click AND destroys the clipped-count's meaning —
+         * the one number that says the gain is too high. */
+        if (v > 32767) {
+            v = 32767;
+            st.clipped++;
+        } else if (v < -32768) {
+            v = -32768;
+            st.clipped++;
+        }
+        pcm[i] = (int16_t)v;
+
+        const int32_t mag = (v < 0) ? -v : v;
+        if (mag > st.peak) {
+            st.peak = (int16_t)((mag > 32767) ? 32767 : mag);
+        }
+    }
+
+    if (out_stats) {
+        *out_stats = st;
+    }
+}

--- a/packages/robocar/unified/main/audio_clip.h
+++ b/packages/robocar/unified/main/audio_clip.h
@@ -1,0 +1,133 @@
+/**
+ * @file audio_clip.h
+ * @brief Sizing, WAV framing and normalisation for a recorded microphone clip.
+ *
+ * ## Why this is a separate, pure module
+ *
+ * Two jobs that a bench will never exercise the failing case of, and that are
+ * both miserable to debug where they actually break:
+ *
+ * 1. **The size arithmetic.** `seconds * rate * 2 * 4 / 3` is the classic
+ *    silent-overflow shape: a 32-bit wrap yields a *small* allocation, the
+ *    encoder then writes past it, and the crash lands somewhere else entirely.
+ *    No plausible console input triggers it, so it cannot be found by using the
+ *    robot — only by calling the function with the input directly.
+ *
+ * 2. **The WAV header.** Gemini rejects raw PCM (see below), so every clip must
+ *    carry a canonical 44-byte header. A field-width or byte-order slip there
+ *    does not fail locally: it produces an HTTP 400 from a remote server whose
+ *    message names no field. Pinning the 44 bytes in a host test turns a
+ *    remote, opaque failure into a local, obvious one.
+ *
+ * ## The API rejects audio/pcm — this is measured, not assumed
+ *
+ * Probed live against `models/gemini-flash-latest:generateContent` (2026-07)
+ * with a 0.5 s 16 kHz mono tone as an `inlineData` part:
+ *
+ *   - `mimeType: "audio/wav"`  -> 200, replied, usage reported 13 AUDIO tokens.
+ *   - `mimeType: "audio/pcm"`  -> **HTTP 400 "Request contains an invalid
+ *     argument."**, naming no field.
+ *
+ * So the firmware wraps. The header is fixed-size and trivially built for a
+ * known rate/width/channel count, which is why doing it on-device costs
+ * essentially nothing — 44 bytes prepended to a buffer that is already hundreds
+ * of kB.
+ *
+ * Audio is cheap in tokens (~26 tokens/second measured), so clip length is
+ * bounded by MEMORY, not by API cost. See AUDIO_CLIP_MAX_BYTES.
+ */
+
+#ifndef AUDIO_CLIP_H
+#define AUDIO_CLIP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Canonical PCM WAV header length. Not configurable — it is the format. */
+#define AUDIO_CLIP_WAV_HEADER_BYTES 44
+
+/** Default record window. A knob (`listen <secs>`) because "is four seconds
+ *  long enough to finish a sentence" is a judgement only someone talking to the
+ *  robot can make. */
+#define AUDIO_CLIP_WINDOW_MS_DEFAULT 4000
+
+/** Console-accepted window bounds, in seconds. */
+#define AUDIO_CLIP_WINDOW_S_MIN 1
+#define AUDIO_CLIP_WINDOW_S_MAX 8
+
+/**
+ * @brief Hard ceiling on raw PCM bytes for one clip.
+ *
+ * 8 s at 16 kHz mono 16-bit = 256 000 bytes. The base64 of that plus its header
+ * is ~341 kB, and cJSON duplicates the string once, so the transient peak is
+ * roughly 430 kB of PSRAM if — and only if — the caller frees in the order
+ * voice_turn.c documents. That fits alongside the camera framebuffers and the
+ * 512 kB TTS ring; much beyond it does not.
+ */
+#define AUDIO_CLIP_MAX_BYTES 256000u
+
+/** Per-clip measurements, all computed in one pass. */
+typedef struct {
+    int32_t dc;       /**< Mean sample value before removal. Large = a DC-biased mic. */
+    int16_t peak;     /**< Largest absolute sample after DC removal. */
+    uint32_t clipped; /**< Samples at or beyond full scale. */
+    uint32_t samples; /**< Samples examined. */
+} audio_clip_stats_t;
+
+/**
+ * @brief Bytes of raw PCM for a window, or 0 if the request is out of bounds.
+ *
+ * Returns 0 — never a truncated or wrapped value — for a window that would
+ * exceed AUDIO_CLIP_MAX_BYTES or overflow the arithmetic. A caller that treats
+ * 0 as "refuse" cannot be handed a short buffer to overrun.
+ */
+size_t audio_clip_pcm_bytes(uint32_t window_ms, uint32_t sample_rate_hz);
+
+/**
+ * @brief Total base64 length for a WAV-wrapped clip of @p pcm_bytes, or 0.
+ *
+ * Accounts for the 44-byte header, which is the whole reason this is a function
+ * and not an expression at the call site: forgetting the header under-allocates
+ * by exactly 60 base64 characters, which corrupts only the tail of the audio and
+ * therefore looks like a microphone problem rather than an arithmetic one.
+ * Returns 0 on overflow.
+ */
+size_t audio_clip_b64_length(size_t pcm_bytes);
+
+/**
+ * @brief Write a canonical 44-byte PCM WAV header into @p out.
+ *
+ * @param out         Destination, at least AUDIO_CLIP_WAV_HEADER_BYTES.
+ * @param pcm_bytes   Payload size that will follow the header.
+ * @param sample_rate_hz  Sample rate.
+ * @param channels    Channel count (1 here).
+ * @param bits        Bits per sample (16 here).
+ * @return true on success, false on a NULL pointer or a degenerate parameter.
+ */
+bool audio_clip_wav_header(uint8_t *out, size_t pcm_bytes, uint32_t sample_rate_hz,
+                           uint16_t channels, uint16_t bits);
+
+/**
+ * @brief Remove DC and measure the clip, in place.
+ *
+ * The stats are the point, not the DC removal: `peak` and `clipped` are the
+ * audio analogue of what `cam` prints for gain and exposure, and they are the
+ * only way to tell a mis-set microphone gain from a bad model reply. A clip that
+ * comes back with peak ~200 was never going to be transcribed no matter what the
+ * model said.
+ *
+ * A large `dc` is itself diagnostic: PDM microphones carry a substantial DC
+ * term, and leaving it in wastes headroom and biases every downstream measure.
+ */
+void audio_clip_normalise(int16_t *pcm, size_t samples, audio_clip_stats_t *out_stats);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // AUDIO_CLIP_H

--- a/packages/robocar/unified/main/gemini_backend.c
+++ b/packages/robocar/unified/main/gemini_backend.c
@@ -723,64 +723,6 @@ static char *build_narrate_json(const char *facts, bool is_update)
     return body; /* caller frees */
 }
 
-/** Collapse newlines to spaces and strip surrounding whitespace, in place. */
-static void sanitize_spoken_line(char *s)
-{
-    for (char *p = s; *p != '\0'; ++p) {
-        if (*p == '\n' || *p == '\r' || *p == '\t') {
-            *p = ' ';
-        }
-    }
-    /* trim leading */
-    char *start = s;
-    while (*start == ' ') {
-        ++start;
-    }
-    if (start != s) {
-        memmove(s, start, strlen(start) + 1);
-    }
-    /* trim trailing */
-    size_t len = strlen(s);
-    while (len > 0 && s[len - 1] == ' ') {
-        s[--len] = '\0';
-    }
-}
-
-/** Extract and concatenate candidates[0].content.parts[*].text into @p out. */
-static esp_err_t parse_narrate_response(const char *json, char *out, size_t out_len)
-{
-    cJSON *root = cJSON_Parse(json);
-    if (!root) {
-        return ESP_FAIL;
-    }
-
-    esp_err_t ret = ESP_FAIL;
-    cJSON *candidates = cJSON_GetObjectItem(root, "candidates");
-    cJSON *c0 = cJSON_IsArray(candidates) ? cJSON_GetArrayItem(candidates, 0) : NULL;
-    cJSON *content = c0 ? cJSON_GetObjectItem(c0, "content") : NULL;
-    cJSON *parts = content ? cJSON_GetObjectItem(content, "parts") : NULL;
-
-    if (cJSON_IsArray(parts)) {
-        out[0] = '\0';
-        const int n = cJSON_GetArraySize(parts);
-        for (int i = 0; i < n; ++i) {
-            cJSON *t = cJSON_GetObjectItem(cJSON_GetArrayItem(parts, i), "text");
-            if (cJSON_IsString(t) && t->valuestring) {
-                strlcat(out, t->valuestring, out_len);
-            }
-        }
-        if (out[0] != '\0') {
-            sanitize_spoken_line(out);
-            if (out[0] != '\0') {
-                ret = ESP_OK;
-            }
-        }
-    }
-
-    cJSON_Delete(root);
-    return ret;
-}
-
 esp_err_t gemini_backend_narrate(const char *facts, bool is_update, char *out, size_t out_len)
 {
     if (!facts || !out || out_len == 0) {
@@ -826,7 +768,7 @@ esp_err_t gemini_backend_narrate(const char *facts, bool is_update, char *out, s
         return ESP_FAIL;
     }
 
-    err = parse_narrate_response(acc.buf, out, out_len);
+    err = gemini_parse_text(acc.buf, out, out_len);
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "narrate: no usable text in response");
     }

--- a/packages/robocar/unified/main/gemini_parse.c
+++ b/packages/robocar/unified/main/gemini_parse.c
@@ -189,3 +189,80 @@ done:
     cJSON_Delete(root);
     return result;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Plain-text replies                                                          */
+/* -------------------------------------------------------------------------- */
+
+/** Collapse newlines to spaces and strip surrounding whitespace, in place.
+ *
+ *  A spoken line must be one line: the TTS renderer reads the layout otherwise,
+ *  and a leading newline becomes an audible pause before the robot says
+ *  anything. */
+static void sanitize_spoken_line(char *s)
+{
+    for (char *p = s; *p != '\0'; ++p) {
+        if (*p == '\n' || *p == '\r' || *p == '\t') {
+            *p = ' ';
+        }
+    }
+    char *start = s;
+    while (*start == ' ') {
+        ++start;
+    }
+    if (start != s) {
+        memmove(s, start, strlen(start) + 1);
+    }
+    size_t len = strlen(s);
+    while (len > 0 && s[len - 1] == ' ') {
+        s[--len] = '\0';
+    }
+}
+
+esp_err_t gemini_parse_text(const char *json_text, char *out, size_t out_len)
+{
+    if (!json_text || !out || out_len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    cJSON *root = cJSON_Parse(json_text);
+    if (!root) {
+        return ESP_FAIL;
+    }
+
+    esp_err_t ret = ESP_FAIL;
+    cJSON *candidates = cJSON_GetObjectItem(root, "candidates");
+    cJSON *c0 = cJSON_IsArray(candidates) ? cJSON_GetArrayItem(candidates, 0) : NULL;
+    cJSON *content = c0 ? cJSON_GetObjectItem(c0, "content") : NULL;
+    cJSON *parts = content ? cJSON_GetObjectItem(content, "parts") : NULL;
+
+    if (cJSON_IsArray(parts)) {
+        out[0] = '\0';
+        size_t pos = 0;
+        const int n = cJSON_GetArraySize(parts);
+        for (int i = 0; i < n && pos + 1 < out_len; ++i) {
+            cJSON *t = cJSON_GetObjectItem(cJSON_GetArrayItem(parts, i), "text");
+            if (cJSON_IsString(t) && t->valuestring) {
+                /* snprintf rather than strlcat: this file also builds on the
+                 * host for the unit tests, where strlcat is not portable. It
+                 * always NUL-terminates and returns the length it WOULD have
+                 * written, so clamp before advancing or a long first part makes
+                 * pos run past the buffer. */
+                const int w = snprintf(out + pos, out_len - pos, "%s", t->valuestring);
+                if (w < 0) {
+                    break;
+                }
+                pos += ((size_t)w < out_len - pos) ? (size_t)w : (out_len - pos - 1);
+            }
+        }
+        if (out[0] != '\0') {
+            sanitize_spoken_line(out);
+            if (out[0] != '\0') {
+                ret = ESP_OK;
+            }
+        }
+    }
+
+    cJSON_Delete(root);
+    return ret;
+}

--- a/packages/robocar/unified/main/gemini_parse.h
+++ b/packages/robocar/unified/main/gemini_parse.h
@@ -56,6 +56,30 @@ esp_err_t gemini_parse_function_call(const char *json_text, goal_t *out_goal);
 esp_err_t gemini_parse_response(const char *json_text, goal_t *out_goal, char *out_speech,
                                 size_t speech_cap);
 
+/**
+ * @brief Extract a plain TEXT reply — candidates[0].content.parts[*].text.
+ *
+ * The counterpart to gemini_parse_function_call() for the calls that ask the
+ * model for prose rather than a tool call: the self-report narrator and the
+ * voice turn. Every `text` part is concatenated in order, then newlines, returns
+ * and tabs are collapsed to spaces and the result is trimmed — a spoken line
+ * must be one line, and the TTS renderer would otherwise pronounce the layout.
+ *
+ * Lives here rather than in gemini_backend.c (where it began, static and
+ * untested) so that it can be exercised on the host, and so the two callers
+ * cannot drift apart. Extracting it gave the narrate path its first test as a
+ * side effect.
+ *
+ * @param json_text  NUL-terminated response body. Must not be NULL.
+ * @param out        Destination buffer. Must not be NULL.
+ * @param out_len    Capacity of @p out, including the NUL.
+ * @return ESP_OK when at least one non-empty text part was found and survived
+ *         sanitisation; ESP_FAIL on a parse error, a missing/!array parts list,
+ *         or a reply that sanitises to nothing; ESP_ERR_INVALID_ARG on a NULL
+ *         pointer or zero capacity.
+ */
+esp_err_t gemini_parse_text(const char *json_text, char *out, size_t out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/packages/robocar/unified/main/main.c
+++ b/packages/robocar/unified/main/main.c
@@ -27,6 +27,7 @@
 
 #include "ambient_audio.h"
 #include "ambient_listener.h"
+#include "audio_clip.h"
 #include "audio_player.h"
 #include "buzzer.h"
 #include "camera.h"
@@ -58,6 +59,7 @@
 #include "speech_budget.h"
 #include "speech_queue.h"
 #include "voice_persona.h"
+#include "voice_turn.h"
 #include "wifi_manager.h"
 
 static const char *TAG = "robocar";
@@ -333,6 +335,7 @@ static void handle_periph_cmd(const char *buf)
  * `voice loud <db>`            — excursion above the noise floor (0 = sub-gate off)
  * `voice sound <db>`           — how much the room's spectrum must move (0 = off)
  * `mic` / `mic dump <n>`       — microphone state; dump PCM frames to the console
+ * `listen [seconds]`           — one push-to-talk voice turn (record, ask, answer)
  *
  * Switching and auditioning are runtime rather than compile-time because only a
  * listener can judge a voice; a reflash per candidate is far too slow a loop.
@@ -728,6 +731,53 @@ static void handle_mic_cmd(const char *buf)
     printf("  usage: mic | mic dump <n>   (thresholds: voice loud <db> | voice sound <db>)\n");
 }
 
+/**
+ * @brief `listen [seconds]` — one push-to-talk voice turn.
+ *
+ * Records, asks Gemini, and speaks the reply through the existing TTS path. The
+ * window is a knob rather than a constant because "is four seconds long enough
+ * to finish a sentence" is a judgement only somebody talking to the robot can
+ * make, and a reflash per trial is far too slow a loop.
+ */
+static void handle_listen_cmd(const char *buf)
+{
+    unsigned secs = 0;
+    uint32_t window_ms = AUDIO_CLIP_WINDOW_MS_DEFAULT;
+    if (sscanf(buf, "listen %u", &secs) == 1) {
+        if (secs < AUDIO_CLIP_WINDOW_S_MIN || secs > AUDIO_CLIP_WINDOW_S_MAX) {
+            printf("listen: usage: listen [%d..%d seconds]\n", AUDIO_CLIP_WINDOW_S_MIN,
+                   AUDIO_CLIP_WINDOW_S_MAX);
+            return;
+        }
+        window_ms = (uint32_t)secs * 1000U;
+    }
+
+    const esp_err_t ret = voice_turn_request(window_ms);
+    switch (ret) {
+        case ESP_OK:
+            printf("listen: recording %u ms after the beep — speak now\n", (unsigned)window_ms);
+            break;
+        case ESP_ERR_NO_MEM:
+            printf("listen: busy — a turn is already in flight\n");
+            break;
+        case ESP_ERR_INVALID_STATE:
+            /* Three quite different causes, and telling them apart matters:
+             * a robot mid-sentence is working correctly, a missing microphone is
+             * a fault, and an unstarted task means the AI phase did not come up. */
+            if (!mic_pdm_is_ready()) {
+                printf("listen: no microphone — voice turns unavailable\n");
+            } else if (audio_player_is_active()) {
+                printf("listen: the robot is speaking — try again in a moment\n");
+            } else {
+                printf("listen: voice turns are not running\n");
+            }
+            break;
+        default:
+            printf("listen: rejected (%s)\n", esp_err_to_name(ret));
+            break;
+    }
+}
+
 // ========================================
 // Improv WiFi provisioning (serial)
 // ========================================
@@ -843,6 +893,8 @@ static void command_task(void *pvParameters)
                     handle_voice_cmd(buf);
                 } else if (strncmp(buf, "snap", 4) == 0) {
                     handle_snap_cmd(buf);
+                } else if (strncmp(buf, "listen", 6) == 0) {
+                    handle_listen_cmd(buf);
                 } else if (strncmp(buf, "mic", 3) == 0) {
                     handle_mic_cmd(buf);
                 } else if (strncmp(buf, "cam", 3) == 0) {
@@ -1011,6 +1063,13 @@ static esp_err_t init_hierarchical_ai(void)
         ESP_LOGW(TAG, "mic_pdm_init failed — ambient audio gate disabled");
     } else if (ambient_listener_start() != ESP_OK) {
         ESP_LOGW(TAG, "ambient_listener_start failed — ambient audio gate disabled");
+    }
+
+    /* Push-to-talk. Independent of the ambient listener above — a board whose
+     * gate failed to start can still answer a `listen`, and vice versa — so it
+     * gets its own non-fatal branch rather than riding the same else-if chain. */
+    if (voice_turn_start() != ESP_OK) {
+        ESP_LOGW(TAG, "voice_turn_start failed — `listen` unavailable");
     }
 
     // reactive_controller spawns the 30 Hz executor on Core 0. This one *is*

--- a/packages/robocar/unified/main/voice_turn.c
+++ b/packages/robocar/unified/main/voice_turn.c
@@ -1,0 +1,391 @@
+/**
+ * @file voice_turn.c
+ * @brief Push-to-talk: record a clip, ask Gemini, speak the reply.
+ *
+ * See voice_turn.h for the design. The ordering inside run_turn() is the part
+ * worth reading — it is what keeps the transient allocation at roughly 430 kB
+ * rather than 800 kB, on a device where the camera framebuffers and the 512 kB
+ * TTS ring are already spoken for.
+ */
+
+#include "voice_turn.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "ambient_audio.h"
+#include "audio_clip.h"
+#include "audio_player.h"
+#include "base64.h"
+#include "buzzer.h"
+#include "cJSON.h"
+#include "credentials_loader.h"
+#include "dialogue_style.h"
+#include "esp_heap_caps.h"
+#include "esp_http_client.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "freertos/task.h"
+#include "gemini_http.h"
+#include "gemini_parse.h"
+#include "mic_pdm.h"
+#include "pin_config.h"
+#include "speech_budget.h"
+#include "speech_queue.h"
+#include "voice_persona.h"
+
+static const char *TAG = "voice_turn";
+
+/** A flash model, NOT the planner's Robotics-ER: quota is per model, and the
+ *  planner already saturates ER's 5 req/min. Verified reachable and verified to
+ *  accept an inline audio part (2026-07). */
+#define VOICE_TURN_MODEL "gemini-flash-latest"
+#define VOICE_TURN_URL \
+    "https://generativelanguage.googleapis.com/v1beta/models/" VOICE_TURN_MODEL ":generateContent"
+
+/** 30 s, not the planner's 15 s: a ~170 kB upload over a domestic uplink can
+ *  spend most of a planner timeout still sending. */
+#define VOICE_TURN_TIMEOUT_MS 30000
+
+/** Own response buffer, never gemini_backend.c's shared s_response_buf —
+ *  gemini_backend_plan() is documented single-task and this runs on a different
+ *  one. A one-sentence reply is tiny; 4 kB also absorbs an error body. */
+#define VOICE_TURN_RESPONSE_BUF_SIZE (4 * 1024)
+
+/** Combined thinking + reply budget (thinking is spent first, and this model
+ *  always thinks). Measured elsewhere in this firmware at 487–745 thought tokens
+ *  for a one-sentence answer, so 512 truncates every time and 1024 has no
+ *  margin. Raising it is nearly free: thinking tokens are billed either way, and
+ *  the cap only decides whether the sentence survives. */
+#define VOICE_TURN_MAX_OUTPUT_TOKENS 2048
+
+/** Settle time after the start beep. The buzzer is on GPIO2, a different
+ *  peripheral from the I2S amplifier, so audio_player_is_active() does NOT cover
+ *  it — without this the first fraction of every clip is the robot's own beep,
+ *  and the model politely transcribes it. */
+#define VOICE_TURN_BEEP_SETTLE_MS 120
+
+typedef struct {
+    uint32_t window_ms;
+} voice_turn_req_t;
+
+static QueueHandle_t s_queue;
+static volatile bool s_busy;
+
+/* Per-turn state at FILE scope, not on the 8 kB stack — the same reason
+ * gemini_tts.c keeps its context static. The response buffer alone would be
+ * half the stack. */
+static char s_response[VOICE_TURN_RESPONSE_BUF_SIZE];
+static char s_reply[SPEECH_TEXT_MAX];
+
+typedef struct {
+    char *buf;
+    size_t len;
+    size_t cap;
+} response_acc_t;
+
+static esp_err_t http_event_handler(esp_http_client_event_t *evt)
+{
+    if (evt->event_id != HTTP_EVENT_ON_DATA) {
+        return ESP_OK;
+    }
+    response_acc_t *acc = (response_acc_t *)evt->user_data;
+    if (!acc || !acc->buf || !evt->data || evt->data_len <= 0) {
+        return ESP_OK;
+    }
+    const size_t avail = acc->cap - 1 - acc->len;
+    const size_t to_copy = ((size_t)evt->data_len < avail) ? (size_t)evt->data_len : avail;
+    if (to_copy > 0) {
+        memcpy(acc->buf + acc->len, evt->data, to_copy);
+        acc->len += to_copy;
+        acc->buf[acc->len] = '\0';
+    }
+    return ESP_OK;
+}
+
+/**
+ * @brief Record @p pcm_bytes of audio, holding the microphone for the window.
+ *
+ * The ambient listener simply misses these frames, and that is correct rather
+ * than merely tolerable: the noise floor must not learn from a conversation, or
+ * a chat with the robot would raise the floor enough to deafen the gate
+ * afterwards.
+ */
+static esp_err_t record_clip(int16_t *pcm, size_t samples, size_t *out_samples)
+{
+    if (mic_pdm_lock(1000) != ESP_OK) {
+        ESP_LOGW(TAG, "microphone busy");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    /* Drop whatever the DMA accumulated while we were beeping and settling. */
+    mic_pdm_flush();
+
+    size_t filled = 0;
+    esp_err_t err = ESP_OK;
+    while (filled < samples) {
+        size_t got = 0;
+        err = mic_pdm_read(pcm + filled, samples - filled, &got, 1000);
+        if (err != ESP_OK || got == 0) {
+            break;
+        }
+        filled += got;
+    }
+    mic_pdm_unlock();
+
+    *out_samples = filled;
+    if (filled == 0) {
+        return (err == ESP_OK) ? ESP_FAIL : err;
+    }
+    return ESP_OK;
+}
+
+/** Build the request body, taking ownership of nothing and freeing nothing. */
+static char *build_body(const char *b64_wav)
+{
+    const voice_persona_t *persona = voice_persona_get();
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON *contents = cJSON_AddArrayToObject(root, "contents");
+    cJSON *turn = cJSON_CreateObject();
+    cJSON_AddItemToArray(contents, turn);
+    cJSON *parts = cJSON_AddArrayToObject(turn, "parts");
+
+    cJSON *text_part = cJSON_CreateObject();
+    cJSON_AddItemToArray(parts, text_part);
+    cJSON_AddStringToObject(
+        text_part, "text",
+        "You are a small wheeled robot. Someone has just spoken to you; the audio follows. "
+        "Answer them in ONE short spoken sentence. Reply with the sentence itself and nothing "
+        "else — no preamble, no quotation marks, no stage directions, no markdown. If the audio "
+        "contains no intelligible speech, say so briefly in the same voice.");
+
+    cJSON *audio_part = cJSON_CreateObject();
+    cJSON_AddItemToArray(parts, audio_part);
+    cJSON *inline_data = cJSON_AddObjectToObject(audio_part, "inlineData");
+    /* audio/wav, never audio/pcm: the latter is rejected with a 400 that names
+     * no field. See audio_clip.h for the probe that established this. */
+    cJSON_AddStringToObject(inline_data, "mimeType", "audio/wav");
+    cJSON_AddStringToObject(inline_data, "data", b64_wav);
+
+    cJSON *sys = cJSON_AddObjectToObject(root, "systemInstruction");
+    cJSON *sys_parts = cJSON_AddArrayToObject(sys, "parts");
+    cJSON *sys_text = cJSON_CreateObject();
+    cJSON_AddItemToArray(sys_parts, sys_text);
+    cJSON_AddStringToObject(sys_text, "text",
+                            persona && persona->text_brief ? persona->text_brief : "Be brief.");
+
+    cJSON *gen = cJSON_AddObjectToObject(root, "generationConfig");
+    cJSON_AddNumberToObject(gen, "maxOutputTokens", VOICE_TURN_MAX_OUTPUT_TOKENS);
+    cJSON *thinking = cJSON_AddObjectToObject(gen, "thinkingConfig");
+    /* thinkingLevel, NOT thinkingBudget: the numeric form is rejected by
+     * Gemini 3-era models with a bare 400 that names no field. */
+    cJSON_AddStringToObject(thinking, "thinkingLevel", "low");
+
+    char *body = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    return body; /* caller frees */
+}
+
+static void run_turn(uint32_t window_ms)
+{
+    const uint32_t t_start = (uint32_t)(esp_timer_get_time() / 1000);
+
+    const size_t pcm_bytes = audio_clip_pcm_bytes(window_ms, MIC_SAMPLE_RATE_HZ);
+    if (pcm_bytes == 0) {
+        ESP_LOGE(TAG, "window %u ms rejected by clip sizing", (unsigned)window_ms);
+        return;
+    }
+    const size_t samples = pcm_bytes / sizeof(int16_t);
+
+    const char *api_key = get_gemini_api_key();
+    if (!api_key || api_key[0] == '\0') {
+        ESP_LOGE(TAG, "no Gemini API key — cannot run a voice turn");
+        return;
+    }
+
+    /* PSRAM: this is hundreds of kB and internal RAM is the scarce pool the
+     * camera and the TLS handshake compete for. */
+    int16_t *pcm = heap_caps_malloc(pcm_bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!pcm) {
+        ESP_LOGE(TAG, "no PSRAM for a %u-byte clip", (unsigned)pcm_bytes);
+        return;
+    }
+
+    /* Record-start feedback. buzzer_beep() blocks for its full duration, which
+     * is exactly the "wait for it to finish" this needs; the settle delay covers
+     * the piezo ringing down afterwards. */
+    buzzer_beep();
+    vTaskDelay(pdMS_TO_TICKS(VOICE_TURN_BEEP_SETTLE_MS));
+
+    size_t got = 0;
+    if (record_clip(pcm, samples, &got) != ESP_OK) {
+        ESP_LOGE(TAG, "recording failed");
+        heap_caps_free(pcm);
+        return;
+    }
+
+    audio_clip_stats_t st;
+    audio_clip_normalise(pcm, got, &st);
+
+    const size_t got_bytes = got * sizeof(int16_t);
+    const size_t wav_bytes = got_bytes + AUDIO_CLIP_WAV_HEADER_BYTES;
+
+    /* Build the WAV in its own buffer so the header and payload are contiguous
+     * for a single base64 pass. */
+    uint8_t *wav = heap_caps_malloc(wav_bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!wav || !audio_clip_wav_header(wav, got_bytes, MIC_SAMPLE_RATE_HZ, 1, 16)) {
+        ESP_LOGE(TAG, "WAV framing failed");
+        heap_caps_free(wav);
+        heap_caps_free(pcm);
+        return;
+    }
+    memcpy(wav + AUDIO_CLIP_WAV_HEADER_BYTES, pcm, got_bytes);
+    heap_caps_free(pcm); /* the raw PCM is now redundant — release it before the
+                          * base64 copy exists, not after */
+    pcm = NULL;
+
+    char *b64 = base64_encode_alloc(wav, wav_bytes);
+    heap_caps_free(wav); /* likewise: the encoder has its own copy now */
+    wav = NULL;
+    if (!b64) {
+        ESP_LOGE(TAG, "base64 encode failed");
+        return;
+    }
+
+    char *body = build_body(b64);
+    /* cJSON duplicated the string when it was added; holding both is a pure
+     * waste of ~170 kB at the exact moment the body is also live. */
+    free(b64);
+    b64 = NULL;
+    if (!body) {
+        ESP_LOGE(TAG, "request build failed");
+        return;
+    }
+
+    const size_t body_len = strlen(body);
+    ESP_LOGI(TAG,
+             "listen: window=%u ms samples=%u peak=%d clipped=%u dc=%d | upload=%u B | free "
+             "PSRAM=%u B",
+             (unsigned)window_ms, (unsigned)got, (int)st.peak, (unsigned)st.clipped, (int)st.dc,
+             (unsigned)body_len, (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM));
+
+    response_acc_t acc = {.buf = s_response, .len = 0, .cap = sizeof(s_response)};
+    s_response[0] = '\0';
+    int status = 0;
+    const esp_err_t err = gemini_http_post(VOICE_TURN_URL, api_key, body, VOICE_TURN_TIMEOUT_MS,
+                                           http_event_handler, &acc, &status);
+    free(body);
+
+    if (err != ESP_OK) {
+        /* ERROR, never DEBUG. A Gemini 400 names no field, so the body IS the
+         * diagnosis — hiding it at debug level is what made an earlier call site
+         * fail opaquely for an entire debugging round. */
+        ESP_LOGE(TAG, "voice turn HTTP failed (status %d): %s", status,
+                 acc.len ? s_response : "(empty body)");
+        return;
+    }
+
+    if (gemini_parse_text(s_response, s_reply, sizeof(s_reply)) != ESP_OK) {
+        ESP_LOGE(TAG, "no usable text in reply: %s", acc.len ? s_response : "(empty body)");
+        return;
+    }
+
+    const uint32_t latency_ms = (uint32_t)(esp_timer_get_time() / 1000) - t_start;
+    ESP_LOGI(TAG, "listen: latency=%u ms reply=\"%s\"", (unsigned)latency_ms, s_reply);
+
+    if (speech_queue_post(s_reply) != ESP_OK) {
+        ESP_LOGW(TAG, "speech queue full — reply dropped");
+        return;
+    }
+
+    /* Post-speech bookkeeping. Each of these is a deliberate ruling:
+     *
+     *  - note_spoken: so the planner does not parrot the answer back at its next
+     *    cycle, having no idea the robot just said it.
+     *  - budget_note: the robot just talked. A spontaneous remark three seconds
+     *    later is exactly the chattering the minimum gap exists to prevent.
+     *  - ambient mark_spoken: the human's voice is what armed the audio latch.
+     *    Having answered it, the robot must not then volunteer "I heard
+     *    something" on the next planner cycle.
+     *
+     * Deliberately NOT done:
+     *  - scene_change_mark_spoken(): answering a question is not remarking on
+     *    the view, and consuming the visual evidence would silence a genuine
+     *    observation the robot had not yet made.
+     *  - dialogue_style_is_repetitive(): a direct answer is allowed to repeat.
+     *    Same reasoning that exempts `voice say` and the self-report — screening
+     *    it would turn a working command into one that silently does nothing
+     *    whenever someone asks the same question twice. */
+    dialogue_style_note_spoken(s_reply);
+    speech_budget_note((uint32_t)(esp_timer_get_time() / 1000));
+    ambient_audio_mark_spoken();
+}
+
+static void voice_turn_task(void *arg)
+{
+    (void)arg;
+    ESP_LOGI(TAG, "Voice turn task started (model %s)", VOICE_TURN_MODEL);
+
+    for (;;) {
+        voice_turn_req_t req;
+        if (xQueueReceive(s_queue, &req, portMAX_DELAY) != pdTRUE) {
+            continue;
+        }
+        s_busy = true;
+        run_turn(req.window_ms);
+        s_busy = false;
+    }
+}
+
+esp_err_t voice_turn_start(void)
+{
+    if (s_queue) {
+        return ESP_OK;
+    }
+    /* Depth 1: a second request while a turn is in flight must be REJECTED, not
+     * buffered. Buffering would leave someone waiting through a turn they have
+     * already forgotten about, and would let two turns fight for the mic. */
+    s_queue = xQueueCreate(1, sizeof(voice_turn_req_t));
+    if (!s_queue) {
+        return ESP_ERR_NO_MEM;
+    }
+    const BaseType_t ok =
+        xTaskCreatePinnedToCore(voice_turn_task, "voice_turn", VOICE_TURN_TASK_STACK_SIZE, NULL,
+                                VOICE_TURN_TASK_PRIORITY, NULL, VOICE_TURN_TASK_CORE);
+    if (ok != pdPASS) {
+        vQueueDelete(s_queue);
+        s_queue = NULL;
+        return ESP_ERR_NO_MEM;
+    }
+    return ESP_OK;
+}
+
+esp_err_t voice_turn_request(uint32_t window_ms)
+{
+    if (!s_queue) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (audio_clip_pcm_bytes(window_ms, MIC_SAMPLE_RATE_HZ) == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!mic_pdm_is_ready()) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    /* Refuse while the robot is talking rather than recording it. The check is
+     * here, at request time, so the console can say so immediately instead of
+     * the turn failing silently a second later. */
+    if (audio_player_is_active()) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    const voice_turn_req_t req = {.window_ms = window_ms};
+    return (xQueueSend(s_queue, &req, 0) == pdTRUE) ? ESP_OK : ESP_ERR_NO_MEM;
+}
+
+bool voice_turn_is_busy(void)
+{
+    return s_busy;
+}

--- a/packages/robocar/unified/main/voice_turn.h
+++ b/packages/robocar/unified/main/voice_turn.h
@@ -1,0 +1,94 @@
+/**
+ * @file voice_turn.h
+ * @brief Push-to-talk: record a clip, ask Gemini, speak the reply.
+ *
+ * ## What this is
+ *
+ * The robot's first *conversational* path. Everything else it says is
+ * unprompted — the planner decides there is something worth remarking on and
+ * the gates decide whether it may. A voice turn is the opposite: a person asks
+ * it something and it answers, once, on demand.
+ *
+ * The TTS half is reused entirely unchanged. This module produces a line of
+ * text and hands it to `speech_queue_post()`, exactly as the planner does.
+ *
+ * ## Why a persistent task and a 1-deep queue
+ *
+ * Matching `gemini_tts.c`'s shape rather than creating a task per command. Two
+ * reasons, and neither is style:
+ *
+ *   - A 1-deep queue makes "already listening" a *queue-full* rejection rather
+ *     than a race. Two `listen` commands in quick succession cannot both hold
+ *     the microphone, and the second gets an immediate, honest "busy".
+ *   - A per-turn task would have to size its stack for an HTTPS handshake
+ *     (>= 8 KB, see .claude/rules/freertos-task-gotchas.md) and would allocate
+ *     and free it around every utterance, on a device where the fragmentation
+ *     that causes is paid by the camera.
+ *
+ * ## Why it does not use the planner's model
+ *
+ * Gemini's free-tier quota is **per model**, and the planner already saturates
+ * `gemini-robotics-er-1.6-preview` at 5 requests/minute. A voice turn on a flash
+ * model draws on a separate allowance, so answering someone can never cost the
+ * robot its ability to plan a movement.
+ *
+ * ## The clip is WAV, not raw PCM
+ *
+ * Measured, not assumed: `audio/pcm` is rejected with an HTTP 400 that names no
+ * field; `audio/wav` works. See audio_clip.h for the probe.
+ */
+
+#ifndef VOICE_TURN_H
+#define VOICE_TURN_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** 8 KB because this task performs an HTTPS request: the mbedTLS handshake is
+ *  several KB deep on its own, and a 4 KB stack survives only while DNS is
+ *  broken enough to short-circuit before it. That intermittency is why the
+ *  number is not tuned down. */
+#define VOICE_TURN_TASK_STACK_SIZE 8192
+#define VOICE_TURN_TASK_PRIORITY 3
+#define VOICE_TURN_TASK_CORE 1
+
+/**
+ * @brief Start the voice-turn task.
+ *
+ * Non-fatal like the rest of the AI phase: without it the console simply
+ * reports that voice turns are unavailable.
+ */
+esp_err_t voice_turn_start(void);
+
+/**
+ * @brief Request one turn of @p window_ms milliseconds of recording.
+ *
+ * Returns immediately; the turn runs on the voice-turn task.
+ *
+ * Deliberately callable from anywhere, including the ambient listener, so an
+ * energy-triggered (VAD) turn can be added later without redesign. Before doing
+ * that, note the pacing problem: a VAD in a noisy room would issue turns
+ * continuously and Gemini's `retryDelay` grows while a client keeps asking. The
+ * likely answer is that a VAD trigger must draw on `speech_budget` too, which is
+ * a decision worth making deliberately rather than discovering.
+ *
+ * @return ESP_OK when queued; ESP_ERR_INVALID_STATE if the task is not running
+ *         or the robot is currently speaking; ESP_ERR_NO_MEM if a turn is
+ *         already in flight; ESP_ERR_INVALID_ARG on an out-of-range window.
+ */
+esp_err_t voice_turn_request(uint32_t window_ms);
+
+/** @brief True while a turn is recording, uploading or awaiting a reply. */
+bool voice_turn_is_busy(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // VOICE_TURN_H

--- a/packages/robocar/unified/test/CMakeLists.txt
+++ b/packages/robocar/unified/test/CMakeLists.txt
@@ -191,3 +191,19 @@ if(CJSON_FOUND)
 else()
     message(STATUS "cJSON not found — skipping test_gemini_parse. Install via `brew install cjson` or `apt install libcjson-dev`.")
 endif()
+
+# -----------------------------------------------------------------------------
+# audio_clip (clip sizing, WAV framing, normalisation)
+#
+# Pure C, and the two load-bearing cases are ones the device cannot show you: a
+# 32-bit overflow in the size arithmetic (a wrapped product is an ordinary small
+# number, so the bug is a short allocation that is then overrun), and the exact
+# 44 WAV header bytes — Gemini rejects raw PCM with a 400 that names no field, so
+# a byte-order slip fails remotely and opaquely instead of here.
+# -----------------------------------------------------------------------------
+add_executable(test_audio_clip
+    "${MAIN_SRC_DIR}/audio_clip.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_audio_clip.c"
+)
+target_link_libraries(test_audio_clip PRIVATE Threads::Threads m)
+add_test(NAME audio_clip COMMAND test_audio_clip)

--- a/packages/robocar/unified/test/test_audio_clip.c
+++ b/packages/robocar/unified/test/test_audio_clip.c
@@ -1,0 +1,228 @@
+/**
+ * @file test_audio_clip.c
+ * @brief Host tests for clip sizing, WAV framing and normalisation.
+ *
+ * Two of these pin failures that are effectively impossible to find any other
+ * way:
+ *
+ *   - The **WAV header**, byte for byte. Gemini rejects raw PCM with an HTTP 400
+ *     that names no field, so a wrong field width or byte order here does not
+ *     fail on the device at all — it fails at a remote server, opaquely, after a
+ *     ~340 kB upload. Asserting the exact 44 bytes converts that into a local
+ *     failure with an obvious cause.
+ *
+ *   - The **size arithmetic at the overflow boundary**. A wrapped product is an
+ *     ordinary-looking small number, so the bug is a short allocation that is
+ *     then overrun — and no console input a person would ever type produces it.
+ *     Only calling the function directly does.
+ *
+ * The normalisation tests are cheaper but still worth having: `peak` and
+ * `clipped` are what tell a mis-set microphone gain from a bad model reply, so a
+ * wrong count would misdirect exactly the debugging session they exist to serve.
+ */
+
+#include "audio_clip.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* =========================================================================
+ * Test harness
+ * ========================================================================= */
+
+static int test_count = 0;
+static int test_pass = 0;
+
+static void test_assert(int cond, const char *file, int line, const char *expr)
+{
+    if (!cond) {
+        printf("FAIL: %s:%d assertion failed: %s\n", file, line, expr);
+        assert(cond);
+    }
+}
+
+#define ASSERT(cond) test_assert((cond), __FILE__, __LINE__, #cond)
+
+static void test_run(const char *name, void (*fn)(void))
+{
+    test_count++;
+    fn();
+    test_pass++;
+    printf("  ok: %s\n", name);
+}
+
+/* =========================================================================
+ * Sizing
+ * ========================================================================= */
+
+static void test_nominal_window_sizes_correctly(void)
+{
+    /* 4 s at 16 kHz mono 16-bit = 64000 samples = 128000 bytes. */
+    ASSERT(audio_clip_pcm_bytes(4000u, 16000u) == 128000u);
+    ASSERT(audio_clip_pcm_bytes(1000u, 16000u) == 32000u);
+}
+
+static void test_zero_parameters_refuse(void)
+{
+    ASSERT(audio_clip_pcm_bytes(0u, 16000u) == 0u);
+    ASSERT(audio_clip_pcm_bytes(4000u, 0u) == 0u);
+}
+
+static void test_the_cap_is_enforced_exactly(void)
+{
+    /* AUDIO_CLIP_MAX_BYTES is 256000 = exactly 8 s. 8 s must pass and the next
+     * millisecond must refuse — an off-by-one here either rejects the documented
+     * maximum window or admits one past the memory budget. */
+    ASSERT(audio_clip_pcm_bytes(8000u, 16000u) == 256000u);
+    ASSERT(audio_clip_pcm_bytes(8001u, 16000u) == 0u);
+}
+
+static void test_overflow_refuses_rather_than_wraps(void)
+{
+    /* THE case a bench cannot produce. window_ms * sample_rate_hz overflows 32
+     * bits comfortably here; the function must return 0 (refuse) and never a
+     * small wrapped value that would be used as an allocation size. */
+    ASSERT(audio_clip_pcm_bytes(0xFFFFFFFFu, 16000u) == 0u);
+    ASSERT(audio_clip_pcm_bytes(0xFFFFFFFFu, 0xFFFFFFFFu) == 0u);
+    ASSERT(audio_clip_pcm_bytes(1000000u, 48000u) == 0u);
+}
+
+static void test_b64_length_includes_the_header(void)
+{
+    /* 128000 PCM + 44 header = 128044 bytes -> ceil(128044/3)*4 = 170728, +1 NUL.
+     * Computed independently here rather than by calling the same expression, so
+     * the test would catch the header being dropped from the calculation. */
+    const size_t pcm = 128000u;
+    const size_t total = pcm + 44u;
+    const size_t expect = ((total + 2u) / 3u) * 4u + 1u;
+    ASSERT(audio_clip_b64_length(pcm) == expect);
+    /* And it must genuinely differ from the header-less answer, or the test
+     * above would pass with the header omitted. */
+    const size_t without = ((pcm + 2u) / 3u) * 4u + 1u;
+    ASSERT(audio_clip_b64_length(pcm) > without);
+}
+
+static void test_b64_length_refuses_out_of_range(void)
+{
+    ASSERT(audio_clip_b64_length(0u) == 0u);
+    ASSERT(audio_clip_b64_length(AUDIO_CLIP_MAX_BYTES + 1u) == 0u);
+}
+
+/* =========================================================================
+ * WAV header — asserted byte for byte
+ * ========================================================================= */
+
+static void test_wav_header_is_byte_exact(void)
+{
+    uint8_t h[AUDIO_CLIP_WAV_HEADER_BYTES];
+    memset(h, 0xAA, sizeof(h));
+    ASSERT(audio_clip_wav_header(h, 128000u, 16000u, 1u, 16u));
+
+    /* Hand-computed for 16 kHz / mono / 16-bit / 128000 payload:
+     *   RIFF size  = 36 + 128000 = 128036 = 0x0001F424
+     *   byte rate  = 16000 * 2   = 32000  = 0x00007D00
+     *   block align= 2, bits = 16, channels = 1, fmt = 1 (PCM)
+     *   data size  = 128000               = 0x0001F400 */
+    static const uint8_t expect[AUDIO_CLIP_WAV_HEADER_BYTES] = {
+        'R',  'I',  'F',  'F',  0x24, 0xF4, 0x01, 0x00, 'W',  'A',  'V',  'E',  'f',  'm',  't',
+        ' ',  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x80, 0x3E, 0x00, 0x00, 0x00, 0x7D,
+        0x00, 0x00, 0x02, 0x00, 0x10, 0x00, 'd',  'a',  't',  'a',  0x00, 0xF4, 0x01, 0x00,
+    };
+    ASSERT(memcmp(h, expect, sizeof(expect)) == 0);
+}
+
+static void test_wav_header_refuses_degenerate_input(void)
+{
+    uint8_t h[AUDIO_CLIP_WAV_HEADER_BYTES];
+    ASSERT(!audio_clip_wav_header(NULL, 1000u, 16000u, 1u, 16u));
+    ASSERT(!audio_clip_wav_header(h, 0u, 16000u, 1u, 16u));
+    ASSERT(!audio_clip_wav_header(h, 1000u, 0u, 1u, 16u));
+    ASSERT(!audio_clip_wav_header(h, 1000u, 16000u, 0u, 16u));
+    ASSERT(!audio_clip_wav_header(h, 1000u, 16000u, 1u, 12u)); /* not a byte multiple */
+}
+
+/* =========================================================================
+ * Normalisation
+ * ========================================================================= */
+
+static void test_dc_is_removed_and_reported(void)
+{
+    int16_t pcm[8];
+    for (size_t i = 0; i < 8; ++i) {
+        pcm[i] = 1000; /* pure DC, no signal at all */
+    }
+    audio_clip_stats_t st;
+    audio_clip_normalise(pcm, 8, &st);
+
+    ASSERT(st.dc == 1000);
+    ASSERT(st.peak == 0); /* after removal there is nothing left */
+    ASSERT(st.samples == 8u);
+    for (size_t i = 0; i < 8; ++i) {
+        ASSERT(pcm[i] == 0);
+    }
+}
+
+static void test_peak_survives_dc_removal(void)
+{
+    int16_t pcm[4] = {100, -100, 300, -300};
+    audio_clip_stats_t st;
+    audio_clip_normalise(pcm, 4, &st);
+    ASSERT(st.dc == 0);
+    ASSERT(st.peak == 300);
+    ASSERT(st.clipped == 0u);
+}
+
+static void test_clipping_saturates_rather_than_wraps(void)
+{
+    /* A negative DC pushes positive samples past full scale. Wrapping would flip
+     * their sign — an audible click, and it would also under-count `clipped`,
+     * which is the number that says "the gain is too high". */
+    int16_t pcm[4] = {32000, 32000, 32000, -32768};
+    audio_clip_stats_t st;
+    audio_clip_normalise(pcm, 4, &st);
+
+    for (size_t i = 0; i < 3; ++i) {
+        ASSERT(pcm[i] > 0); /* still positive: saturated, not wrapped */
+    }
+    ASSERT(st.clipped >= 1u);
+    ASSERT(st.peak == 32767);
+}
+
+static void test_degenerate_input_is_safe(void)
+{
+    audio_clip_stats_t st;
+    audio_clip_normalise(NULL, 8, &st);
+    ASSERT(st.samples == 0u);
+
+    int16_t pcm[1] = {5};
+    audio_clip_normalise(pcm, 0, &st);
+    ASSERT(st.samples == 0u);
+}
+
+/* =========================================================================
+ * Runner
+ * ========================================================================= */
+
+int main(void)
+{
+    printf("=== audio_clip host tests ===\n\n");
+
+    test_run("a nominal window sizes correctly", test_nominal_window_sizes_correctly);
+    test_run("zero parameters refuse", test_zero_parameters_refuse);
+    test_run("the cap is enforced exactly", test_the_cap_is_enforced_exactly);
+    test_run("overflow refuses rather than wraps", test_overflow_refuses_rather_than_wraps);
+    test_run("base64 length includes the header", test_b64_length_includes_the_header);
+    test_run("base64 length refuses out of range", test_b64_length_refuses_out_of_range);
+
+    test_run("the WAV header is byte exact", test_wav_header_is_byte_exact);
+    test_run("the WAV header refuses degenerate input", test_wav_header_refuses_degenerate_input);
+
+    test_run("DC is removed and reported", test_dc_is_removed_and_reported);
+    test_run("peak survives DC removal", test_peak_survives_dc_removal);
+    test_run("clipping saturates rather than wraps", test_clipping_saturates_rather_than_wraps);
+    test_run("degenerate input is safe", test_degenerate_input_is_safe);
+
+    printf("\n=== %d/%d passed ===\n", test_pass, test_count);
+    return (test_pass == test_count) ? 0 : 1;
+}

--- a/packages/robocar/unified/test/test_gemini_parse.c
+++ b/packages/robocar/unified/test/test_gemini_parse.c
@@ -330,6 +330,81 @@ static void test_legacy_wrapper_unchanged(void)
  * Main
  * ========================================================================= */
 
+/* =========================================================================
+ * gemini_parse_text — plain TEXT replies (the narrate + voice-turn path)
+ *
+ * This path had no host test at all while it lived static inside
+ * gemini_backend.c. It is worth one now for a specific reason: a reply that
+ * sanitises to nothing must be reported as FAILURE, not as an empty success,
+ * or the caller cheerfully hands "" to the TTS renderer and the robot performs
+ * a silence that looks exactly like a broken speaker.
+ * ========================================================================= */
+
+static void test_text_single_part(void)
+{
+    const char *json =
+        "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"Hei, mita kuuluu?\"}]}}]}";
+    char out[64] = {0};
+    ASSERT(gemini_parse_text(json, out, sizeof(out)) == ESP_OK);
+    ASSERT(strcmp(out, "Hei, mita kuuluu?") == 0);
+}
+
+static void test_text_concatenates_parts_in_order(void)
+{
+    const char *json = "{\"candidates\":[{\"content\":{\"parts\":["
+                       "{\"text\":\"one \"},{\"text\":\"two \"},{\"text\":\"three\"}]}}]}";
+    char out[64] = {0};
+    ASSERT(gemini_parse_text(json, out, sizeof(out)) == ESP_OK);
+    ASSERT(strcmp(out, "one two three") == 0);
+}
+
+static void test_text_collapses_layout_to_one_line(void)
+{
+    /* The TTS renderer pronounces layout: a leading newline is an audible pause
+     * before the robot says anything. */
+    const char *json =
+        "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"\\n  a\\tb\\r\\n  \"}]}}]}";
+    char out[64] = {0};
+    ASSERT(gemini_parse_text(json, out, sizeof(out)) == ESP_OK);
+    ASSERT(strcmp(out, "a b") == 0);
+}
+
+static void test_text_whitespace_only_is_a_failure(void)
+{
+    const char *json = "{\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"  \\n \"}]}}]}";
+    char out[64] = {0};
+    ASSERT(gemini_parse_text(json, out, sizeof(out)) != ESP_OK);
+}
+
+static void test_text_missing_parts_is_a_failure(void)
+{
+    /* What a MAX_TOKENS truncation actually looks like: a candidate with no
+     * parts array at all. Must not read as an empty success. */
+    const char *json = "{\"candidates\":[{\"finishReason\":\"MAX_TOKENS\"}]}";
+    char out[64] = {0};
+    ASSERT(gemini_parse_text(json, out, sizeof(out)) != ESP_OK);
+}
+
+static void test_text_truncates_without_overrunning(void)
+{
+    const char *json = "{\"candidates\":[{\"content\":{\"parts\":["
+                       "{\"text\":\"aaaaaaaaaa\"},{\"text\":\"bbbbbbbbbb\"}]}}]}";
+    char out[8];
+    memset(out, 0x7F, sizeof(out));
+    ASSERT(gemini_parse_text(json, out, sizeof(out)) == ESP_OK);
+    ASSERT(out[sizeof(out) - 1] == '\0');
+    ASSERT(strlen(out) == sizeof(out) - 1);
+}
+
+static void test_text_rejects_null_and_bad_json(void)
+{
+    char out[16] = {0};
+    ASSERT(gemini_parse_text(NULL, out, sizeof(out)) == ESP_ERR_INVALID_ARG);
+    ASSERT(gemini_parse_text("{}", NULL, sizeof(out)) == ESP_ERR_INVALID_ARG);
+    ASSERT(gemini_parse_text("{}", out, 0) == ESP_ERR_INVALID_ARG);
+    ASSERT(gemini_parse_text("not json", out, sizeof(out)) == ESP_FAIL);
+}
+
 int main(void)
 {
     printf("=== gemini_parse host tests ===\n\n");
@@ -351,6 +426,14 @@ int main(void)
     test_run("parse_no_speak_clears_buffer", test_parse_no_speak_clears_buffer);
     test_run("parse_speak_truncates", test_parse_speak_truncates);
     test_run("legacy_wrapper_unchanged", test_legacy_wrapper_unchanged);
+
+    test_run("text_single_part", test_text_single_part);
+    test_run("text_concatenates_parts_in_order", test_text_concatenates_parts_in_order);
+    test_run("text_collapses_layout_to_one_line", test_text_collapses_layout_to_one_line);
+    test_run("text_whitespace_only_is_a_failure", test_text_whitespace_only_is_a_failure);
+    test_run("text_missing_parts_is_a_failure", test_text_missing_parts_is_a_failure);
+    test_run("text_truncates_without_overrunning", test_text_truncates_without_overrunning);
+    test_run("text_rejects_null_and_bad_json", test_text_rejects_null_and_bad_json);
 
     printf("\n=== Results ===\n");
     printf("Passed: %d / %d\n", test_pass, test_count);


### PR DESCRIPTION
> **#453 has merged**; this branch has been rebased onto `main` and now contains only its own commit. It builds on slice A's `mic_pdm` driver and `audio_player_is_active()`, both now in `main`.

## What

`listen [seconds]` records from the onboard microphone, sends the clip to Gemini, and speaks the reply through the **existing TTS path, unchanged**. It's the opposite of everything else the robot says: unprompted speech is gated and rationed, a voice turn is asked for and answered once.

Console-triggered only in this PR. `voice_turn_request()` is deliberately callable from anywhere — including `ambient_listener` — so an energy-triggered (VAD) turn can be added later without redesign. The header records the pacing problem to solve first: a VAD in a noisy room would issue turns continuously, and Gemini's `retryDelay` grows while a client keeps asking, so a VAD trigger probably has to draw on `speech_budget` too.

## The fact that changed the design

A live probe against `gemini-flash-latest:generateContent` with a 0.5 s tone:

| `mimeType` | Result |
|---|---|
| `audio/wav` | 200, replied, usage reported 13 AUDIO tokens |
| `audio/pcm` | **HTTP 400 "Request contains an invalid argument."** — naming no field |

The plan had assumed raw PCM would work. So `audio_clip.c` builds a canonical 44-byte WAV header on-device, and `test_audio_clip.c` asserts those 44 bytes **byte-for-byte**. That test exists for a specific reason: a field-width or byte-order slip there doesn't fail on the device at all — it fails at a remote server, opaquely, after a ~170 kB upload. The test converts that into a local failure with an obvious cause.

Audio costs ~26 tokens/second measured, so clip length is bounded by **memory**, not API cost.

## Why a flash model

Gemini's free-tier quota is **per model**, and the planner already saturates `gemini-robotics-er-1.6-preview` at 5 req/min. Putting the voice turn on a separate model means answering someone can never cost the robot its ability to plan a movement.

## The free order is load-bearing, not tidiness

Raw PCM is released once the WAV copy exists → the WAV once base64 exists → our base64 copy immediately after `cJSON_AddStringToObject` duplicates it. Holding any pair simultaneously roughly doubles the transient to ~800 kB, which does not fit beside the camera framebuffers and the 512 kB TTS ring. The per-turn log prints upload size and free PSRAM so that's checkable rather than trusted:

```
listen: window=4000 ms samples=64000 peak=8412 clipped=0 dc=-37 | upload=170812 B | free PSRAM=...
listen: latency=2140 ms reply="..."
```

`peak`/`clipped`/`dc` are the audio analogue of what `cam` prints for gain and exposure — the only way to tell a mis-set mic gain from a bad model reply. A clip returning peak ~200 was never going to be transcribed no matter what the model said.

## A start beep, and then a wait

The buzzer is GPIO2 — a *different* peripheral from the I2S amplifier — so `audio_player_is_active()` doesn't cover it. Without the settle delay and the mic flush, the first fraction of every clip is the robot's own beep, which the model then politely transcribes.

## Refactor included

`parse_narrate_response()` moves out of `gemini_backend.c` (where it was static and untested) into `gemini_parse.c` as a public, host-tested `gemini_parse_text()`. The voice turn needed exactly it, and extracting rather than copying gives the existing narrate path its first host test as a side effect — including the case that matters most: a reply which sanitises to nothing is reported as a **failure**, not an empty success. The latter hands `""` to the renderer and the robot performs a silence indistinguishable from a broken speaker.

## Post-turn bookkeeping — deliberate in both directions

**Does:** note the line as spoken (so the planner doesn't parrot the answer back on its next cycle), spend the speech budget (the robot just talked — a spontaneous remark three seconds later is the chattering the gap exists to stop), and mark the ambient gate (the human's voice armed that latch; having answered it, the robot must not then volunteer "I heard something").

**Does not:** mark `scene_change` — answering a question is not remarking on the view, and consuming that evidence would silence an observation not yet made. And does not screen the reply through `dialogue_style_is_repetitive()` — a direct answer is allowed to repeat, the same exemption `voice say` and the self-report already have. Screening it would turn a working command into one that silently does nothing whenever someone asks the same question twice.

## Verification

- **11/11 host tests pass**, including 12 new `audio_clip` cases and 7 new `gemini_parse_text` cases. The two that earn their keep are the exact WAV header bytes and the 32-bit overflow boundary in the size arithmetic — a wrapped product is an ordinary-looking small number, so the bug is a short allocation that then gets overrun, and no console input a person would type produces it.
- **Containerized ESP-IDF build green** — 1,282,288 bytes, 65% of the OTA partition free.
- `just format-check` clean; cppcheck reports nothing on any new file.
- **Not verified on hardware.** No clip has been recorded or uploaded from the device. The probe confirms the API contract; it does not confirm the mic gain is usable at conversational distance, which is what `mic dump` from #453 is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
